### PR TITLE
Update phrasing to 'AI era'

### DIFF
--- a/src/content/about/our-mission.mdx
+++ b/src/content/about/our-mission.mdx
@@ -1,5 +1,5 @@
 ---
-title: We’re on a mission to help the next 1k clouds thrive in the age of AI
+title: We’re on a mission to help the next 1k clouds thrive in the AI era
 ---
 
 Datum is unlocking the internet superpowers that all the big guys use – global edges, private networks, deterministic routing, direct interconnection – for the next generation of builders.

--- a/src/content/docs/docs/overview/why-datum.mdx
+++ b/src/content/docs/docs/overview/why-datum.mdx
@@ -20,7 +20,7 @@ That's why Datum exists.
 
 ## Empowering the Next 1000 Clouds
 
-To help 1000 new clouds thrive in the age of AI by arming them with the internet superpowers all the big guys have:
+To help 1000 new clouds thrive in the AI era by arming them with the internet superpowers all the big guys have:
 - A global edge to meet the internet at scale
 - Your own private backbones to route traffic off the public internet
 - Enterprise-grade DNS and domain management

--- a/src/content/docs/docs/platform/index.mdx
+++ b/src/content/docs/docs/platform/index.mdx
@@ -4,4 +4,4 @@ sidebar:
   order: 1
 ---
 
-Datum is focused on helping the next 1000 clouds thrive in the age of AI. One of the implications of this mission is that we aren’t super excited about restricting features.
+Datum is focused on helping the next 1000 clouds thrive in the AI era. One of the implications of this mission is that we aren’t super excited about restricting features.

--- a/src/content/docs/docs/quickstart/account-setup.mdx
+++ b/src/content/docs/docs/quickstart/account-setup.mdx
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 ## Empowering Builders in the AI Age
-Datum’s mission is to help 1000 new clouds thrive in the age of AI. That’s why we’re bringing the “internet superpowers” that all the big guys use into the tools that builders love, like Cursor and Kubernetes.
+Datum’s mission is to help 1000 new clouds thrive in the AI era. That’s why we’re bringing the “internet superpowers” that all the big guys use into the tools that builders love, like Cursor and Kubernetes.
 
 Let’s get you started!
 

--- a/src/content/docs/docs/quickstart/index.mdx
+++ b/src/content/docs/docs/quickstart/index.mdx
@@ -7,6 +7,6 @@ meta:
   description: "Start your journey with Datum! Register your account, join our Slack community, and attend monthly Community Huddles. Learn how to create organizations, invite team members, and get support as you explore network cloud features."
 ---
 
-Datum’s mission is to help 1000 new clouds thrive in the age of AI. That’s why we’re bringing the “internet superpowers” that all the big guys use into the tools that builders love, like Cursor and Kubernetes.
+Datum’s mission is to help 1000 new clouds thrive in the AI era. That’s why we’re bringing the “internet superpowers” that all the big guys use into the tools that builders love, like Cursor and Kubernetes.
 
 Let’s get you started!

--- a/src/content/handbook/about/purpose.md
+++ b/src/content/handbook/about/purpose.md
@@ -21,6 +21,6 @@ We believe that most people devote their time, energy, families, reputations and
 
 ## Focus & Niche
 The next thing we share is our [Hedgehog concept](https://www.jimcollins.com/concepts/the-hedgehog-concept.html), which was articulated by Jim Collins in his iconic book Good to Great. Similar to the Japanese concept of [ikigai](https://en.wikipedia.org/wiki/Ikigai), the Hedgehog concept is the intersection of three circles: 1) what you are deeply passionate about, 2) what you can be the best in the world at, and 3) what best drives your economic or resource engine.
-* **Our Purpose/Cause/Passion** - Helping 1k new clouds thrive in the age of AI.
+* **Our Purpose/Cause/Passion** - Helping 1k new clouds thrive in the AI era.
 * **Our “best in the world” niche** - We unlock internet superpowers for builders
 * **Economic Engine** - We are the best way for Alt Clouds and their customers to interact.


### PR DESCRIPTION
Replaced occurrences of 'age of AI' with 'AI era' in mission statements and related content for consistency and clarity across files.