### PR TITLE
fix: correct web manifest color format and enable dynamic GitHub star

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -16,6 +16,6 @@
     }
   ],
   "theme_color": "#ffffff",
-  "background_color": "0C1D31",
+  "background_color": "#0c1d31",
   "display": "standalone"
 }

--- a/src/components/MobileMenu.astro
+++ b/src/components/MobileMenu.astro
@@ -139,7 +139,7 @@ const { navigation }: Props = Astro.props;
           <div class="btn-icon">
             <Icon name="github" size="md" />
           </div>
-          <span class="btn-text">85.4k</span>
+          <span class="btn-text gh-mobile-button">0</span>
         </a>
 
         <a href="https://cloud.datum.net/" class="btn btn--navy" @click="closeMenu()">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -133,6 +133,7 @@ const descriptionValue =
       import { getCookie, setCookie } from '@libs/cookie';
       document.addEventListener('DOMContentLoaded', function () {
         const ghButton = document.querySelectorAll('.gh-button');
+        const ghMobileButton = document.querySelector('.gh-mobile-button');
         const starIcon = `<svg xmlns="http://www.w3.org/2000/svg" stroke-width="2" width="24" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" fill="none" viewBox="0 0 24 24" class="lucide lucide-github h-5 w-5 stroke-1.5">  <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"></path> <path d="M9 18c-4.51 2-5-2-7-2"></path></svg>`;
         updateStargazerCount();
 
@@ -164,6 +165,10 @@ const descriptionValue =
             }
             button.innerHTML = `${starIcon} ${formattedStarCount}`;
           });
+
+          if (ghMobileButton) {
+            ghMobileButton.innerHTML = formattedStarCount || '0';
+          }
         }
       });
     </script>


### PR DESCRIPTION
- Fix background_color format in site.webmanifest (add # prefix)
- Replace hardcoded mobile GitHub star count with dynamic fetching
- Add mobile button support to stargazer count script