### PR TITLE
Remove 'What's next' section from datumctl quickstart

### DIFF
--- a/src/content/docs/docs/quickstart/datumctl.mdx
+++ b/src/content/docs/docs/quickstart/datumctl.mdx
@@ -159,7 +159,3 @@ Groups                                                   [system:authenticated]
 Extra: authentication.datum.net/datum-organization-uid   [pp4zn7tiw5be3beygm2d6mbcfe]
 Extra: authentication.kubernetes.io/credential-id        [JTI=01jgsr1m8fpb9cn0yrh05taa5v]
 ```
-
-## What's next
-
-- [Create a Project](/docs/tasks/create-project/)


### PR DESCRIPTION
Deleted the 'What's next' section and related project creation link from the datumctl quickstart documentation for improved clarity and conciseness.