### PR TITLE
Add back travel policy and update handbook links

### DIFF
--- a/src/content/handbook/about/strategy.md
+++ b/src/content/handbook/about/strategy.md
@@ -27,7 +27,7 @@ To update the concept in an age of AI and complex digital ecosystems, we are bui
 Our open source commitment:
 * Core Datum Cloud functionality is fully open source
 * [Community contributions](https://github.com/orgs/datum-cloud/discussions/categories/feature-requests) are welcomed and celebrated 
-* [Documentation](https://www.datum.net/docs/) and examples are extensive and maintained
+* [Documentation](/docs/) and examples are extensive and maintained
 * We provide paths for both self-hosted and managed data planes deployments
 
 We’re building Datum to be genuinely neutral because providers need a place to collaborate without competitive dynamics. We believe we succeed when our ecosystem partners succeed, so that means:

--- a/src/content/handbook/culture/build-or-buy.md
+++ b/src/content/handbook/culture/build-or-buy.md
@@ -2,7 +2,7 @@
 title: "Build or buy"
 sidebar:
   label: Build or buy
-  order: 6
+  order: 7
 updatedDate: Jan 21, 2026
 authors: jacob
 meta:

--- a/src/content/handbook/culture/purchasing.md
+++ b/src/content/handbook/culture/purchasing.md
@@ -18,8 +18,6 @@ If it's a small expense, just buy it using the Ramp card we issue to each employ
 
 For larger expenses that don't fit into the categories below, please suggest amending this policy with a pull request on this page. This avoids lots of one-off exceptions and helps us operate better over time.
 
- 
-
 ## Small expenses
 
 Just do it. This means expenses that are under $75 one off or under $20/month recurring that we can cancel easily.
@@ -120,12 +118,9 @@ Folks outside of Engineering should use their individual software budget for AI 
 
 ## Optional software
 
-There are other tools some team members choose to use individually. In those cases, as they become more widely adopted in the company, it makes sense to have a company account.
-
-Ask for access in [#tools-onboarding-requests](https://datum.slack.com).
+There are other tools some team members choose to use individually. In those cases, as they become more widely adopted in the company, it makes sense to have a company account. Ask for access in [#onboarding-tool-requests](https://datum-inc.slack.com/archives/C084NHC417T).
 
 - [Zoom Pro](https://www.zoom.us/)
-
 - Cap
 
 IDEs
@@ -144,7 +139,7 @@ You can spend up to $200/month to work in cafés or coworking spaces. You must p
 
 ## Travel
 
-If you need to travel on Datum’s behalf for in-person onboarding, meeting customers, and offsites, again please spend money in the best interests of the company. [See our travel expense policy for more details](https://www.datum.net/handbook/culture/traveling/).
+If you need to travel on Datum’s behalf for in-person onboarding, meeting customers, and offsites, again please spend money in the best interests of the company. [See our travel expense policy for more details](/handbook/culture/purchasing/).
 
 ## Budget for working together/socializing
 

--- a/src/content/handbook/culture/rhythms.md
+++ b/src/content/handbook/culture/rhythms.md
@@ -12,7 +12,7 @@ meta:
 
 Datum is an early stage startup, working to find its way to users, customers, and world-changing outcomes. While some people absolutely love the iterative nature of “zero to one” companies, we recognize that it isn’t for everyone. This is an especially tricky balance in the infrastructure and network layers, where stability is core to the product promise.
 
-In addition to understanding our small size and big ambitions, it’s important that everyone working at Datum understands our [core values](https://www.datum.net/handbook/about/purpose/), goals, and [strategy](https://www.datum.net/handbook/about/strategy/). This is the “why” that not only gets us out of bed on a rainy day, but helps us keep our compass pointed in the right direction when things get tough. Here are some of our key rhythms that keep us grounded:
+In addition to understanding our small size and big ambitions, it’s important that everyone working at Datum understands our [core values](/handbook/about/purpose/), goals, and [strategy](/handbook/about/strategy/). This is the “why” that not only gets us out of bed on a rainy day, but helps us keep our compass pointed in the right direction when things get tough. Here are some of our key rhythms that keep us grounded:
 
 <h3>Weekly</h3>
 

--- a/src/content/handbook/culture/tooling.md
+++ b/src/content/handbook/culture/tooling.md
@@ -2,7 +2,7 @@
 title: "Tooling"
 sidebar:
   label: Tooling
-  order: 5
+  order: 6
 updatedDate: Nov 13, 2025
 authors: jacob
 meta:

--- a/src/content/handbook/culture/traveling.md
+++ b/src/content/handbook/culture/traveling.md
@@ -1,0 +1,61 @@
+---
+title: "Traveling"
+sidebar:
+  label: Traveling
+  order: 5
+updatedDate: Nov 13, 2025
+authors: jacob
+meta:
+  title: "Datum Company Travel Policy"
+  description: "Guidelines for business travel. Read the Datum travel policy, including expense reimbursements, booking procedures, and per diems for team offsites."
+---
+
+All US-based employees use Ramp for expense management, which includes travel related purchases. The guidelines below are suggestions to help frame good judgment.
+
+**Business travel principles** - Everyone in the company should try to book travel that balances cost, quality and convenience. Use your Ramp card and make sure to get approval for:
+* Travel over $2,000 (total trip cost)
+* All international travel
+* Any single expense over $1,000
+
+**Flights** - When taking to the skies, please keep the following in mind:
+* Economy class for all flights (premium economy for flights over 6 hours).
+* Fly direct when the price is reasonable. Max ~$600 roundtrip.
+* Use Ramp Travel or book through any site with your Ramp card
+* Book as far in advance as possible to get the best price
+* Typical domestic flights should be under $600 roundtrip
+* One checked bag covered for trips over 3 nights (keep receipts for fees)
+
+**Hotels** - When booking hotels, here’s what we recommend:
+* Choose hotels convenient to your meetings
+* Standard business hotels (Marriott, Hilton, Hyatt, Holiday Inn) or Airbnb
+* Take advantage of our corporate discount rate with Holiday Inn properties in NYC
+* Conference hotel blocks may exceed limits, so consider a nearby option when possible
+* Feel free to earn personal loyalty points
+* Aim for $225/night or less in major cities, $175/night in midsize cities.
+
+**Ground transportation** - We cover the following transportation, ideally using your Ramp card:
+* Uber/Lyft for business travel
+* Taxis and public transportation
+* Airport parking up to $40/day (for trips under 5 days)
+* Tolls and parking at business locations
+
+Rental cars require manager approval. If you do need to rent a car (via a major agency or also Turo) make sure to choose economy or mid-size vehicles where possible.
+
+* **IMPORTANT:** Accept the rental car insurance (CDW/LDW).
+* Our company insurance covers liability but NOT damage to the rental car itself
+* Keep all receipts including rental insurance charges
+
+For use of your personal car, we reimburse at IRS rate ($0.67/mile in 2025). Please submit mileage log via Ramp with start/end points and business purpose. Note: we do not reimburse for regular commuting, such as to an office or coworking space.
+
+**Eating while traveling for work**
+* $75/day (domestic) or $100/day (international)
+* These are maximums, not entitlements, so please use good judgment
+* Upload receipts for meals over $25, including names of fellow diners
+* Alcohol is fine when dining with clients, prospects, or team. Please drink responsibly.
+
+**Other travel**
+* We coordinate and book accommodations on your behalf for team events.
+* Pre-approval is required for conferences
+
+**Out-of-pocket reimbursements**
+* Use Ramp cards whenever possible. For rare exceptions, submit via Ramp app with receipt and business purpose within 10 days.

--- a/src/content/handbook/eos/quarterly-conversations.md
+++ b/src/content/handbook/eos/quarterly-conversations.md
@@ -67,7 +67,7 @@ How can we work together more effectively?
 
 ## 5. Values & Culture
 
-What Datum [core values](https://www.datum.net/handbook/about/purpose/) do you embody?
+What Datum [core values](/handbook/about/purpose/) do you embody?
 
 What values are you working to strengthen?
 

--- a/src/content/handbook/policy/data-retention.md
+++ b/src/content/handbook/policy/data-retention.md
@@ -34,7 +34,7 @@ _Datum acts as the data processor for this information pursuant to our DPA. In a
 Where not specified, customer data will be retained no longer than is needed to provide the service, and anonymized or deleted afterwards.
 
 ## Privacy Policy
-Datum will delete personal data pursuant to individual data subject requests in accordance with applicable data privacy laws as set forth in our [Privacy Policy](https://www.datum.net/legal/privacy/).
+Datum will delete personal data pursuant to individual data subject requests in accordance with applicable data privacy laws as set forth in our [Privacy Policy](/legal/privacy/).
 
 ## Suspension
 Datum may suspend routine deletion of customer data if required for security forensic analysis purposes or a legal hold involving such data. Legal holds may be issued, for example, in connection with an active, imminent, threatened or reasonably anticipated investigation, litigation, arbitration, subpoena, financial transaction, or other legal matter.

--- a/src/content/handbook/policy/disaster-recovery.md
+++ b/src/content/handbook/policy/disaster-recovery.md
@@ -13,7 +13,7 @@ meta:
 Datum’s customers are dependent on our services operating as expected. Proper planning, monitoring, and recovery steps are critical to address incidents that may impact the integrity or availability of services and data is critical to the operation of Datum. Disaster Recovery is a set of processes and techniques used to help an organization like ours recover from a disaster and resume routine business operations.
 
 **Scope**
-The following minimum standards apply to Datum’s assets as managed by employees, contractors and vendors. These include but are not limited to: cloud service providers, cloud regions, major components within cloud regions, key vendors (those included in our [vendor assessment](../vendors/)), key open-source components
+The following minimum standards apply to Datum’s assets as managed by employees, contractors and vendors. These include but are not limited to: cloud service providers, cloud regions, major components within cloud regions, key vendors (those included in our [vendor assessment](/handbook/policy/vendors/)), key open-source components
 
 **Schedule**
 Datum reviews its backups, and any Disaster Recovery plans annually with a walkthrough exercise. Datum tests its ability to restore production data at least annually.
@@ -29,4 +29,4 @@ Datum regularly reviews backups and service redundancy to ensure they can be use
 An incident could be detected internally by monitoring tools, by an employee in their course of work, or reported by a third party including customers.
 
 **Outage response and remediation**
-If a suspected outage or other business continuity incident is detected, it should be responded to following the [Incident response process](../incident-response/).
+If a suspected outage or other business continuity incident is detected, it should be responded to following the [Incident response process](/handbook/policy/incident-response/).

--- a/src/content/handbook/policy/incident-disclosure.md
+++ b/src/content/handbook/policy/incident-disclosure.md
@@ -16,7 +16,7 @@ Both client software and our managed infrastructure (i.e. Datum Cloud) are in sc
 
 For incidents that fall under any legal disclosure requirements (such as [California’s Data Security Breach Reporting](https://oag.ca.gov/privacy/databreach/reporting)), those requirements will take precedence over this policy.
 
-By “notify” here we mean explicitly contacting users in addition to regular release notes in our [changelog](https://www.datum.net/resources/changelog/) and GitHub commit history. For example, you may read about minor vulnerability patches in release notes, but we may not notify users via a dedicated security bulletin.
+By “notify” here we mean explicitly contacting users in addition to regular release notes in our [changelog](/resources/changelog/) and GitHub commit history. For example, you may read about minor vulnerability patches in release notes, but we may not notify users via a dedicated security bulletin.
 
 ## When We Notify Users
 Generally, we aim to reduce noise and only notify users for actionable incidents. Datum does not notify users for routine security patching of dependencies. We also don't notify users for vulnerabilities in our software, if we confirm the vulnerability was not exploited and no users were affected.
@@ -31,7 +31,7 @@ We will notify users directly about a security vulnerability when we can confirm
 * We can confirm that Organization metadata or data was visible to an unauthorized party.
 
 ## How We Notify Users
-To disclose security vulnerabilities (broad audience), Datum publishes security bulletins publicly at https://www.datum.net/blog/. These can be consumed directly, via RSS readers or via social media bot accounts.
+To disclose security vulnerabilities (broad audience), Datum publishes security bulletins publicly at [blog](/blog/). These can be consumed directly, via RSS readers or via social media bot accounts.
 
 To notify users about security vulnerabilities (specific to the Organization), Datum will email affected Organization administrators, with information specific to the Organization, including specific users or nodes which are affected. These emails will be sent to the default owner of the Organization.
 

--- a/src/content/handbook/policy/incident-response.md
+++ b/src/content/handbook/policy/incident-response.md
@@ -10,7 +10,7 @@ meta:
   description: "Read Datum's Incident Response Policy. Our framework for detecting, containing, and recovering from security incidents to maintain platform resilience."
 ---
 
-Datum’s customers are dependent on our services operating as expected. Proper detection and response to incidents that may impact the integrity, confidentiality or availability of services and data is [critical to Datum’s business in many ways](../../technical/incidents/).
+Datum’s customers are dependent on our services operating as expected. Proper detection and response to incidents that may impact the integrity, confidentiality or availability of services and data is [critical to Datum’s business in many ways](/handbook/technical/incidents/).
 
 The following minimum standards apply to Datum’s assets as managed by employees, contractors and vendors. These recommendations represent the recommended minimum efforts necessary for incident detection and response.
 
@@ -41,4 +41,4 @@ Datum regularly reviews logs to detect and track attempted intrusions and other 
 ## Incident Response
 Datum’s Security Team reviews and responds to potential third-party reports of security issues sent to security@datum.net promptly. If a suspected incident is detected, it should be reported immediately. We respond to reported incidents, and resolve and determine impact as soon as possible. We aim to remediate incidents as soon as possible.
 
-Confirmed incidents may be disclosed publicly per our [disclosure policy](../incident-disclosure/).
+Confirmed incidents may be disclosed publicly per our [disclosure policy](/handbook/policy/incident-disclosure/).

--- a/src/content/handbook/policy/information-classification.md
+++ b/src/content/handbook/policy/information-classification.md
@@ -21,7 +21,7 @@ Datum catalogues assets with several pieces of information, to help identify the
 * **Location**, i.e. where is it stored, used, and backed up?
 * **Sharing**, i.e. is it shared with any third parties, such as vendors? Which specific third parties?
 
-If new data is catalogued, or data use changes, it should be specifically reviewed to verify that its collection and use is in line with [Datum's Privacy Policy](https://www.datum.net/legal/privacy/).
+If new data is catalogued, or data use changes, it should be specifically reviewed to verify that its collection and use is in line with [Datum's Privacy Policy](/legal/privacy/).
 
 ## Asset risk classification
 Datum classifies assets into three risk categories: Low Risk, Medium Risk, and High Risk. The definitions are as follows:

--- a/src/content/handbook/policy/testing.md
+++ b/src/content/handbook/policy/testing.md
@@ -18,7 +18,7 @@ This policy applies to code developed by Datum for its clients or run on its pro
 ## Code Changes
 Changes to production code which alter Datum’s product functionality should be tested by Datum’s continuous integration (CI) system prior to being merged. Testing should not be conducted locally in a development environment or in production.
 
-Exceptionally, changes to production code may be merged without first testing them, such as to resolve an incident. See the [Change management policy](../change-management/).
+Exceptionally, changes to production code may be merged without first testing them, such as to resolve an incident. See the [Change management policy](/handbook/policy/change-management/).
 
 Changes to production code which do not alter product functionality, e.g., changes to documentation, may be but do not need to be tested.
 

--- a/src/content/handbook/product/pricing.md
+++ b/src/content/handbook/product/pricing.md
@@ -10,7 +10,7 @@ meta:
   description: "Understanding our billing model. A guide to Datum's pricing tiers, from the free Builder plan to Enterprise interconnection, and the logic behind our rate limits."
 ---
 
-We currently have outlined three tiers of service. Only time in the market will tell us if we’re correct, and where we need to evolve. Since this entry is likely to get out of date from time to time, please check our [pricing page](https://www.datum.net/pricing/) for the latest official details. 
+We currently have outlined three tiers of service. Only time in the market will tell us if we’re correct, and where we need to evolve. Since this entry is likely to get out of date from time to time, please check our [pricing page](/pricing/) for the latest official details. 
 
 ## Datum for Builders (Forever free)
 Our initial focus is to help a new class of builders get access to the core ‘internet superpowers’ for learning, integration, testing, and exploring new use cases. We also want to make their lives easier when it comes to troublesome bits like domains, certificates, and DNS. 

--- a/src/content/handbook/product/roadmap.md
+++ b/src/content/handbook/product/roadmap.md
@@ -18,4 +18,4 @@ While it’s somewhat of a new practice, we try to ideate around potential featu
 
 Once ideas are formalized we create [detailed enhancements](https://github.com/orgs/datum-cloud/projects/22) that prepare the work. Since this is where all active work on our various open source projects are tracked and progressed, this is how we generate our public roadmap for [datum.net](http://datum.net) and milo-os.com. 
 
-As the work on enhancements are completed, we publish notices to [GitHub Discussions](http://datum.net) and include a summary in our monthly newsletter.
+As the work on enhancements are completed, we publish notices to [GitHub Discussions](https://github.com/orgs/datum-cloud/discussions) and include a summary in our monthly newsletter.


### PR DESCRIPTION
- Added a new travel policy page under culture.
- Replaced external URLs with relative links throughout handbook markdown files for consistency and maintainability.
- Minor content edits for clarity and accuracy in purchasing and roadmap documents.
#856