### PR TITLE
cont: Add November 2025 huddle and update October details

### DIFF
--- a/src/content/huddles/2025-10-08.mdx
+++ b/src/content/huddles/2025-10-08.mdx
@@ -1,10 +1,9 @@
 ---
-title: "October 8th, 2025"
-subtitle: "Community Huddle"
-description: "Join us for our end-of-year community huddle where we'll discuss the latest updates and plans for the new year."
+title: ""
 date: 2025-10-08
 time: "12pm - 1pm EST"
-zoomLink: "https://us06web.zoom.us/j/81882732147?pwd=TOsMxTvZrJJgNjTQIucbyT8qrg1Fyd.1"
+zoomLink: "https://us06web.zoom.us/rec/share/Sd6P33rdwMeAjlA0chVEWVz8fv7I6Vyuig0kzI7XfWXJBBe8HLOB3ve5z1i-Lgk.P5YczcBu6UplBsev"
+zoomPass: "jQW!8d#m"
 slidesUrl: "https://docs.google.com/presentation/d/1PxPadaoX0m37UEBGuO0l9Pz06F_zLDnh996DjfWJ2Lg/edit"
 draft: false
 ---

--- a/src/content/huddles/2025-11-12.mdx
+++ b/src/content/huddles/2025-11-12.mdx
@@ -1,0 +1,12 @@
+---
+title: "November 12th, 2025"
+subtitle: "Community Huddle"
+description: "Join us for our end-of-year community huddle where we'll discuss the latest updates and plans for the new year."
+date: 2025-11-12
+time: "12pm - 1pm EST"
+zoomLink: "https://us06web.zoom.us/j/81882732147?pwd=TOsMxTvZrJJgNjTQIucbyT8qrg1Fyd.1"
+slidesUrl: "https://docs.google.com/presentation/d/1PxPadaoX0m37UEBGuO0l9Pz06F_zLDnh996DjfWJ2Lg/edit"
+draft: false
+---
+
+TBD


### PR DESCRIPTION
Added a new huddle entry for November 12, 2025. Updated the October 8, 2025 huddle by clearing the title, changing the Zoom link to a recording, and adding a Zoom password.

Create 2025-11-12.mdx