### PR TITLE
Add Office MIME types and force downloads

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -36,6 +36,12 @@ const CONTENT_TYPES = {
   '.otf': 'font/otf',
   '.pdf': 'application/pdf',
   '.zip': 'application/zip',
+  '.doc': 'application/msword',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.ppt': 'application/vnd.ms-powerpoint',
+  '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
   '.webmanifest': 'application/manifest+json',
   '.map': 'application/json',
   '.pf_fragment': 'application/octet-stream',
@@ -115,6 +121,9 @@ const PREFIX_REDIRECTS = [
   { from: '/handbook/culture/', to: '/handbook/operate/', status: 302 },
 ];
 
+// File extensions that should trigger download instead of display
+const DOWNLOAD_EXTENSIONS = /\.(docx?|xlsx?|pptx?|zip)$/i;
+
 // Static file server for pre-rendered pages and assets
 const staticServer = sirv(CLIENT_DIR, {
   maxAge: 31536000,
@@ -130,6 +139,11 @@ const staticServer = sirv(CLIENT_DIR, {
       res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
     } else if (pathname.match(/\.(html)$/)) {
       res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate');
+    }
+    // Force download for Office documents and archives
+    if (DOWNLOAD_EXTENSIONS.test(pathname)) {
+      const filename = pathname.split('/').pop();
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
     }
   },
 });


### PR DESCRIPTION
Register MIME types for Microsoft Office formats (.doc, .docx, .xls, .xlsx, .ppt, .pptx) and add a DOWNLOAD_EXTENSIONS regex to trigger Content-Disposition: attachment for Office documents and archives (including .zip). This ensures these files are served with correct MIME types and prompt the browser to download them instead of attempting inline display.