### PR TITLE
docs: Add nix to the datumctl install options

### DIFF
--- a/src/content/docs/docs/quickstart/datumctl.mdx
+++ b/src/content/docs/docs/quickstart/datumctl.mdx
@@ -36,6 +36,21 @@ mkdir -p ~/.local/bin
 mv ./datumctl ~/.local/bin/datumctl
 ```
 
+### Mac or Linux with nix
+
+Standard nix flake setup:
+
+```
+# Pick latest from git
+nix run github:datum-cloud/datumctl
+
+# Specify version
+nix run github:datum-cloud/datumctl/<SHA or version>
+```
+
+You can also incorporate it into your home-manager build or other
+flake so that it's available in a custom environment.
+
 ### Go with Go [v1.XX](http://v1.xx)+
 
 You must have Go version [1.XX](http://1.xx) or better for this to work as expected.


### PR DESCRIPTION
This is a companion to https://github.com/datum-cloud/datumctl/pull/56.

[nix](https://nixos.org/) is a common way to consume packages. I can't live without it! 🙏 