### PR TITLE
Responsive blog detail fix

### DIFF
--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -365,7 +365,7 @@ const blogListingMeta = {
                   </Breadcrumbs>
                 </div>
                 <h1 class="blog-article-title">{fm?.title}</h1>
-                <div class="datum-text-sm mt-4 flex gap-1 opacity-60 md:hidden">
+                <div class="datum-text-sm mt-4 flex flex-wrap gap-1 opacity-60 md:hidden">
                   <a href={authorHref ?? '#'} class="blog-article-author-name">
                     {authorName},
                   </a>

--- a/src/v1/styles/components-blog.css
+++ b/src/v1/styles/components-blog.css
@@ -179,7 +179,7 @@
   }
 
   .blog-article {
-    @apply max-w-179 flex-grow;
+    @apply max-w-179 min-w-0 flex-grow;
   }
 
   .blog-article-container {


### PR DESCRIPTION
1. components-blog.css — Added min-w-0 to .blog-article. This is the root cause: flex children without min-w-0 won't shrink below their minimum content width, so wide elements (images, code blocks, tables) inside the article can push the layout wider than the viewport, breaking responsiveness.
  2. [slug].astro — Added flex-wrap to the mobile meta row (author / reading time / date / copy URL). Without it, long content on narrow screens (e.g. 320px phones) overflows in a single unwrapped line.

#965