### PR TITLE
feat: add redirect from brand.datum.net to www.datum.net/brand

### DIFF
--- a/config/gateway/gateway.yaml
+++ b/config/gateway/gateway.yaml
@@ -52,6 +52,26 @@ spec:
       mode: Terminate
       options:
         gateway.networking.datumapis.com/certificate-issuer: auto
+  # This listener is used to serve the HTTPS traffic for the brand.datum.net
+  # domain and redirects to www.datum.net/brand.
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    name: http-brand-datum-net-redirect
+    port: 80
+    protocol: HTTP
+    hostname: brand.datum.net
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    name: https-brand-datum-net-redirect
+    port: 443
+    protocol: HTTPS
+    hostname: brand.datum.net
+    tls:
+      mode: Terminate
+      options:
+        gateway.networking.datumapis.com/certificate-issuer: auto
   # This listener is used to serve the HTTPS traffic for the www.datum.net
   # domain. All other listeners redirect to this domain.
   - allowedRoutes:

--- a/config/gateway/httproute-redirect.yaml
+++ b/config/gateway/httproute-redirect.yaml
@@ -3,7 +3,7 @@ kind: HTTPRoute
 metadata:
   name: datum-net-redirect
 spec:
-  # Match the port 80 and 443 listeners for datum.net and docs.datum.net domains
+  # Match the port 80 and 443 listeners for datum.net, docs.datum.net, and brand.datum.net domains
   # so we can redirect to https://www.datum.net.
   parentRefs:
   - group: gateway.networking.k8s.io
@@ -26,8 +26,16 @@ spec:
     kind: Gateway
     name: datum-net-gateway
     sectionName: https-docs-datum-net-redirect
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: datum-net-gateway
+    sectionName: http-brand-datum-net-redirect
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: datum-net-gateway
+    sectionName: https-brand-datum-net-redirect
   rules:
-  # First rule: Exact match for docs.datum.net/ redirects to www.datum.net/docs
+  # Exact match for docs.datum.net/ redirects to www.datum.net/docs
   - matches:
     - path:
         type: Exact
@@ -44,7 +52,7 @@ spec:
         path:
           type: ReplaceFullPath
           replaceFullPath: /docs
-  # Second rule: All other docs.datum.net paths redirect to www.datum.net preserving path
+  # All other docs.datum.net paths redirect to www.datum.net preserving path
   - matches:
     - path:
         type: PathPrefix
@@ -58,7 +66,41 @@ spec:
         hostname: www.datum.net
         scheme: https
         statusCode: 301
-  # Third rule: datum.net and www.datum.net redirects to www.datum.net preserving path
+  # Exact match for brand.datum.net/ redirects to www.datum.net/brand
+  - matches:
+    - path:
+        type: Exact
+        value: /
+      headers:
+      - name: Host
+        value: brand.datum.net
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: www.datum.net
+        scheme: https
+        statusCode: 301
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: /brand
+  # All other brand.datum.net paths redirect to www.datum.net/brand preserving path
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+      headers:
+      - name: Host
+        value: brand.datum.net
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: www.datum.net
+        scheme: https
+        statusCode: 301
+        path:
+          type: ReplacePrefixMatch
+          replacePrefixMatch: /brand
+  # datum.net and www.datum.net redirects to www.datum.net preserving path
   - matches:
     - path:
         type: PathPrefix


### PR DESCRIPTION
## Summary

Add redirect from brand.datum.net to [www.datum.net/brand](http://www.datum.net/brand)

## Changes

- Added HTTP and HTTPS gateway listeners for brand.datum.net domain
- Configured redirect rules to route brand.datum.net traffic to [www.datum.net/brand](http://www.datum.net/brand)
- Root path (/) redirects to /brand, all other paths preserve their structure under /brand

## Implementation

- Updated `config/gateway/gateway.yaml` with new listeners
- Updated `config/gateway/httproute-redirect.yaml` with redirect rules and parent refs