### PR TITLE
refactor(content): clean up FrontMatter metadata and standardize formating

### DIFF
--- a/.frontmatter/starlight/contenttypes.json
+++ b/.frontmatter/starlight/contenttypes.json
@@ -426,7 +426,7 @@
       ]
     },
     {
-      "name": "blog",
+      "name": "blogPost",
       "pageBundle": false,
       "previewPath": "blog",
       "filePrefix": null,
@@ -440,11 +440,6 @@
         {
           "title": "Slug",
           "name": "slug",
-          "type": "string"
-        },
-        {
-          "title": "Subtitle",
-          "name": "subtitle",
           "type": "string"
         },
         {
@@ -482,11 +477,6 @@
           "title": "Draft",
           "name": "draft",
           "type": "boolean"
-        },
-        {
-          "title": "Updated Date",
-          "name": "updatedDate",
-          "type": "string"
         },
         {
           "title": "Meta (SEO)",
@@ -634,7 +624,7 @@
       ]
     },
     {
-      "name": "handbook",
+      "name": "handbookPost",
       "pageBundle": false,
       "previewPath": "handbook",
       "filePrefix": null,
@@ -1123,7 +1113,7 @@
       ]
     },
     {
-      "name": "huddles",
+      "name": "huddlePost",
       "pageBundle": false,
       "previewPath": "community-huddle",
       "filePrefix": null,
@@ -1792,6 +1782,56 @@
               ]
             }
           ]
+        }
+      ]
+    },
+    {
+      "name": "changelog",
+      "pageBundle": false,
+      "previewPath": "changelog",
+      "filePrefix": null,
+      "clearEmpty": true,
+      "fields": [
+        {
+          "title": "Title",
+          "name": "title",
+          "type": "string"
+        },
+        {
+          "title": "Description",
+          "name": "description",
+          "type": "string"
+        },
+        {
+          "title": "Date",
+          "name": "date",
+          "type": "datetime",
+          "default": "{{now}}"
+        }
+      ]
+    },
+    {
+      "name": "faqPost",
+      "pageBundle": false,
+      "previewPath": null,
+      "filePrefix": null,
+      "clearEmpty": true,
+      "fields": [
+        {
+          "title": "Question",
+          "name": "question",
+          "type": "string",
+          "single": true
+        },
+        {
+          "title": "Order",
+          "name": "order",
+          "type": "number"
+        },
+        {
+          "title": "Category",
+          "name": "category",
+          "type": "string"
         }
       ]
     }

