### PR TITLE
Job detail form not showing

### DIFF
--- a/src/pages/careers.astro
+++ b/src/pages/careers.astro
@@ -65,8 +65,7 @@ const description = fm.description || '';
       </div>
     </section>
 
-    <script>
-      // @ts-expect-error - Ashby is a global variable
+    <script is:inline>
       window.__Ashby = {
         settings: {
           ashbyBaseJobBoardUrl: 'https://jobs.ashbyhq.com/datum',


### PR DESCRIPTION
Root cause: Astro processes `<script>` tags without `is:inline` as ES modules (`type="module"`), which are always deferred.
The Ashby embed is a classic deferred script, which runs before ES modules in browser execution order. So Ashby initialized before `window.__Ashby` was defined.                                                                       
                                                                                                                       
Adding `is:inline` makes it a synchronous inline script that executes during HTML parsing — guaranteed to run before either Ashby or Alpine.   