### PR TITLE
add: image tag configuration to kustomize bundle workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
     needs: check-files
     uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@add-build-outputs
     with:
-      image-name: datum-net]
+      image-name: datum-net
       target: production
       extra-build-args: |
         ASTRO_TELEMETRY_DISABLED=1


### PR DESCRIPTION
**PR Description:**

This change updates the kustomize bundle publishing workflow to automatically inject the correct image tag into the kustomization manifests before publishing. By adding the `image-overlays` and `image-name` parameters, the published OCI bundle will contain the appropriate image tag matching the Docker image that was just built. This enables Flux to use semver filtering on the OCI repository reference instead of relying on ImageUpdateAutomation policies, simplifying the deployment process to a single release in this repo without requiring changes to datum-infra.