### PR TITLE
feat: add datum gateway config

### DIFF
--- a/config/gateway/endpoint.yaml
+++ b/config/gateway/endpoint.yaml
@@ -1,0 +1,15 @@
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: public-website
+addressType: FQDN
+ports:
+  - name: https
+    protocol: TCP
+    appProtocol: https
+    port: 443
+endpoints:
+  - addresses:
+      - "website.staging.env.datum.net"
+    conditions:
+      ready: true

--- a/config/gateway/gateway.yaml
+++ b/config/gateway/gateway.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: public-website-gateway
+spec:
+  gatewayClassName: datum-external-global-proxy
+  listeners:
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    name: http
+    port: 80
+    protocol: HTTP
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    name: https
+    port: 443
+    protocol: HTTPS
+    tls:
+      mode: Terminate
+      options:
+        gateway.networking.datumapis.com/certificate-issuer: auto

--- a/config/gateway/httproute.yaml
+++ b/config/gateway/httproute.yaml
@@ -1,0 +1,27 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: public-website-http-route
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: public-website-gateway
+  rules:
+  - backendRefs:
+    - group: discovery.k8s.io
+      kind: EndpointSlice
+      name: public-website
+      port: 443
+      weight: 1
+    filters:
+      - type: URLRewrite
+        urlRewrite:
+          hostname: "website.staging.env.datum.net"
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+    timeouts:
+      backendRequest: 25s
+      request: 25s

--- a/config/gateway/kustomization.yaml
+++ b/config/gateway/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - gateway.yaml
+  - httproute.yaml
+  - endpoint.yaml


### PR DESCRIPTION
Adds a new Datum Gateway configuration to expose the staging website over our Gateway. 