### PR TITLE
Set overview sidebar group to collapsed by default

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -104,7 +104,7 @@ export default defineConfig({
         {
           label: 'Overview',
           autogenerate: { directory: 'docs/overview' },
-          collapsed: false, // First group is expanded by default
+          collapsed: true, // First group is expanded by default
         },
         {
           label: 'Quickstart',


### PR DESCRIPTION
Changed the 'collapsed' property of the overview sidebar group from false to true in astro.config.mjs, making the group collapsed by default for improved navigation.