### PR TITLE
feat: add datum cloud gateway configuration

### DIFF
--- a/config/gateway/endpoint.yaml
+++ b/config/gateway/endpoint.yaml
@@ -10,6 +10,6 @@ ports:
     port: 443
 endpoints:
   - addresses:
-      - "website.staging.env.datum.net"
+      - "website.prod.env.datum.net"
     conditions:
       ready: true

--- a/config/gateway/gateway.yaml
+++ b/config/gateway/gateway.yaml
@@ -32,6 +32,26 @@ spec:
       mode: Terminate
       options:
         gateway.networking.datumapis.com/certificate-issuer: auto
+  # This listener is used to serve the HTTPS traffic for the docs.datum.net
+  # domain and redirects to www.datum.net.
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    name: http-docs-datum-net-redirect
+    port: 80
+    protocol: HTTP
+    hostname: docs.datum.net
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    name: https-docs-datum-net-redirect
+    port: 443
+    protocol: HTTPS
+    hostname: docs.datum.net
+    tls:
+      mode: Terminate
+      options:
+        gateway.networking.datumapis.com/certificate-issuer: auto
   # This listener is used to serve the HTTPS traffic for the www.datum.net
   # domain. All other listeners redirect to this domain.
   - allowedRoutes:

--- a/config/gateway/gateway.yaml
+++ b/config/gateway/gateway.yaml
@@ -8,15 +8,39 @@ spec:
   - allowedRoutes:
       namespaces:
         from: Same
-    name: http
+    name: http-datum-net-redirect
     port: 80
     protocol: HTTP
+    hostname: datum.net
   - allowedRoutes:
       namespaces:
         from: Same
-    name: https
+    name: http-www-datum-net-redirect
+    port: 80
+    protocol: HTTP
+    hostname: www.datum.net
+  # This listener is used to serve the HTTPS traffic for the datum.net
+  # domain.
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    name: https-datum-net-redirect
     port: 443
     protocol: HTTPS
+    hostname: datum.net
+    tls:
+      mode: Terminate
+      options:
+        gateway.networking.datumapis.com/certificate-issuer: auto
+  # This listener is used to serve the HTTPS traffic for the www.datum.net
+  # domain. All other listeners redirect to this domain.
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    name: https-www-datum-net
+    port: 443
+    protocol: HTTPS
+    hostname: www.datum.net
     tls:
       mode: Terminate
       options:

--- a/config/gateway/httproute-redirect.yaml
+++ b/config/gateway/httproute-redirect.yaml
@@ -3,9 +3,8 @@ kind: HTTPRoute
 metadata:
   name: datum-net-redirect
 spec:
-  # Match the port 80 listeners for the milo-os.com and www.milo-os.com domains
-  # and the port 443 listener for the milo-os.com domain so we can redirect to
-  # https://www.milo-os.com.
+  # Match the port 80 and 443 listeners for datum.net and docs.datum.net domains
+  # so we can redirect to https://www.datum.net.
   parentRefs:
   - group: gateway.networking.k8s.io
     kind: Gateway
@@ -19,8 +18,47 @@ spec:
     kind: Gateway
     name: datum-net-gateway
     sectionName: http-datum-net-redirect
-  # Redirect to https://www.datum.net for all paths.
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: datum-net-gateway
+    sectionName: http-docs-datum-net-redirect
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: datum-net-gateway
+    sectionName: https-docs-datum-net-redirect
   rules:
+  # First rule: Exact match for docs.datum.net/ redirects to www.datum.net/docs
+  - matches:
+    - path:
+        type: Exact
+        value: /
+      headers:
+      - name: Host
+        value: docs.datum.net
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: www.datum.net
+        scheme: https
+        statusCode: 301
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /docs
+  # Second rule: All other docs.datum.net paths redirect to www.datum.net preserving path
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+      headers:
+      - name: Host
+        value: docs.datum.net
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: www.datum.net
+        scheme: https
+        statusCode: 301
+  # Third rule: datum.net and www.datum.net redirects to www.datum.net preserving path
   - matches:
     - path:
         type: PathPrefix

--- a/config/gateway/httproute-redirect.yaml
+++ b/config/gateway/httproute-redirect.yaml
@@ -1,0 +1,33 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: datum-net-redirect
+spec:
+  # Match the port 80 listeners for the milo-os.com and www.milo-os.com domains
+  # and the port 443 listener for the milo-os.com domain so we can redirect to
+  # https://www.milo-os.com.
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: datum-net-gateway
+    sectionName: https-datum-net-redirect
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: datum-net-gateway
+    sectionName: http-www-datum-net-redirect
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: datum-net-gateway
+    sectionName: http-datum-net-redirect
+  # Redirect to https://www.datum.net for all paths.
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: www.datum.net
+        scheme: https
+        statusCode: 301

--- a/config/gateway/httproute.yaml
+++ b/config/gateway/httproute.yaml
@@ -7,6 +7,7 @@ spec:
   - group: gateway.networking.k8s.io
     kind: Gateway
     name: datum-net-gateway
+    sectionName: https-www-datum-net
   rules:
   - backendRefs:
     - group: discovery.k8s.io
@@ -17,7 +18,7 @@ spec:
     filters:
       - type: URLRewrite
         urlRewrite:
-          hostname: "website.staging.env.datum.net"
+          hostname: "website.prod.env.datum.net"
     matches:
     - path:
         type: PathPrefix

--- a/config/gateway/kustomization.yaml
+++ b/config/gateway/kustomization.yaml
@@ -1,4 +1,7 @@
+namespace: datum-net
 resources:
+  - namespace.yaml
   - gateway.yaml
   - httproute.yaml
   - endpoint.yaml
+  - httproute-redirect.yaml

--- a/config/gateway/namespace.yaml
+++ b/config/gateway/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: datum-net


### PR DESCRIPTION
Configures a Datum Cloud HTTP Gateway to serve the https://www.datum.net website from the production environment. Also configures a redirect to redirect traffic from docs.datum.net to www.datum.net. 