### PR TITLE
fix: use tagged action version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       packages: write
       id-token: write
     needs: check-files
-    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@add-build-outputs
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.7.2
     with:
       image-name: datum-net
       target: production
@@ -39,7 +39,7 @@ jobs:
       contents: read
       packages: write
     needs: build-and-push
-    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@add-build-outputs
+    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.7.2
     with:
       bundle-name: ghcr.io/datum-cloud/datum-net-kustomize
       bundle-path: config/base


### PR DESCRIPTION
Fixes the [build error](https://github.com/datum-cloud/datum.net/actions/runs/18711990274) by moving to a tagged version of the action.