--- a/.frontmatter/starlight/pagefolders.json
+++ b/.frontmatter/starlight/pagefolders.json
@@ -4,12 +4,42 @@
     {
       "title": "Docs",
       "path": "[[workspace]]/src/content/docs/docs",
-      "previewPath": "docs"
+      "previewPath": "docs",
+      "contentTypes": ["docs"]
     },
     {
       "title": "About",
       "path": "[[workspace]]/src/content/about",
       "previewPath": "about"
+    },
+    {
+      "title": "Blog",
+      "path": "[[workspace]]/src/content/blog",
+      "previewPath": "blog",
+      "contentTypes": ["blogPost"]
+    },
+    {
+      "title": "Changelog",
+      "path": "[[workspace]]/src/content/changelog",
+      "previewPath": "changelog",
+      "contentTypes": ["changelog"]
+    },
+    {
+      "title": "Handbook",
+      "path": "[[workspace]]/src/content/handbook",
+      "previewPath": "handbook",
+      "contentTypes": ["handbookPost"]
+    },
+    {
+      "title": "Huddle",
+      "path": "[[workspace]]/src/content/huddle",
+      "previewPath": "community-huddle",
+      "contentTypes": ["huddlePost"]
+    },
+    {
+      "title": "Faq",
+      "path": "[[workspace]]/src/content/faq",
+      "contentTypes": ["faqPost"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -205,7 +205,11 @@ The setup uses a multi-stage Dockerfile:
 
 ### Development with local kubernetes
 
-1. Install [Minikube](https://minikube.sigs.k8s.io/docs/).
+1. Install [Minikube](https://minikube.sigs.k8s.io/docs/) and start minikube
+
+```
+minikube start
+```
 
 2. Create secret.yaml file separated with this source. Value:
 
@@ -224,25 +228,33 @@ data:
   APP_PRIVATE_KEY:
 ```
 
-Then apply with command:
+3. Then apply with command:
 
-```bash
-kubectl apply -f <this_secret_file_path>
+Create namespace
+
+```
+kubectl create namespace datum-net
 ```
 
-3. Apply the kustomize config file
+Apply secret
+
+```bash
+kubectl apply -f config/dev/secret.yaml
+```
+
+Apply the kustomize config file
 
 ```bash
 kubectl apply -k config/base
 ```
 
-4. Apply the kustomize postgres config file
+Apply the kustomize postgres config file
 
 ```bash
 kubectl apply -k config/dev/postgres-config.yaml
 ```
 
-5. Install postgresql helm. example from bitnami source
+4. Install postgresql helm. example from bitnami source
 
 ```bash
 helm install postgresql -f config/dev/postgres-values.yaml -n datum-net oci://registry-1.docker.io/bitnamicharts/postgresql

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,8 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.0.tgz",
       "integrity": "sha512-mqVORhUJViA28fwHYaWmsXSzLO9osbdZ5ImUfxBarqsYdMlPbqAqGJCxsNzvppp1BEzc1mJNjOVvQqeDN8Vspw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.7.5",
@@ -2218,6 +2219,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -3471,60 +3473,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.7.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
@@ -3596,7 +3544,8 @@
       "version": "3.13.11",
       "resolved": "https://registry.npmjs.org/@types/alpinejs/-/alpinejs-3.13.11.tgz",
       "integrity": "sha512-3KhGkDixCPiLdL3Z/ok1GxHwLxEWqQOKJccgaQL01wc0EVM2tCTaqlC3NIedmxAXkVzt/V6VTM8qPgnOHKJ1MA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/alpinejs__collapse": {
       "version": "3.13.4",
@@ -4073,20 +4022,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.50.1.tgz",
-      "integrity": "sha512-PKhLGDq3JAg0Jk/aK890knnqduuI/Qj+udH7wCf0217IGi4gt+acgCyPVe79qoT+qKUvHMDQkwJeKW9fwl8Cyw==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.51.0.tgz",
+      "integrity": "sha512-XtssGWJvypyM2ytBnSnKtHYOGT+4ZwTnBVl36TA4nRO2f4PRNGz5/1OszHzcZCvcBMh+qb7I06uoCmLTRdR9og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.50.1",
-        "@typescript-eslint/type-utils": "8.50.1",
-        "@typescript-eslint/utils": "8.50.1",
-        "@typescript-eslint/visitor-keys": "8.50.1",
+        "@typescript-eslint/scope-manager": "8.51.0",
+        "@typescript-eslint/type-utils": "8.51.0",
+        "@typescript-eslint/utils": "8.51.0",
+        "@typescript-eslint/visitor-keys": "8.51.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.2.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4096,7 +4045,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.50.1",
+        "@typescript-eslint/parser": "^8.51.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -4112,16 +4061,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.50.1.tgz",
-      "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.51.0.tgz",
+      "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.50.1",
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/typescript-estree": "8.50.1",
-        "@typescript-eslint/visitor-keys": "8.50.1",
+        "@typescript-eslint/scope-manager": "8.51.0",
+        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/typescript-estree": "8.51.0",
+        "@typescript-eslint/visitor-keys": "8.51.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4137,14 +4087,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.50.1.tgz",
-      "integrity": "sha512-E1ur1MCVf+YiP89+o4Les/oBAVzmSbeRB0MQLfSlYtbWU17HPxZ6Bhs5iYmKZRALvEuBoXIZMOIRRc/P++Ortg==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.51.0.tgz",
+      "integrity": "sha512-Luv/GafO07Z7HpiI7qeEW5NW8HUtZI/fo/kE0YbtQEFpJRUuR0ajcWfCE5bnMvL7QQFrmT/odMe8QZww8X2nfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.50.1",
-        "@typescript-eslint/types": "^8.50.1",
+        "@typescript-eslint/tsconfig-utils": "^8.51.0",
+        "@typescript-eslint/types": "^8.51.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4159,14 +4109,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.50.1.tgz",
-      "integrity": "sha512-mfRx06Myt3T4vuoHaKi8ZWNTPdzKPNBhiblze5N50//TSHOAQQevl/aolqA/BcqqbJ88GUnLqjjcBc8EWdBcVw==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.51.0.tgz",
+      "integrity": "sha512-JhhJDVwsSx4hiOEQPeajGhCWgBMBwVkxC/Pet53EpBVs7zHHtayKefw1jtPaNRXpI9RA2uocdmpdfE7T+NrizA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/visitor-keys": "8.50.1"
+        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/visitor-keys": "8.51.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4177,9 +4127,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.1.tgz",
-      "integrity": "sha512-ooHmotT/lCWLXi55G4mvaUF60aJa012QzvLK0Y+Mp4WdSt17QhMhWOaBWeGTFVkb2gDgBe19Cxy1elPXylslDw==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.51.0.tgz",
+      "integrity": "sha512-Qi5bSy/vuHeWyir2C8u/uqGMIlIDu8fuiYWv48ZGlZ/k+PRPHtaAu7erpc7p5bzw2WNNSniuxoMSO4Ar6V9OXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4194,17 +4144,17 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.50.1.tgz",
-      "integrity": "sha512-7J3bf022QZE42tYMO6SL+6lTPKFk/WphhRPe9Tw/el+cEwzLz1Jjz2PX3GtGQVxooLDKeMVmMt7fWpYRdG5Etg==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.51.0.tgz",
+      "integrity": "sha512-0XVtYzxnobc9K0VU7wRWg1yiUrw4oQzexCG2V2IDxxCxhqBMSMbjB+6o91A+Uc0GWtgjCa3Y8bi7hwI0Tu4n5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/typescript-estree": "8.50.1",
-        "@typescript-eslint/utils": "8.50.1",
+        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/typescript-estree": "8.51.0",
+        "@typescript-eslint/utils": "8.51.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.2.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4219,9 +4169,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.50.1.tgz",
-      "integrity": "sha512-v5lFIS2feTkNyMhd7AucE/9j/4V9v5iIbpVRncjk/K0sQ6Sb+Np9fgYS/63n6nwqahHQvbmujeBL7mp07Q9mlA==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.51.0.tgz",
+      "integrity": "sha512-TizAvWYFM6sSscmEakjY3sPqGwxZRSywSsPEiuZF6d5GmGD9Gvlsv0f6N8FvAAA0CD06l3rIcWNbsN1e5F/9Ag==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4233,21 +4183,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.50.1.tgz",
-      "integrity": "sha512-woHPdW+0gj53aM+cxchymJCrh0cyS7BTIdcDxWUNsclr9VDkOSbqC13juHzxOmQ22dDkMZEpZB+3X1WpUvzgVQ==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.51.0.tgz",
+      "integrity": "sha512-1qNjGqFRmlq0VW5iVlcyHBbCjPB7y6SxpBkrbhNWMy/65ZoncXCEPJxkRZL8McrseNH6lFhaxCIaX+vBuFnRng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.50.1",
-        "@typescript-eslint/tsconfig-utils": "8.50.1",
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/visitor-keys": "8.50.1",
+        "@typescript-eslint/project-service": "8.51.0",
+        "@typescript-eslint/tsconfig-utils": "8.51.0",
+        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/visitor-keys": "8.51.0",
         "debug": "^4.3.4",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.2.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4287,16 +4237,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.50.1.tgz",
-      "integrity": "sha512-lCLp8H1T9T7gPbEuJSnHwnSuO9mDf8mfK/Nion5mZmiEaQD9sWf9W4dfeFqRyqRjF06/kBuTmAqcs9sewM2NbQ==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.51.0.tgz",
+      "integrity": "sha512-11rZYxSe0zabiKaCP2QAwRf/dnmgFgvTmeDTtZvUvXG3UuAdg/GU02NExmmIXzz3vLGgMdtrIosI84jITQOxUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.50.1",
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/typescript-estree": "8.50.1"
+        "@typescript-eslint/scope-manager": "8.51.0",
+        "@typescript-eslint/types": "8.51.0",
+        "@typescript-eslint/typescript-estree": "8.51.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4311,13 +4261,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.1.tgz",
-      "integrity": "sha512-IrDKrw7pCRUR94zeuCSUWQ+w8JEf5ZX5jl/e6AHGSLi1/zIr0lgutfn/7JpfCey+urpgQEdrZVYzCaVVKiTwhQ==",
+      "version": "8.51.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.51.0.tgz",
+      "integrity": "sha512-mM/JRQOzhVN1ykejrvwnBRV3+7yTKK8tVANVN3o1O0t0v7o+jqdVu9crPy5Y9dov15TJk/FTIgoUGHrTOVL3Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.50.1",
+        "@typescript-eslint/types": "8.51.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -4481,31 +4431,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/accepts/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/accepts/node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -4520,6 +4445,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4567,6 +4493,7 @@
       "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.3.tgz",
       "integrity": "sha512-fSI6F5213FdpMC4IWaup92KhuH3jBX0VVqajRJ6cOTCy1cL6888KyXdGO+seAAkn+g6fnrxBqQEx6gRpQ5EZoQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/reactivity": "~3.1.1"
       }
@@ -4847,6 +4774,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.16.6.tgz",
       "integrity": "sha512-6mF/YrvwwRxLTu+aMEa5pwzKUNl5ZetWbTyZCs9Um0F12HUmxUiF5UHiZPy4rifzU3gtpM3xP2DfdmkNX9eZRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.5",
@@ -5193,6 +5121,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -6380,6 +6309,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -6789,6 +6719,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7658,6 +7589,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7734,6 +7666,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8258,31 +8191,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/express/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/express/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/expressive-code": {
       "version": "0.41.5",
       "resolved": "https://registry.npmjs.org/expressive-code/-/expressive-code-0.41.5.tgz",
@@ -8605,6 +8513,27 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -10268,6 +10197,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -12311,24 +12241,28 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-function": {
@@ -12462,6 +12396,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -13424,6 +13359,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13555,6 +13491,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13584,6 +13521,7 @@
       "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.9.1",
         "prettier": "^3.0.0",
@@ -13788,9 +13726,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -14726,31 +14664,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/send/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/send/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/serve-static": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
@@ -15629,7 +15542,8 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -15885,31 +15799,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/type-is/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/type-is/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -16006,6 +15895,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16805,7 +16695,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16822,7 +16711,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16839,7 +16727,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16856,7 +16743,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16873,7 +16759,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16890,7 +16775,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16907,7 +16791,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16924,7 +16807,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16941,7 +16823,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16958,7 +16839,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16975,7 +16855,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -16992,7 +16871,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17009,7 +16887,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17026,7 +16903,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17043,7 +16919,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17060,7 +16935,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17077,7 +16951,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17094,7 +16967,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17111,7 +16983,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17128,7 +16999,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17145,7 +17015,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17162,7 +17031,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17179,7 +17047,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17196,7 +17063,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17213,7 +17079,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17230,7 +17095,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -17241,7 +17105,6 @@
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -17839,6 +17702,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -17923,6 +17787,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18089,10 +17954,11 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
-      "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.2.tgz",
+      "integrity": "sha512-b8L8yn4rIVfiXyHAmnr52/ZEpDumlT0bmxiq3Ws1ybrinhflGpt12Hvv54kYnEsGPRs6o/Ka3/ppA2OWY21IVg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/content/docs/docs/alt-cloud/domain-validation.mdx
+++ b/src/content/docs/docs/alt-cloud/domain-validation.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: Domain Validation
 sidebar:
   order: 2

--- a/src/content/docs/docs/alt-cloud/index.mdx
+++ b/src/content/docs/docs/alt-cloud/index.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: Overview
 sidebar:
   order: 1

--- a/src/content/docs/docs/api/authenticating.mdx
+++ b/src/content/docs/docs/api/authenticating.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Authenticating"
 sidebar:
   order: 3

--- a/src/content/docs/docs/api/connecting-to-the-api.mdx
+++ b/src/content/docs/docs/api/connecting-to-the-api.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Connecting"
 sidebar:
   order: 2

--- a/src/content/docs/docs/api/index.mdx
+++ b/src/content/docs/docs/api/index.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Overview"
 sidebar:
   order: 1

--- a/src/content/docs/docs/api/locations.mdx
+++ b/src/content/docs/docs/api/locations.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: Locations
 description: Locations are where Datum workloads run. They define the geographical and cloud provider context for your workloads.
 sidebar:

--- a/src/content/docs/docs/api/networks.mdx
+++ b/src/content/docs/docs/api/networks.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: Networks
 description: Networks are essential for deploying workloads in Datum. They define how workloads communicate.
 sidebar:

--- a/src/content/docs/docs/api/reference.mdx
+++ b/src/content/docs/docs/api/reference.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "API Reference"
 sidebar:
   order: 4

--- a/src/content/docs/docs/api/resources.mdx
+++ b/src/content/docs/docs/api/resources.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: Glossary of Resources
 sidebar:
   hidden: true

--- a/src/content/docs/docs/api/workloads.mdx
+++ b/src/content/docs/docs/api/workloads.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: Workloads
 description: Datum lets you deploy and manage workloads. Today, these workloads can be either virtual machines or containers. They're defined like any other Kubernetes custom resource, usually in YAML.
 sidebar:

--- a/src/content/docs/docs/assets/domains.mdx
+++ b/src/content/docs/docs/assets/domains.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Domains"
 sidebar:
   order: 2
@@ -15,5 +14,5 @@ Users gain visibility to all of their domains when added to Datum, regardless of
 3. Clear UI – Provide fast search, filter, and sort features including pagination (\~50 per)
 4. Verification – Verify a domain or subdomain with either a DNS record or HTTP token
 5. Registration details – View registrar, registration status, expiration date, and DNS Host
-6. Domain resource details – View services that are enabled within Datum 
+6. Domain resource details – View services that are enabled within Datum
 7. Activity Log – Track and expose events (add/remove, DNS status linked/unlinked, etc).

--- a/src/content/docs/docs/assets/index.mdx
+++ b/src/content/docs/docs/assets/index.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Cloud Assets Overview"
 sidebar:
   order: 1

--- a/src/content/docs/docs/assets/secrets.mdx
+++ b/src/content/docs/docs/assets/secrets.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Secrets"
 sidebar:
   order: 3

--- a/src/content/docs/docs/connections/connections.mdx
+++ b/src/content/docs/docs/connections/connections.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Connections"
 sidebar:
   order: 3

--- a/src/content/docs/docs/connections/galactic-vpc.mdx
+++ b/src/content/docs/docs/connections/galactic-vpc.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Galactic VPC"
 sidebar:
   order: 2

--- a/src/content/docs/docs/connections/index.mdx
+++ b/src/content/docs/docs/connections/index.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Connections Overview"
 sidebar:
   order: 1

--- a/src/content/docs/docs/galactic-vpc/index.mdx
+++ b/src/content/docs/docs/galactic-vpc/index.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Galactic VPC"
 description: This guide helps you understand the concepts and requirements of Galactic VPC.
 sidebar:
@@ -11,22 +10,22 @@ meta:
 
 ## Summary
 
-This guide provides background on the architecture, design decisions, and installation of the 
+This guide provides background on the architecture, design decisions, and installation of the
 components that make up Galactic VPC.
 
 
 ### What it is
 
-Galactic VPC is a Kubernetes-native overlay that enables the creation of Virtual Private Cloud (VPC) networks 
-between containers. It allows termination of directly attached interfaces as well as routed network 
-prefixes across a given VPC. This is achieved using an SRv6 (Segment Routing IPv6)-enabled underlay 
+Galactic VPC is a Kubernetes-native overlay that enables the creation of Virtual Private Cloud (VPC) networks
+between containers. It allows termination of directly attached interfaces as well as routed network
+prefixes across a given VPC. This is achieved using an SRv6 (Segment Routing IPv6)-enabled underlay
 network through which the necessary encapsulated packets are routed.
 
 
 ### Developing and Testing it
 
-Our [galactic-lab](https://github.com/datum-cloud/galactic-lab) is a one-stop-shop to 
-set up, test and develop the Galactic components. Check out the documentation there 
+Our [galactic-lab](https://github.com/datum-cloud/galactic-lab) is a one-stop-shop to
+set up, test and develop the Galactic components. Check out the documentation there
 for step-by-step instructions on how to get started.
 
 
@@ -41,11 +40,11 @@ for step-by-step instructions on how to get started.
 Our [galactic-operator](https://github.com/datum-cloud/galactic-operator) is responsible for two major tasks.
 
 It translates our CRDs into the necessary native or downstream manifests to provide the required functionality.
-Primarily, this means creating Multus `NetworkAttachmentDefinition` manifests that configure the 
+Primarily, this means creating Multus `NetworkAttachmentDefinition` manifests that configure the
 relevant CNI plugins.
 
-Additionally, the operator assigns unique identifiers for `VPC` and `VPCAttachment` objects. These 
-identifiers are important, as they are used to encode all the relevant endpoint information for the SRv6 
+Additionally, the operator assigns unique identifiers for `VPC` and `VPCAttachment` objects. These
+identifiers are important, as they are used to encode all the relevant endpoint information for the SRv6
 targets.
 
 [DeepWiki](https://deepwiki.com/datum-cloud/galactic-operator).
@@ -53,8 +52,8 @@ targets.
 
 ### galactic-cni
 
-[galactic-cni](https://github.com/datum-cloud/galactic-cni) is our Kubernetes CNI plugin. It is responsible for creating 
-the necessary low-level Linux kernel resources that tie the container into the relevant SRv6 endpoint. The CNI 
+[galactic-cni](https://github.com/datum-cloud/galactic-cni) is our Kubernetes CNI plugin. It is responsible for creating
+the necessary low-level Linux kernel resources that tie the container into the relevant SRv6 endpoint. The CNI
 plugin also assigns a unique local VRF on each host where termination is performed.
 
 [DeepWiki](https://deepwiki.com/datum-cloud/galactic-cni).
@@ -62,16 +61,16 @@ plugin also assigns a unique local VRF on each host where termination is perform
 
 ### galactic-agent
 
-[galactic-agent](https://github.com/datum-cloud/galactic-agent) runs on each Kubernetes node that hosts containers 
-with terminated endpoints. It does not need to run on `control-plane`-only nodes if they do not 
+[galactic-agent](https://github.com/datum-cloud/galactic-agent) runs on each Kubernetes node that hosts containers
+with terminated endpoints. It does not need to run on `control-plane`-only nodes if they do not
 host such workloads. It is usually deployed as a `DaemonSet` to ensure this.
 
-The primary purpose of the `galactic-agent` is to receive and configure routing instructions from the 
-central routing control plane (aka `galactic-router`). It connects to an [MQTT](https://mqtt.org/) broker, 
+The primary purpose of the `galactic-agent` is to receive and configure routing instructions from the
+central routing control plane (aka `galactic-router`). It connects to an [MQTT](https://mqtt.org/) broker,
 through which the necessary messages are passed using [Protobuf-encoded messages](https://github.com/datum-cloud/galactic-agent/blob/main/api/remote/remote.proto).
 
-In addition, the `galactic-agent` listens on a host-local Unix socket for [gRPC messages](https://github.com/datum-cloud/galactic-agent/blob/main/api/local/local.proto) 
-from containers created by the `galactic-cni` plugin. These messages register and deregister network 
+In addition, the `galactic-agent` listens on a host-local Unix socket for [gRPC messages](https://github.com/datum-cloud/galactic-agent/blob/main/api/local/local.proto)
+from containers created by the `galactic-cni` plugin. These messages register and deregister network
 segments and terminations with the central control plane.
 
 [DeepWiki](https://deepwiki.com/datum-cloud/galactic-agent).
@@ -79,16 +78,16 @@ segments and terminations with the central control plane.
 
 ### galactic-router
 
-[galactic-router](https://github.com/datum-cloud/galactic-router) is abstracted behind an MQTT-based 
-pub-sub queue, where it can receive register and deregister events for workloads. Based on 
+[galactic-router](https://github.com/datum-cloud/galactic-router) is abstracted behind an MQTT-based
+pub-sub queue, where it can receive register and deregister events for workloads. Based on
 these events, the `galactic-router` builds knowledge of the VPCs and their attached workloads.
 From this, it creates the necessary routing instructions for each Kubernetes node and dispatches them accordingly.
 
-It is written in Python to allow for higher-level interaction with the Galactic infrastructure. 
-We believe Python is a better match for this component, as its ecosystem for data processing 
-tasks is very rich. That said, there is no fundamental requirement for it to be written in Python. Any 
-language could connect to the MQTT broker and perform the necessary computations. It is also possible 
-to remove the MQTT abstraction entirely and listen for manifest changes inside the cluster to 
+It is written in Python to allow for higher-level interaction with the Galactic infrastructure.
+We believe Python is a better match for this component, as its ecosystem for data processing
+tasks is very rich. That said, there is no fundamental requirement for it to be written in Python. Any
+language could connect to the MQTT broker and perform the necessary computations. It is also possible
+to remove the MQTT abstraction entirely and listen for manifest changes inside the cluster to
 issue the relevant routing instructions. This side of the system is intentionally kept flexible,
 as we expect to innovate around how routing is performed.
 
@@ -97,8 +96,8 @@ as we expect to innovate around how routing is performed.
 
 ## CRDs
 
-Galactic Custom Resource Definitions are [specified](https://github.com/datum-cloud/galactic-operator/tree/main/config/crd/bases) 
-in the `galactic-operator` repository. The repository also contains [samples](https://github.com/datum-cloud/galactic-operator/tree/main/config/samples) 
+Galactic Custom Resource Definitions are [specified](https://github.com/datum-cloud/galactic-operator/tree/main/config/crd/bases)
+in the `galactic-operator` repository. The repository also contains [samples](https://github.com/datum-cloud/galactic-operator/tree/main/config/samples)
 for all the resources the operator works with.
 
 ### Example
@@ -107,11 +106,11 @@ In the following example, we showcase a VPC scenario where we connect workloads 
 
 Each of the three workloads directly connects to the VPC within the subnets defined for the VPC using both IPv4 and IPv6.
 
-In addition, the workloads in SJC (San Jose) and AMS (Amsterdam) route their own prefixes across this VPC to each 
-other. This is a scenario often encountered in more complex network setups and is often not supported by other overlay 
+In addition, the workloads in SJC (San Jose) and AMS (Amsterdam) route their own prefixes across this VPC to each
+other. This is a scenario often encountered in more complex network setups and is often not supported by other overlay
 technologies.
 
-For those prefixes to work, the container must set up the relevant interface and addresses inside itself. This is similar to what 
+For those prefixes to work, the container must set up the relevant interface and addresses inside itself. This is similar to what
 might be done by something like WireGuard.
 
 If you just want to test the basic function, you can simply set them up manually:

--- a/src/content/docs/docs/galactic-vpc/installation.mdx
+++ b/src/content/docs/docs/galactic-vpc/installation.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: Installation
 description: Details the components required to have Galactic fully installed.
 sidebar:
@@ -8,10 +7,10 @@ sidebar:
 
 ## Summary
 
-Galactic consists of several [components](../../galactic-vpc/#components) that work together to provide its 
+Galactic consists of several [components](../../galactic-vpc/#components) that work together to provide its
 full functionality.
 
-In addition, each host that terminates Galactic VPCs must meet certain configuration requirements 
+In addition, each host that terminates Galactic VPCs must meet certain configuration requirements
 for the low-level Linux networking stack to perform the necessary work.
 
 
@@ -19,7 +18,7 @@ for the low-level Linux networking stack to perform the necessary work.
 
 #### Routing
 
-We assume that you have created the necessary IPv6 underlay according to the requirements 
+We assume that you have created the necessary IPv6 underlay according to the requirements
 described in our [naming and numbering section](../naming-numbering/#srv6-addressing).
 
 For the installation, you will require the relevant node prefixes in the steps described below.
@@ -27,16 +26,16 @@ For the installation, you will require the relevant node prefixes in the steps d
 
 #### SRv6 Loopback
 
-Each node requires an SRv6 loopback address that can be used as the originating address for outgoing 
-packets.  
-We recommend using the highest VPC Identifier and Function values for this.  
-For example, if your node subnet is `2001:db8:ff01:0100::/56`, you might use `2001:db8:ff01:0100:ffff:ffff:ffff:ffff`.  
+Each node requires an SRv6 loopback address that can be used as the originating address for outgoing
+packets.
+We recommend using the highest VPC Identifier and Function values for this.
+For example, if your node subnet is `2001:db8:ff01:0100::/56`, you might use `2001:db8:ff01:0100:ffff:ffff:ffff:ffff`.
 To facilitate this, the Galactic codebase prevents assigning the first and last addresses in the given segment otherwise.
 
 
 #### VRF Kernel Module
 
-Our CNI plugin makes use of Linux kernel network VRF (Virtual Routing and Forwarding) to fully isolate containers and provide 
+Our CNI plugin makes use of Linux kernel network VRF (Virtual Routing and Forwarding) to fully isolate containers and provide
 access to all packets entering and exiting a given container.
 
 For this, your host system *must* have the VRF kernel module loaded and strict mode enabled using `sysctl`:
@@ -67,22 +66,22 @@ net.ipv6.conf.{iface}.seg6_enabled: 1
 
 #### Firewall
 
-The CNI plugin will insert and remove the necessary forwarding rules into the `iptables` 
+The CNI plugin will insert and remove the necessary forwarding rules into the `iptables`
 `FORWARD` chain to allow traffic to pass in and out of the container workload.
 
-You must ensure that traffic to *and* from your node subnet can be both received 
+You must ensure that traffic to *and* from your node subnet can be both received
 and sent.
 
-You should also be aware that SRv6 traffic may pass through your node 
-as a transit-only segment. You must therefore ensure that traffic can be forwarded 
-into and out of your node for the entirety of the IPv6 space you have allocated to your 
+You should also be aware that SRv6 traffic may pass through your node
+as a transit-only segment. You must therefore ensure that traffic can be forwarded
+into and out of your node for the entirety of the IPv6 space you have allocated to your
 SRv6 nodes.
 
 
 ### MQTT
 
-You must provide an MQTT broker to which the `galactic-router` and all instances of 
-`galactic-agent` nodes can connect. You can use a simple instance of [Eclipse Mosquitto](https://mosquitto.org/) 
+You must provide an MQTT broker to which the `galactic-router` and all instances of
+`galactic-agent` nodes can connect. You can use a simple instance of [Eclipse Mosquitto](https://mosquitto.org/)
 or a hosted MQTT broker such as [HiveMQ](https://www.hivemq.com/).
 
 
@@ -92,22 +91,22 @@ Galactic CNI requires some additional components to function.
 
 #### Community Plugins
 
-Install the [CNI community plugins](https://github.com/containernetworking/plugins/) according to 
+Install the [CNI community plugins](https://github.com/containernetworking/plugins/) according to
 their instructions.
 
 
 #### Multus
 
-[Multus](https://github.com/k8snetworkplumbingwg/multus-cni) is used to allow a container to have multiple 
+[Multus](https://github.com/k8snetworkplumbingwg/multus-cni) is used to allow a container to have multiple
 network interfaces. Install and test it according to their instructions.
 
-A note of caution: depending on your Kubernetes cluster network (Cilium, etc.), you may need to adjust the configuration to allow 
-the use of third-party plugins, as some of them prevent such use by default. The Multus documentation contains 
+A note of caution: depending on your Kubernetes cluster network (Cilium, etc.), you may need to adjust the configuration to allow
+the use of third-party plugins, as some of them prevent such use by default. The Multus documentation contains
 details on this.
 
 #### Galactic CNI
 
-As with the community plugins, you can retrieve the 
+As with the community plugins, you can retrieve the
 [Galactic CNI binary](https://github.com/datum-cloud/galactic-cni/releases) (named `galactic`) and install it in your cluster.
 
 
@@ -120,7 +119,7 @@ Galactic Operator can be installed with our `dist` manifest package directly:
 kubectl apply -f 'https://raw.githubusercontent.com/datum-cloud/galactic-operator/refs/heads/main/dist/install.yaml'
 ```
 
-You may wish to adjust the `image` reference from the default `:latest` to a 
+You may wish to adjust the `image` reference from the default `:latest` to a
 [release version](https://github.com/datum-cloud/galactic-operator/pkgs/container/galactic-operator).
 
 
@@ -129,18 +128,18 @@ You may wish to adjust the `image` reference from the default `:latest` to a
 The Galactic Agent must be installed so that it runs on each node hosting Galactic-terminated workloads.
 A `DaemonSet` is the preferred way to achieve this.
 
-You must provide the [necessary configuration](https://github.com/datum-cloud/galactic-agent/blob/main/main.go#L27) 
-for each node to operate properly. In our production environment, we run an `initContainer` as part of the `DaemonSet` that 
-retrieves the relevant runtime configuration from our configuration management system and provides it to the `galactic-agent` 
+You must provide the [necessary configuration](https://github.com/datum-cloud/galactic-agent/blob/main/main.go#L27)
+for each node to operate properly. In our production environment, we run an `initContainer` as part of the `DaemonSet` that
+retrieves the relevant runtime configuration from our configuration management system and provides it to the `galactic-agent`
 in a configuration file.
 
-[Here is an example](https://github.com/datum-cloud/galactic-agent/blob/main/config/base/daemonset.yaml) Kubernetes 
+[Here is an example](https://github.com/datum-cloud/galactic-agent/blob/main/config/base/daemonset.yaml) Kubernetes
 manifest you can use.
 
 The `/var/run/galactic` host mount is where the `galactic-agent` and the `galactic` CNI plugin by default
 connect to exchange register/deregister information. You may change it, but you must adjust it in both components.
 
-`NET_ADMIN` is a mandatory capability for the `galactic-agent` to add, modify, and delete the necessary SRv6 
+`NET_ADMIN` is a mandatory capability for the `galactic-agent` to add, modify, and delete the necessary SRv6
 routes in the host system. For this to work, the `galactic-agent` must also operate in the `hostNetwork`.
 
 
@@ -149,7 +148,7 @@ routes in the host system. For this to work, the `galactic-agent` must also oper
 The Galactic Router can be installed anywhere as long as it can access the MQTT broker.
 There is no requirement for it to operate inside the Kubernetes cluster hosting the workloads.
 
-[Here is an example](https://github.com/datum-cloud/galactic-router/blob/main/config/base/deployment.yaml) `Deployment` 
-manifest you can use. To make this work, you must provide 
-[configuration](https://github.com/datum-cloud/galactic-router/blob/main/galactic_router/__init__.py#L19) for the 
+[Here is an example](https://github.com/datum-cloud/galactic-router/blob/main/config/base/deployment.yaml) `Deployment`
+manifest you can use. To make this work, you must provide
+[configuration](https://github.com/datum-cloud/galactic-router/blob/main/galactic_router/__init__.py#L19) for the
 database and MQTT connection. You can provide this configuration as command arguments or environment variables.

--- a/src/content/docs/docs/galactic-vpc/naming-numbering.mdx
+++ b/src/content/docs/docs/galactic-vpc/naming-numbering.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: Naming & Numbering
 description: Describes concepts around naming and numbering of various Galactic resources.
 sidebar:
@@ -11,13 +10,13 @@ meta:
 
 ## Summary
 
-Galactic is built, as much as possible, around pattern-based naming and numbering to avoid 
+Galactic is built, as much as possible, around pattern-based naming and numbering to avoid
 adding additional state that would need to be persisted and kept in sync.
 
 
 ### SRv6 Addressing
 
-For an introduction to IPv6 segment routing, you may find 
+For an introduction to IPv6 segment routing, you may find
 [this presentation](https://www.segment-routing.net/tutorials/2017-12-05-srv6-introduction/) useful.
 
 ```
@@ -29,13 +28,13 @@ For an introduction to IPv6 segment routing, you may find
        0-31         32-39      40-47     48-55   56-63        64-111          112-127
 ```
 
-In this addressing scheme, you are free to choose everything up to the /56 boundary.  
-We provide the section prior to the /56 boundary simply as inspiration for how we chose to 
+In this addressing scheme, you are free to choose everything up to the /56 boundary.
+We provide the section prior to the /56 boundary simply as inspiration for how we chose to
 allocate those bits.
 
 Our chosen addressing scheme aims to be as simple as possible while allowing deployment both
-on the public Internet and within any data center’s internal IPv6 network. The minimum 
-prefix length is /48 to allow for global propagation in the public IPv6 BGP table.  
+on the public Internet and within any data center’s internal IPv6 network. The minimum
+prefix length is /48 to allow for global propagation in the public IPv6 BGP table.
 At the /48 boundary, we aggregate our internal nodes into a PoP-wide prefix for the public Internet.
 
 #### Parent Prefix
@@ -45,23 +44,23 @@ This aligns with the minimum /32 prefix, which is currently allocated by RIRs fo
 A static `ff` value that signals this address is part of our SRv6-based underlay.
 
 #### PoP
-Encodes a unique identifier for our Point of Presence (PoP) and is the prefix we announce 
+Encodes a unique identifier for our Point of Presence (PoP) and is the prefix we announce
 globally.
 
 #### Node
 Our internal identifier for a given node within this PoP.
 
 #### Version
-The first part of the Galactic internal bits, which must adhere to the relevant fields.  
-We start with a static `00` value to signal the first version of this addressing scheme.  
+The first part of the Galactic internal bits, which must adhere to the relevant fields.
+We start with a static `00` value to signal the first version of this addressing scheme.
 Future versions may assign this differently, changing the meaning of the following bits.
 
 #### VPC Identifier
 A 48-bit globally unique identifier for a given VPC.
 
 #### VPC Function
-A 16-bit identifier that allows further function assignments for a given endpoint.  
-Currently, this is used to differentiate multiple terminations of a given VPC on a single worker.  
+A 16-bit identifier that allows further function assignments for a given endpoint.
+Currently, this is used to differentiate multiple terminations of a given VPC on a single worker.
 It could also be used to further process a given packet with various SRv6-enabled functions.
 
 ### Network Interface Naming
@@ -69,7 +68,7 @@ It could also be used to further process a given packet with various SRv6-enable
 Our `galactic-cni` must create interfaces on the Kubernetes hosts. To follow our pattern-
 first principle, we encode both the VPC and the VPC attachment into the interface names.
 
-For the encoding, we have chosen a [base62 format](https://github.com/kenshaw/baseconv/blob/master/baseconv.go#L126) 
+For the encoding, we have chosen a [base62 format](https://github.com/kenshaw/baseconv/blob/master/baseconv.go#L126)
 to suit the Linux kernel’s requirements for valid characters.
 
 ```
@@ -94,18 +93,18 @@ This means we have encoded the maximum values for both the VPC and the attachmen
 
 ### MTU
 
-As with any packet-switched transport that adds encapsulation, SRv6 adds overheads that must be 
+As with any packet-switched transport that adds encapsulation, SRv6 adds overheads that must be
 taken into consideration when determining the maximum MTU a client can use.
 
-SRv6 uses an IPv6 packet to encapsulate the given payload. This means the regular 40 bytes 
+SRv6 uses an IPv6 packet to encapsulate the given payload. This means the regular 40 bytes
 of a standard [IPv6 header](https://www.rfc-editor.org/rfc/rfc8200#section-3) must be accounted for.
 
-In addition, the [Segment Routing Header](https://www.rfc-editor.org/rfc/rfc8754#name-segment-routing-header) 
+In addition, the [Segment Routing Header](https://www.rfc-editor.org/rfc/rfc8754#name-segment-routing-header)
 must be taken into account.
 
 At the moment, we are not using any special features in either the IPv6 header or SRv6 processing.
-Therefore, the overhead calculation has only one dynamic factor: the maximum number of segments you are 
-going to use within your underlay forwarding. Let's assume we allow a maximum of 5 hops in our 
+Therefore, the overhead calculation has only one dynamic factor: the maximum number of segments you are
+going to use within your underlay forwarding. Let's assume we allow a maximum of 5 hops in our
 underlay routing decisions.
 
 This would calculate our overhead as follows:
@@ -135,5 +134,5 @@ So:
              = 1372
 ```
 
-Ideally, your underlay transport should be able to carry larger (jumbo) frames so you can 
+Ideally, your underlay transport should be able to carry larger (jumbo) frames so you can
 present your clients with at least the standard MTU of 1500.

--- a/src/content/docs/docs/glossary.mdx
+++ b/src/content/docs/docs/glossary.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: Datum Cloud Glossary
 description: Definitions for terminology and concepts used in Datum Cloud and its documentation.
 sidebar:

--- a/src/content/docs/docs/guides.mdx
+++ b/src/content/docs/docs/guides.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: Guides and Demos
 sidebar:
   order: 9

--- a/src/content/docs/docs/index.mdx
+++ b/src/content/docs/docs/index.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: Datum Documentation
 sidebar:
   order: 0

--- a/src/content/docs/docs/infrastructure/index.mdx
+++ b/src/content/docs/docs/infrastructure/index.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Our Infrastructure"
 sidebar:
   order: 1

--- a/src/content/docs/docs/infrastructure/network.mdx
+++ b/src/content/docs/docs/infrastructure/network.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Network"
 sidebar:
   order: 3

--- a/src/content/docs/docs/infrastructure/zones-regions.mdx
+++ b/src/content/docs/docs/infrastructure/zones-regions.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Zones and regions"
 sidebar:
   order: 2
@@ -25,8 +24,8 @@ For example, here is how we describe the first region and availability zone in t
 Example: us-east-1a
 ```
 
-Regions and AZs are defined by distance and policy boundaries. 
-* When Points of Presence in the same country are separated by more than about 5 milliseconds round-trip time (RTT), a new Region is created. 
+Regions and AZs are defined by distance and policy boundaries.
+* When Points of Presence in the same country are separated by more than about 5 milliseconds round-trip time (RTT), a new Region is created.
 * If multiple PoPs exist in the same metro but operate independently (for example, separate network clusters or facilities), they are modeled as separate AZs. Increment the Count value to the next letter.
 * If PoPs are within about 5 milliseconds RTT and part of the same operational domain, they remain in the same Region. Example: us-east-1a, us-east-1b, us-east-1c.
 

--- a/src/content/docs/docs/metrics/grafana-cloud.mdx
+++ b/src/content/docs/docs/metrics/grafana-cloud.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Export to Grafana Cloud"
 sidebar:
   order: 2

--- a/src/content/docs/docs/metrics/index.mdx
+++ b/src/content/docs/docs/metrics/index.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Metrics Overview"
 sidebar:
   order: 1

--- a/src/content/docs/docs/overview/pricing.mdx
+++ b/src/content/docs/docs/overview/pricing.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Pricing & tiers"
 sidebar:
   order: 2

--- a/src/content/docs/docs/overview/products.mdx
+++ b/src/content/docs/docs/overview/products.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Our products"
 sidebar:
   order: 1

--- a/src/content/docs/docs/overview/support.mdx
+++ b/src/content/docs/docs/overview/support.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Support"
 sidebar:
   order: 3

--- a/src/content/docs/docs/overview/why-datum.mdx
+++ b/src/content/docs/docs/overview/why-datum.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Why Datum?"
 sidebar:
   order: 0
@@ -12,7 +11,7 @@ Over the last 25 years, our team built a dozen internet-scale cloud platforms fr
 
 Along the way, we scraped our fingers on cage nuts installing gear in data centers, borrowed IP space from friendly neighborhood ISPs, showed up in internet exchanges and meet-me rooms around the world, and figured out how to light our own dark fiber. It was fun, often hard, and almost always community-driven.
 
-Because of this experience, we’ve “grown up” alongside the internet and know that underneath every hyperscale cloud is a laundry list of capabilities that most builders have never heard of: interconnection, private backbones, ASNs, global edge infrastructure, authoritative DNS, etc. 
+Because of this experience, we’ve “grown up” alongside the internet and know that underneath every hyperscale cloud is a laundry list of capabilities that most builders have never heard of: interconnection, private backbones, ASNs, global edge infrastructure, authoritative DNS, etc.
 
 With a new landscape stimulated by AI, we see the potential for millions of new builders and thousands of new clouds to innovate at scale. So we asked: why can't everyone have access to the same, powerful toolset that all the big guys use at scale?
 
@@ -23,6 +22,6 @@ That's why Datum exists — to help 1k new clouds thrive in the age of AI by unl
 - Full packet capture with OTel-compatible telemetry
 - Powerful workflows to mitigate risk and shape network flows
 
-Even with experts at the helm, it can take years to build out this kind of infrastructure. We want to help you do this in minutes, from Cursor, Claude or Kubernetes. Onwards! 
+Even with experts at the helm, it can take years to build out this kind of infrastructure. We want to help you do this in minutes, from Cursor, Claude or Kubernetes. Onwards!
 
 To learn more about our strategy and how we operate, please visit our [Public Handbook](https://www.datum.net/handbook).

--- a/src/content/docs/docs/platform/authentication.mdx
+++ b/src/content/docs/docs/platform/authentication.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Authentication"
 sidebar:
   order: 2

--- a/src/content/docs/docs/platform/groups-members.mdx
+++ b/src/content/docs/docs/platform/groups-members.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Teams & Members"
 sidebar:
   order: 5
@@ -8,7 +7,7 @@ meta:
   description: "Learn to manage Datum organization members and groups. Configure team structures, send invitations, and control access to your cloud infrastructure."
 ---
 
-Standard Organizations enable teams to collaborate on projects, share resources, and centralize management. 
+Standard Organizations enable teams to collaborate on projects, share resources, and centralize management.
 
 When you first sign up for Datum Cloud, you receive a Personal Organization automatically. To collaborate with team members, you'll need to create or join a Standard Organization. Standard Organizations provide:
 - Centralized resource management across team members
@@ -16,7 +15,7 @@ When you first sign up for Datum Cloud, you receive a Personal Organization auto
 - Basic role-based access control
 - Team collaboration on projects and infrastructure
 
-Standard Organizations support the following coarse-grained roles: 
+Standard Organizations support the following coarse-grained roles:
 - Owners - Full control over the organization and all resources.
 - Editors - Control over all resources in an organization, except for team members.
 - Viewer - Read only access to all resources in an organization. No edit or action ability.

--- a/src/content/docs/docs/platform/index.mdx
+++ b/src/content/docs/docs/platform/index.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Control Plane Overview"
 sidebar:
   order: 1
@@ -8,6 +7,6 @@ meta:
   description: "The control plane for your open network cloud. Our guide to structuring Organizations, setting up Teams, and managing Projects within the Datum Platform."
 ---
 
-Datum is focused on helping the next 1k clouds thrive in the age of AI. One of the downstreams impacts of this mission is that we aren’t super excited about restricting features. 
+Datum is focused on helping the next 1k clouds thrive in the age of AI. One of the downstreams impacts of this mission is that we aren’t super excited about restricting features.
 
 Similar to public cloud platforms, you’ll find that we make “enterprise” capabilities available on all tiers, so you can adopt best practices no matter your scale.

--- a/src/content/docs/docs/platform/organizations.mdx
+++ b/src/content/docs/docs/platform/organizations.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Organizations"
 sidebar:
   order: 4
@@ -15,7 +14,7 @@ The organization resource is the root node in Datum Cloud’s resource hierarchy
 - Cannot have additional team members
 - Restricted to free “Builder” tier. No ability to upgrade to a higher level of service.
 
-**Standard Organization** - Designed for team collaboration and production use cases. 
+**Standard Organization** - Designed for team collaboration and production use cases.
 - Access to all platform features
 - Ability to add/manage team members with Owner, Editor or Viewer roles
 - Ability to upgrade to paid tiers when available.

--- a/src/content/docs/docs/platform/projects.mdx
+++ b/src/content/docs/docs/platform/projects.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Projects"
 sidebar:
   order: 6

--- a/src/content/docs/docs/platform/user-preferences.mdx
+++ b/src/content/docs/docs/platform/user-preferences.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "User Preferences"
 sidebar:
   order: 3
@@ -8,8 +7,8 @@ meta:
   description: "Manage your Datum user profile. Documentation on configuring portal themes, setting timezones, and linking identity providers like GitHub and Google."
 ---
 
-Each user has a limited number of preferences they can set via the Datum Cloud portal. 
+Each user has a limited number of preferences they can set via the Datum Cloud portal.
 - Display mode - Choose light mode, dark mode, or system mode
 - Profile picture - Upload an avatar, your colleagues will appreciate it
 - Profile name - Adjust the name that appears when collaborators, system records, etc.
-- Time zone - This helps with localizing activity logs and other messages 
+- Time zone - This helps with localizing activity logs and other messages

--- a/src/content/docs/docs/quickstart/account-setup.mdx
+++ b/src/content/docs/docs/quickstart/account-setup.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Account Setup"
 description: Create a Project via kubectl
 sidebar:
@@ -11,7 +10,7 @@ meta:
 
 As always, the first step is to create a user account! You can do this at https://cloud.datum.net.
 
-- You will be asked to use a Google or a GitHub account for authentication. 
+- You will be asked to use a Google or a GitHub account for authentication.
 - Your Datum account will be associated with the primary email on your social account.
 - We do not accept email and password registrations.
 
@@ -19,9 +18,9 @@ _Note: Datum Cloud is currently accepting registrations for its free “Builder 
 
 Once you’ve created a user account, feel free to personalize your experience a bit (avatar, portal preferences, etc). Just click on your initials at the top right of your screen.
 
-If you want to do anything interesting, however, you’ll need an Organization and a Project. 
+If you want to do anything interesting, however, you’ll need an Organization and a Project.
 
-- Organizations are the resource for managing projects, billing and team access 
+- Organizations are the resource for managing projects, billing and team access
 - Projects, which are nested below Orgs, are where all work takes place
 
 By default, each user receives a Personal Organization, which does not support collaboration and cannot be renamed. Consider this your personal sandbox. If you wish to collaborate with others, simply create a new Standard Organization by providing a description and unique resource name.

--- a/src/content/docs/docs/quickstart/datum-concepts.mdx
+++ b/src/content/docs/docs/quickstart/datum-concepts.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Key Concepts"
 sidebar:
   order: 3
@@ -10,12 +9,12 @@ meta:
 
 As you begin working with Datum, it’s helpful to understand some key decisions we’ve made.
 
-**Kubernetes CRDs** - Datum’s control plane is built on Kubernetes Custom Resource Definitions (CRDs). While you don’t have to use k8s to use Datum Cloud, it helps to understand what’s under the hood. 
+**Kubernetes CRDs** - Datum’s control plane is built on Kubernetes Custom Resource Definitions (CRDs). While you don’t have to use k8s to use Datum Cloud, it helps to understand what’s under the hood.
 
-- Ecosystem - We’ve invested in this approach to align with the largest ecosystem for cloud operators. If you’re a cloud native SRE or platform engineer, working with Datum capabilities exposed as resources should feel super comfy. 
-- LLMs - Because Kubernetes patterns are so well established, LLMs are able to more easily and accurately interact with Datum’s platform.  
+- Ecosystem - We’ve invested in this approach to align with the largest ecosystem for cloud operators. If you’re a cloud native SRE or platform engineer, working with Datum capabilities exposed as resources should feel super comfy.
+- LLMs - Because Kubernetes patterns are so well established, LLMs are able to more easily and accurately interact with Datum’s platform.
 
-**Locations** - We deploy infrastructure in the top internet aggregation points globally. To learn more about how we translate that infrastructure into customer-facing regions and zones, check out the [Infrastructure](../../infrastructure/) section later in these docs. 
+**Locations** - We deploy infrastructure in the top internet aggregation points globally. To learn more about how we translate that infrastructure into customer-facing regions and zones, check out the [Infrastructure](../../infrastructure/) section later in these docs.
 
 **Customer Portal** - Our portal is organized into three main areas: account settings, organization settings, and project settings. Aside from team management, which takes place at the Org level, most resources are managed at the Project level:
 - Runtime Core network services delivered on Datum’s global edge, including:

--- a/src/content/docs/docs/quickstart/datum-mcp.mdx
+++ b/src/content/docs/docs/quickstart/datum-mcp.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Datum MCP"
 sidebar:
   order: 5
@@ -15,17 +14,17 @@ Datum MCP integrates with popular AI assistants like Cursor, enabling you to vie
 - Users
 - Projects
 - Domains
-- Proxies 
+- Proxies
 - API’s (CRDs list/describe)
 
-Datum MCP implements the latest [MCP Authorization](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) specifications and supports OAuth 2.1 (PKCE) auth or macOS Keychain token storage. 
+Datum MCP implements the latest [MCP Authorization](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) specifications and supports OAuth 2.1 (PKCE) auth or macOS Keychain token storage.
 
 **Install** - We offer three ways to get started:
 1. Quick install
 2. Manual download
 3. Add to Cursor locally
 
-Visit the [Datum MCP repo on GitHub](https://github.com/datum-cloud/datum-mcp) for more information. 
+Visit the [Datum MCP repo on GitHub](https://github.com/datum-cloud/datum-mcp) for more information.
 
 From the command line, this will install Datum MCP on your system:
 ```
@@ -34,7 +33,7 @@ curl -fsSL https://github.com/datum-cloud/datum-mcp/releases/latest/download/ins
 
 The [latest release](https://github.com/datum-cloud/datum-mcp/releases/latest) is available at https://github.com/datum-cloud/datum-mcp/releases/latest. Binaries are available for Linux, MacOS and Windows on x86 and arm64 versions.
 
-Add this to your AI client config to run the server via stdio. 
+Add this to your AI client config to run the server via stdio.
 ```
 {
   "datum-mcp": {
@@ -57,7 +56,7 @@ To add the Datum MCP to Cursor, this one-click command will suffice:  [Add to C
 - httproutes - list, get, create, update, delete
 - gateways - list, get, create, update, delete
 - trafficprotectionpolicies - list, get, create, update, delete
-- apis - list, get 
+- apis - list, get
 - dnszones - list, get, create, update, delete
 - dnsrecordsets - list, get, create, update, delete
 - dnszoneclass - list, get

--- a/src/content/docs/docs/quickstart/datumctl.mdx
+++ b/src/content/docs/docs/quickstart/datumctl.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "datumctl"
 description: Set up tools to work with Datum.
 sidebar:
@@ -11,10 +10,10 @@ meta:
 
 datumctl is our CLI for managing Datum Cloud resources via the command line. It provides authorization, API management, and has the ability to manage .kubeconfig files so that you can leverage kubectl for day to day interaction with Datum Cloud.
 
-Let’s assume that you have a working set of Kubernetes command line tools installed on your system, especially \`kubectl\` (which is used to apply resources to the cluster and to inspect the status of work as it happens). In addition, we’ll note that if you want or need to build our tooling from scratch you’ll want to have a Go compiler available. 
+Let’s assume that you have a working set of Kubernetes command line tools installed on your system, especially \`kubectl\` (which is used to apply resources to the cluster and to inspect the status of work as it happens). In addition, we’ll note that if you want or need to build our tooling from scratch you’ll want to have a Go compiler available.
 
 ## Installing datumctl
-datumctl is straightforward to install from prebuilt binaries on many systems, and since it’s open source, you can build it from scratch if that suits your needs. 
+datumctl is straightforward to install from prebuilt binaries on many systems, and since it’s open source, you can build it from scratch if that suits your needs.
 
 ### Mac with Homebrew
 
@@ -39,7 +38,7 @@ mv ./datumctl ~/.local/bin/datumctl
 
 ### Go with Go [v1.XX](http://v1.xx)+
 
-You must have Go version [1.XX](http://1.xx) or better for this to work as expected. 
+You must have Go version [1.XX](http://1.xx) or better for this to work as expected.
 ```
 go install go.datum.net/datumctl@latest
 # Ensure that $GOPATH/bin is in your PATH

--- a/src/content/docs/docs/quickstart/index.mdx
+++ b/src/content/docs/docs/quickstart/index.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Get started with Datum"
 sidebar:
   order: 1

--- a/src/content/docs/docs/quickstart/open-source.mdx
+++ b/src/content/docs/docs/quickstart/open-source.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Open Source"
 sidebar:
   order: 4
@@ -10,14 +9,14 @@ meta:
 
 We’ve always loved how Raj Dutt, CEO at Grafana Labs, says about his company that “open source is our strategy, not our religion.” At Datum, open source is absolutely critical to our strategy, but it also has a dash of religion to it. Here’s why:
 
-- **Take it anywhere** - We’re building Datum to be used anywhere. In order for you to take it home, run it in your lab, put it on GCP, deploy it on an oil rig, or run it in thousands of retail stores, we believe open source is a key feature. 
+- **Take it anywhere** - We’re building Datum to be used anywhere. In order for you to take it home, run it in your lab, put it on GCP, deploy it on an oil rig, or run it in thousands of retail stores, we believe open source is a key feature.
 - **Monetization** - We don’t make money with free software. That’s silly! Instead, we run a big aggregation network in the middle, offer an outstanding hosted control plane, and facilitate valuable connections between parties.
 - **Built better** - We work in the open because it keeps you honest and working hard. We think trust is best built through transparency.
 - **Pay it back** - Open source has touched our lives and enabled our careers. But it’s also at the heart of cloud innovation and the internet, so we need to find ways to contribute, not just consume.
 
 **Our licensing philosophy** - Our licensing strategy, which is centered around an AGPLv3 license, is meant to balance our open source strategy with building a durable, valuable, commercial enterprise. We ended up with an AGPLv3 license because we want folks to feel free to use, fork, and contribute to our core technology. However, since we will make money running a cloud, it’s important that contributions come back into the project and that we don’t facilitate directly competitive cloud offerings without separate agreements.
 
-**Milo “system of action” for alt clouds** - One of the big bets that we’re able to take as a venture-backed company is to build things that aren’t immediately profitable. [Milo is our open source (AGPLv3) “system of action”](https://github.com/datum-cloud/milo) that serves as the backend of Datum Cloud. We’re building it in the open, and making it available to other alt clouds, because we’re committed to helping the next 1000 clouds thrive in the age of AI. Milo helps to remove an enormous amount of undifferentiated toil so they can focus on building value for customers. You can learn more about it here.  
+**Milo “system of action” for alt clouds** - One of the big bets that we’re able to take as a venture-backed company is to build things that aren’t immediately profitable. [Milo is our open source (AGPLv3) “system of action”](https://github.com/datum-cloud/milo) that serves as the backend of Datum Cloud. We’re building it in the open, and making it available to other alt clouds, because we’re committed to helping the next 1000 clouds thrive in the age of AI. Milo helps to remove an enormous amount of undifferentiated toil so they can focus on building value for customers. You can learn more about it here.
 
 **Contributing to Datum** - We welcome contributions and contributors to the Datum community. That being said, it’s hard to contribute to a system that touches a lot of physical infrastructure without having access. We hear you!  Beyond diving into our [Datum Cloud](https://github.com/datum-cloud/) and [Milo](https://github.com/datum-cloud/milo) repos, please reach out and we’ll help you find a great way to get involved.
 

--- a/src/content/docs/docs/runtime/ai-gateway.mdx
+++ b/src/content/docs/docs/runtime/ai-gateway.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "AI Gateway"
 sidebar:
   order: 4

--- a/src/content/docs/docs/runtime/dns.mdx
+++ b/src/content/docs/docs/runtime/dns.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Datum DNS"
 sidebar:
   order: 2

--- a/src/content/docs/docs/runtime/index.mdx
+++ b/src/content/docs/docs/runtime/index.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Runtime Overview"
 sidebar:
   order: 1

--- a/src/content/docs/docs/runtime/proxy.mdx
+++ b/src/content/docs/docs/runtime/proxy.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Datum Proxy"
 sidebar:
   order: 3
@@ -10,11 +9,11 @@ meta:
 
 Simplify how you protect and route internet traffic to your backend services. Datum’s Proxy is a streamlined, single-manifest approach that automatically manages the hard stuff.
 
-1. **Portal Management UI** – View, setup and manage Proxy resources via the portal. Edit backend endpoints and host name/s after creation. 
+1. **Portal Management UI** – View, setup and manage Proxy resources via the portal. Edit backend endpoints and host name/s after creation.
 2. **Enhanced Status Visibility** – Display status information including: Programmed status "Accepted" and "Programmed", Generated hostname(s), Custom hostname verification status, …
 3. **Cloud Portal Traffic Metrics** - Filtered by region: Global Upstream Latency Percentile, Regional Upstream RPS,  Regional Upstream Response and Errors.
 4. **DNS & Domain Integration** – Integration with Domain resources for custom hostname configuration, including: Visual indication of verification status, Quick links to related Domain resources, Clear messaging for unverified hostnames.
-5. **Endpoint Failover with Passive Health Checks** – Track errors at origin and failover to backup when failure threshold is crossed. 
+5. **Endpoint Failover with Passive Health Checks** – Track errors at origin and failover to backup when failure threshold is crossed.
 6. **Path Configuration** - Determine how incoming requests are matched and routed based on their URL paths.
 7. **Audit Log** – Track and expose all events (create/update/delete, hostname changes, backend modifications, programming status changes) for audit and compliance.
 

--- a/src/content/docs/docs/tasks/index.mdx
+++ b/src/content/docs/docs/tasks/index.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: Tasks
 sidebar:
   order: 1

--- a/src/content/docs/docs/tutorials/index.mdx
+++ b/src/content/docs/docs/tutorials/index.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: Tutorials
 sidebar:
   order: 1

--- a/src/content/docs/docs/tutorials/infra-provider-gcp.mdx
+++ b/src/content/docs/docs/tutorials/infra-provider-gcp.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: Create a Datum Workload backed by Google Cloud (GCP)
 sidebar:
   order: 3

--- a/src/content/docs/docs/workflows/1-click-waf.mdx
+++ b/src/content/docs/docs/workflows/1-click-waf.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "1-Click WAF"
 sidebar:
   order: 2

--- a/src/content/docs/docs/workflows/index.mdx
+++ b/src/content/docs/docs/workflows/index.mdx
@@ -1,5 +1,4 @@
 ---
-fmContentType: docs
 title: "Workflows Overview"
 sidebar:
   order: 1


### PR DESCRIPTION
- Remove deprecated `fmContentType` field from all doc frontmatter
- Add trailing newlines to documentation files for consistency
- Fix code formatting (trailing whitespace, indentation)
- Update package-lock.json with dependency changes
- Configure TypeScript and ESLint dependencies
- Update README with improved Kubernetes setup instructions
- Standardize FrontMatter content types and page folders configuration