### PR TITLE
Move copyright notice inside legal links container

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -150,11 +150,10 @@ const navData = navigation as NavData;
               <a href="/legal/terms/" class="footer-nav-link">Terms of Service</a>,
               <a href="/legal/privacy/" class="footer-nav-link">Privacy Policy</a>
             </p>
+            <p class="footer-copyright">
+              &copy; {new Date().getFullYear()} Datum Technology, Inc.
+            </p>
           </div>
-
-          <p class="footer-copyright">
-            &copy; {new Date().getFullYear()} Datum Technology, Inc.
-          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Relocates the copyright notice to be within the same div as the legal links for improved structure and alignment.