### PR TITLE
feat(strapi): add persistent fallback cache and request timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,6 @@ STRAPI_CACHE_TTL=3000
 # Webhook: shared secret for cache invalidation from Strapi
 # Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 STRAPI_WEBHOOK_SECRET=your-shared-secret
+
+# Request timeout in seconds before falling back to the persistent stale cache (default: 10)
+STRAPI_TIMEOUT=10


### PR DESCRIPTION
When Strapi is unreachable the blog now serves stale content from a persistent fallback cache (.cache/strapi-fallback/) instead of showing an upstream timeout error.

- Add AbortController timeout to graphqlQuery (default 10s, configurable via STRAPI_TIMEOUT env var) so slow Strapi responses fail fast
- Write a fallback snapshot to disk on every successful fetch with no TTL, so it survives across Strapi outages of any duration
- Fall back to the stale snapshot for both article listings and individual article detail pages when the live fetch fails


#974