### PR TITLE
fix: datumctl docs bc

### DIFF
--- a/.frontmatter/starlight/pagefolders.json
+++ b/.frontmatter/starlight/pagefolders.json
@@ -13,12 +13,6 @@
       "previewPath": "about"
     },
     {
-      "title": "Blog",
-      "path": "[[workspace]]/src/content/blog",
-      "previewPath": "blog",
-      "contentTypes": ["blogPost"]
-    },
-    {
       "title": "Changelog",
       "path": "[[workspace]]/src/content/changelog",
       "previewPath": "changelog",

--- a/src/components/starlight/TwoColumnContent.astro
+++ b/src/components/starlight/TwoColumnContent.astro
@@ -93,6 +93,8 @@ if (pathSegments.length > 0) {
     }
 
     let segmentTitle;
+    let breadcrumbHref;
+
     if (docEntry && docEntry.data.title) {
       segmentTitle =
         docEntry.data.title === 'Overview'
@@ -102,9 +104,17 @@ if (pathSegments.length > 0) {
       segmentTitle = segment.replace(/-/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase());
     }
 
+    breadcrumbHref = lastSegment != segment ? '/docs' + currentPath + '/' : null;
+
+    // Override segment title with "Overview" if it matches the last path segment
+    if (segmentTitle == 'Command' && currentPath.endsWith('/datumctl/command')) {
+      segmentTitle = 'CLI command reference';
+      breadcrumbHref = '/docs' + '/datumctl/cli-reference/';
+    }
+
     breadcrumbData.push({
       text: segmentTitle,
-      href: lastSegment != segment ? '/docs' + currentPath + '/' : null,
+      href: breadcrumbHref,
     });
   }
 

--- a/src/libs/auth.ts
+++ b/src/libs/auth.ts
@@ -21,7 +21,8 @@ const cookieOptions = {
   sameSite: 'lax' as const,
   secure: process.env.MODE === 'production',
   httpOnly: true,
-  maxAge: 60 * 60 * 24 * 7, // 7 days
+  maxAge: 60 * 60 * 24 * 7, // 7 days,
+  domain: '.datum.net',
 };
 
 /**


### PR DESCRIPTION
- Add custom breadcrumb title and link for CLI command reference section
- Set cookie domain to .datum.net for proper cross-subdomain auth
- Remove blog from Front Matter CMS configuration