### PR TITLE
Renaming website config

### DIFF
--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -2,10 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/instance: public-website
-    app.kubernetes.io/name: public-website
+    app.kubernetes.io/instance: datum-net
+    app.kubernetes.io/name: datum-net
     app.kubernetes.io/version: 1.0.0
-  name: public-website
+  name: datum-net
 spec:
   progressDeadlineSeconds: 600
   replicas: 2
@@ -13,8 +13,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: frontend
-      app.kubernetes.io/instance: public-website
-      app.kubernetes.io/name: public-website
+      app.kubernetes.io/instance: datum-net
+      app.kubernetes.io/name: datum-net
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -24,11 +24,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/component: frontend
-        app.kubernetes.io/instance: public-website
-        app.kubernetes.io/name: public-website
+        app.kubernetes.io/instance: datum-net
+        app.kubernetes.io/name: datum-net
     spec:
       containers:
-        - name: public-website
+        - name: datum-net
           image: ghcr.io/datum-cloud/datum.net:latest
           imagePullPolicy: Always
           ports:

--- a/config/base/http-route.yaml
+++ b/config/base/http-route.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
-  name: public-website
+  name: datum-net
 spec:
   parentRefs:
     # This should be overridden at the environment level if needed to configure
@@ -14,7 +14,7 @@ spec:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: public-website
+        - name: datum-net
           kind: Service
           group: ''
           port: 4321

--- a/config/base/service.yaml
+++ b/config/base/service.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app.kubernetes.io/instance: public-website
-    app.kubernetes.io/name: public-website
+    app.kubernetes.io/instance: datum-net
+    app.kubernetes.io/name: datum-net
     app.kubernetes.io/version: 1.0.0
-  name: public-website
+  name: datum-net
 spec:
   internalTrafficPolicy: Cluster
   ports:
@@ -15,7 +15,7 @@ spec:
       targetPort: http
   selector:
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/instance: public-website
-    app.kubernetes.io/name: public-website
+    app.kubernetes.io/instance: datum-net
+    app.kubernetes.io/name: datum-net
   sessionAffinity: None
   type: ClusterIP

--- a/config/gateway/endpoint.yaml
+++ b/config/gateway/endpoint.yaml
@@ -1,7 +1,7 @@
 apiVersion: discovery.k8s.io/v1
 kind: EndpointSlice
 metadata:
-  name: public-website
+  name: datum-net
 addressType: FQDN
 ports:
   - name: https

--- a/config/gateway/gateway.yaml
+++ b/config/gateway/gateway.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: public-website-gateway
+  name: datum-net-gateway
 spec:
   gatewayClassName: datum-external-global-proxy
   listeners:

--- a/config/gateway/httproute.yaml
+++ b/config/gateway/httproute.yaml
@@ -1,17 +1,17 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: public-website-http-route
+  name: datum-net-http-route
 spec:
   parentRefs:
   - group: gateway.networking.k8s.io
     kind: Gateway
-    name: public-website-gateway
+    name: datum-net-gateway
   rules:
   - backendRefs:
     - group: discovery.k8s.io
       kind: EndpointSlice
-      name: public-website
+      name: datum-net
       port: 443
       weight: 1
     filters:


### PR DESCRIPTION
The public website repository was changed to datum.net. This pull request updates all references to the old name to maintain consistency across applications.