### PR TITLE
Add Design Assets link to navigation

### DIFF
--- a/src/data/navigation.json
+++ b/src/data/navigation.json
@@ -79,7 +79,8 @@
       "items": [
         { "text": "About", "href": "/about/" },
         { "text": "Handbook", "href": "/handbook/" },
-        { "text": "Blog", "href": "/blog/" }
+        { "text": "Blog", "href": "/blog/" },
+        { "text": "Design Assets", "href": "https://design.datum.net/", "isExternal": true }
       ]
     },
     {


### PR DESCRIPTION
Added a new external link to 'Design Assets' in the navigation menu, pointing to https://design.datum.net/.