### PR TITLE
fix(blog): restore homepage Latest section layout and increase image …

### DIFF
--- a/src/components/blog/Latest.astro
+++ b/src/components/blog/Latest.astro
@@ -16,36 +16,85 @@ const sortedArticles = allArticles.sort((a, b) => {
 const latestPosts = sortedArticles.slice(0, POSTS_TO_SHOW).map(normalizeArticle);
 ---
 
-<div class="latest-blog">
-  <div class="latest-blog--header">
-    <h2 class="datum-text-8xl mb-6">Latest from the blog</h2>
-    <a href="/blog/" class="latest-blog--link">
-      View all posts <span aria-hidden="true">&rarr;</span>
-    </a>
-  </div>
+<h2
+  class="datum-text-xl border-midnight-fjord m-0 mb-8 w-full border-b pb-6 md:mb-12 md:pb-8 lg:mb-16"
+>
+  Latest thoughts from the team
+</h2>
 
-  <div class="latest-blog--grid">
-    {
-      latestPosts.map((post) => (
-        <a href={`/blog/${post.id}/`} class="latest-blog--item">
-          {post.data.thumbnail && (
-            <div class="latest-blog--thumbnail">
+{
+  latestPosts.length > 0 ? (
+    <div class="grid grid-cols-4 gap-8 md:grid-cols-11 lg:gap-11">
+      {latestPosts[0] && (
+        <div class="col-span-4 flex flex-1 flex-col md:col-span-5 lg:col-span-6">
+          {latestPosts[0].data.thumbnail && (
+            <a
+              href={`/blog/${latestPosts[0].id}/`}
+              title={latestPosts[0].data.title}
+              class="mb-6 w-full"
+            >
               <img
-                src={post.data.thumbnail}
-                alt={post.data.title}
-                class="latest-blog--image"
-                width={400}
-                height={225}
+                src={latestPosts[0].data.thumbnail}
+                alt={latestPosts[0].data.title}
+                class="block h-auto w-full rounded-[4px] object-cover transition-opacity duration-200 hover:opacity-90"
+                width={1440}
+                height={810}
                 loading="lazy"
               />
-            </div>
+            </a>
           )}
-          <div class="latest-blog--content">
-            <h3 class="latest-blog--title">{post.data.title}</h3>
-            {post.data.description && (
-              <p class="latest-blog--description">{post.data.description}</p>
+          <h3 class="datum-text-2xl mb-3 font-medium">
+            <a
+              href={`/blog/${latestPosts[0].id}/`}
+              title={latestPosts[0].data.title}
+              class="transition-opacity duration-200 hover:opacity-70"
+            >
+              {latestPosts[0].data.title}
+            </a>
+          </h3>
+          {latestPosts[0].data.description && (
+            <p class="datum-text-base mb-3 text-pretty opacity-80">
+              {latestPosts[0].data.description}
+            </p>
+          )}
+          <time datetime={latestPosts[0].data.date.toISOString()} class="datum-text-sm opacity-40">
+            {latestPosts[0].data.date.toLocaleDateString('en-US', {
+              day: 'numeric',
+              month: 'short',
+              year: 'numeric',
+            })}
+          </time>
+        </div>
+      )}
+
+      <div class="col-span-4 flex gap-6 md:col-span-6 md:gap-8 lg:col-span-5 lg:gap-11">
+        {latestPosts.slice(1).map((post) => (
+          <div class="flex flex-1 flex-col">
+            {post.data.thumbnail && (
+              <a href={`/blog/${post.id}/`} title={post.data.title} class="mb-6 w-full">
+                <img
+                  src={post.data.thumbnail}
+                  alt={post.data.title}
+                  class="block h-auto w-full rounded-[4px] object-cover transition-opacity duration-200 hover:opacity-90"
+                  width={800}
+                  height={450}
+                  loading="lazy"
+                />
+              </a>
             )}
-            <time class="latest-blog--date" datetime={post.data.date.toISOString()}>
+            <h4 class="datum-text-xl mb-3 font-medium">
+              <a
+                href={`/blog/${post.id}/`}
+                title={post.data.title}
+                class="transition-opacity duration-200 hover:opacity-70"
+              >
+                {post.data.title}
+              </a>
+            </h4>
+            {post.data.description && (
+              <p class="datum-text-sm mb-3 text-pretty opacity-80">{post.data.description}</p>
+            )}
+            <time datetime={post.data.date.toISOString()} class="datum-text-sm opacity-40">
               {post.data.date.toLocaleDateString('en-US', {
                 day: 'numeric',
                 month: 'short',
@@ -53,8 +102,8 @@ const latestPosts = sortedArticles.slice(0, POSTS_TO_SHOW).map(normalizeArticle)
               })}
             </time>
           </div>
-        </a>
-      ))
-    }
-  </div>
-</div>
+        ))}
+      </div>
+    </div>
+  ) : null
+}

--- a/src/types/strapi.ts
+++ b/src/types/strapi.ts
@@ -185,6 +185,9 @@ export function normalizeArticle(article: StrapiArticle): NormalizedStrapiArticl
       description: article.description,
       date: new Date(publishedDate),
       thumbnail:
+        getStrapiMediaUrl(article.cover?.formats?.large?.url) ||
+        getStrapiMediaUrl(article.cover?.formats?.medium?.url) ||
+        getStrapiMediaUrl(article.cover?.formats?.small?.url) ||
         getStrapiMediaUrl(article.cover?.formats?.thumbnail?.url) ||
         getStrapiMediaUrl(article.cover?.url),
       author: article.author?.name,


### PR DESCRIPTION
…resolution

- Replace undefined BEM CSS classes (latest-blog--*) with inline Tailwind utilities matching the established pre-Strapi design pattern
- Restore featured + two secondary post layout (grid-cols-4 md:grid-cols-11)
- Update title to "Latest thoughts from the team", remove "View all posts" link
- Fix cover image resolution: normalizeArticle now prefers large > medium >
  small > thumbnail > original instead of always picking the thumbnail format