### PR TITLE
Chore: Fix ci workflows to support external contributors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,8 @@ name: Publish Website
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - "README.md"
       - "env.example"

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -69,7 +69,6 @@ jobs:
     needs: quality
     name: Build
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
- Remove fork restriction on build job in quality-checks.yml so external contributors can verify their changes build correctly
- Restrict publish.yml to only run on main branch pushes, preventing failed Docker registry pushes on fork PRs

Ref: #895