### PR TITLE
Feat(strapi): Add Strapi cache regeneration and related updates

### DIFF
--- a/src/libs/strapi/authors.ts
+++ b/src/libs/strapi/authors.ts
@@ -77,7 +77,6 @@ async function graphqlQuery<T>(
 const cache = new Cache('.cache');
 const CACHE_KEY = 'strapi-authors';
 const TEAM_MEMBERS_CACHE_KEY = 'strapi-team-members';
-const AUTHOR_CACHE_PREFIX = 'strapi-author-';
 const AUTHOR_SLUG_CACHE_PREFIX = 'strapi-author-slug-';
 
 /**
@@ -91,35 +90,6 @@ const TEAM_BG_COLORS = ['#5F735E', '#BF9595', '#D1CDC0'] as const;
 export const AUTHORS_QUERY = `
   query GetAuthors {
     authors(pagination: { limit: 100 }) {
-      documentId
-      slug
-      name
-      title
-      bio
-      isTeam
-      team
-      tick
-      surprising
-      weekends
-      avatar {
-        url
-        alternativeText
-      }
-      social {
-        twitter
-        linkedin
-        github
-      }
-    }
-  }
-`;
-
-/**
- * GraphQL query to fetch a single author by documentId
- */
-export const AUTHOR_BY_DOCUMENT_ID_QUERY = `
-  query GetAuthorByDocumentId($documentId: String!) {
-    authors(filters: { documentId: { eq: $documentId } }) {
       documentId
       slug
       name
@@ -306,42 +276,15 @@ export async function fetchStrapiAuthors(): Promise<StrapiAuthorFull[]> {
 
 /**
  * Fetch single author by documentId.
- * Caches each author separately (per-author cache).
- * @param documentId - Author documentId (used as slug in URL)
+ * Uses strapi-authors list (already includes documentId); no separate cache needed.
+ * @param documentId - Author documentId (used as slug in URL for backwards compat)
  * @returns The author or null if not found
  */
 export async function fetchStrapiAuthorByDocumentId(
   documentId: string
 ): Promise<StrapiAuthorFull | null> {
-  const cacheKey = `${AUTHOR_CACHE_PREFIX}${documentId}`;
-
-  if (CACHE_ENABLED && cache.has(cacheKey)) {
-    const cached = cache.get<StrapiAuthorFull>(cacheKey);
-    if (cached && isValidStrapiAuthor(cached)) {
-      return cached;
-    }
-    if (cached) {
-      console.warn(
-        `Invalid cached Strapi author data detected for documentId "${documentId}", fetching fresh data from API`
-      );
-    }
-  }
-
-  const response = await graphqlQuery<StrapiAuthorsResponse>(AUTHOR_BY_DOCUMENT_ID_QUERY, {
-    documentId,
-  });
-
-  if (!response?.authors || response.authors.length === 0) {
-    return null;
-  }
-
-  const author = response.authors[0];
-
-  if (CACHE_ENABLED) {
-    cache.set(cacheKey, author, CACHE_TTL);
-  }
-
-  return author;
+  const authors = await fetchStrapiAuthors();
+  return authors.find((a) => a.documentId === documentId) ?? null;
 }
 
 /**

--- a/src/libs/strapi/index.ts
+++ b/src/libs/strapi/index.ts
@@ -85,7 +85,6 @@ export { getStrapiMediaUrl, normalizeArticle, resolveMarkdownStrapiUrls } from '
 // Re-export authors module
 export {
   AUTHORS_QUERY,
-  AUTHOR_BY_DOCUMENT_ID_QUERY,
   AUTHOR_BY_SLUG_QUERY,
   fetchStrapiAuthors,
   fetchStrapiAuthorByDocumentId,

--- a/src/libs/strapi/regenerateCache.ts
+++ b/src/libs/strapi/regenerateCache.ts
@@ -1,0 +1,130 @@
+// src/libs/strapi/regenerateCache.ts
+/**
+ * Regenerate Strapi cache entries only when the cache file does not exist.
+ * Uses the same cache keys and fetch methods as articles, authors, and roadmaps.
+ */
+
+import path from 'node:path';
+import { Cache } from '@libs/cache';
+import { fetchStrapiArticles, fetchStrapiArticleBySlug } from './articles';
+import { fetchStrapiAuthors, fetchStrapiAuthorBySlug, getStrapiTeamMembers } from './authors';
+import { fetchStrapiRoadmaps } from './roadmaps';
+import type { StrapiArticle } from '../../types/strapi';
+
+const CACHE_DIR = path.resolve(process.cwd(), '.cache');
+const cache = new Cache(CACHE_DIR);
+
+const ARTICLES_CACHE_KEY = 'strapi-articles';
+const ARTICLE_CACHE_PREFIX = 'strapi-article-';
+const AUTHORS_CACHE_KEY = 'strapi-authors';
+const AUTHOR_SLUG_CACHE_PREFIX = 'strapi-author-slug-';
+const TEAM_MEMBERS_CACHE_KEY = 'strapi-team-members';
+const ROADMAPS_CACHE_KEY = 'strapi-roadmaps';
+
+export interface RegenerateResult {
+  regenerated: string[];
+  skipped: string[];
+  errors: string[];
+}
+
+/**
+ * Regenerate all strapi-* cache entries that do not yet exist.
+ * Only populates cache when the JSON file is missing.
+ * @returns Summary of regenerated keys, skipped keys, and any errors
+ */
+export async function regenerateStrapiCacheIfMissing(): Promise<RegenerateResult> {
+  const regenerated: string[] = [];
+  const skipped: string[] = [];
+  const errors: string[] = [];
+
+  // 1. strapi-articles
+  if (!cache.has(ARTICLES_CACHE_KEY)) {
+    try {
+      await fetchStrapiArticles();
+      regenerated.push(ARTICLES_CACHE_KEY);
+    } catch (err) {
+      errors.push(`${ARTICLES_CACHE_KEY}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  } else {
+    skipped.push(ARTICLES_CACHE_KEY);
+  }
+
+  // 2. strapi-authors
+  if (!cache.has(AUTHORS_CACHE_KEY)) {
+    try {
+      await fetchStrapiAuthors();
+      regenerated.push(AUTHORS_CACHE_KEY);
+    } catch (err) {
+      errors.push(`${AUTHORS_CACHE_KEY}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  } else {
+    skipped.push(AUTHORS_CACHE_KEY);
+  }
+
+  // 3. strapi-roadmaps
+  if (!cache.has(ROADMAPS_CACHE_KEY)) {
+    try {
+      await fetchStrapiRoadmaps();
+      regenerated.push(ROADMAPS_CACHE_KEY);
+    } catch (err) {
+      errors.push(`${ROADMAPS_CACHE_KEY}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  } else {
+    skipped.push(ROADMAPS_CACHE_KEY);
+  }
+
+  // 4. strapi-team-members (depends on authors)
+  if (!cache.has(TEAM_MEMBERS_CACHE_KEY)) {
+    try {
+      await getStrapiTeamMembers();
+      regenerated.push(TEAM_MEMBERS_CACHE_KEY);
+    } catch (err) {
+      errors.push(`${TEAM_MEMBERS_CACHE_KEY}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  } else {
+    skipped.push(TEAM_MEMBERS_CACHE_KEY);
+  }
+
+  // 5. Per-article cache (strapi-article-{slug})
+  const articles: StrapiArticle[] = await fetchStrapiArticles();
+  const authorIdsWithArticles = new Set(
+    articles.map((a) => a.author?.documentId).filter((id): id is string => Boolean(id))
+  );
+
+  for (const article of articles) {
+    const key = `${ARTICLE_CACHE_PREFIX}${article.slug}`;
+    if (!cache.has(key)) {
+      try {
+        await fetchStrapiArticleBySlug(article.slug);
+        regenerated.push(key);
+      } catch (err) {
+        errors.push(`${key}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    } else {
+      skipped.push(key);
+    }
+  }
+
+  // 6. Per-author cache (strapi-author-slug-{slug}) — documentId lookup uses strapi-authors list
+  // Only for authors that have at least one article
+  const authors = await fetchStrapiAuthors();
+  for (const author of authors) {
+    if (!authorIdsWithArticles.has(author.documentId) || !author.slug) {
+      continue;
+    }
+
+    const slugKey = `${AUTHOR_SLUG_CACHE_PREFIX}${author.slug}`;
+    if (!cache.has(slugKey)) {
+      try {
+        await fetchStrapiAuthorBySlug(author.slug);
+        regenerated.push(slugKey);
+      } catch (err) {
+        errors.push(`${slugKey}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    } else {
+      skipped.push(slugKey);
+    }
+  }
+
+  return { regenerated, skipped, errors };
+}

--- a/src/pages/api/cache/strapi.ts
+++ b/src/pages/api/cache/strapi.ts
@@ -1,0 +1,67 @@
+// src/pages/api/cache/strapi-regenerate.ts
+
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { regenerateStrapiCacheIfMissing } from '@libs/strapi/regenerateCache';
+
+function verifyWebhookSecret(request: Request): boolean {
+  const webhookSecret = import.meta.env.STRAPI_WEBHOOK_SECRET || process.env.STRAPI_WEBHOOK_SECRET;
+
+  if (!webhookSecret) {
+    return false;
+  }
+
+  const receivedSecret = request.headers.get('X-Webhook-Secret');
+  return receivedSecret === webhookSecret;
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  if (request.method !== 'POST') {
+    return new Response(JSON.stringify({ success: false, error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!verifyWebhookSecret(request)) {
+    return new Response(JSON.stringify({ success: false, error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const result = await regenerateStrapiCacheIfMissing();
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        message: 'Strapi cache regeneration completed',
+        details: {
+          regenerated: result.regenerated,
+          skipped: result.skipped,
+          errors: result.errors,
+          regeneratedCount: result.regenerated.length,
+          skippedCount: result.skipped.length,
+        },
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  } catch (err) {
+    console.error('[strapi-regenerate] Error:', err);
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: err instanceof Error ? err.message : 'Internal server error',
+      }),
+      {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  }
+};

--- a/src/pages/api/webhooks/strapi-content.ts
+++ b/src/pages/api/webhooks/strapi-content.ts
@@ -108,6 +108,9 @@ function invalidateAuthorCache(): string[] {
   // Invalidate team members cache (same underlying authors database)
   deletedFiles.push(...invalidateCache('strapi-team-members'));
 
+  // Invalidate per-author slug cache (strapi-author-slug-*)
+  deletedFiles.push(...invalidateCache('strapi-author-slug-'));
+
   return deletedFiles;
 }
 

--- a/src/pages/dev/cache.astro
+++ b/src/pages/dev/cache.astro
@@ -5,9 +5,20 @@ export const prerender = false;
 import fs from 'node:fs';
 import path from 'node:path';
 
-const mode = process.env.MODE || import.meta.env.MODE;
-if (mode === 'production') {
-  return Astro.redirect('/');
+Astro.response.headers.set('Cache-Control', 'no-store');
+Astro.response.headers.set('Vary', 'User-Agent');
+
+const webhookSecret = import.meta.env.STRAPI_WEBHOOK_SECRET || process.env.STRAPI_WEBHOOK_SECRET;
+const receivedSecret = Astro.request.headers.get('X-Webhook-Secret');
+
+if (!webhookSecret || receivedSecret !== webhookSecret) {
+  return new Response('Unauthorized', {
+    status: 401,
+    headers: {
+      'Content-Type': 'text/plain',
+      'WWW-Authenticate': 'Secret',
+    },
+  });
 }
 
 const CACHE_BASE = path.resolve(process.cwd(), '.cache');


### PR DESCRIPTION
- Add regeneration utility and endpoint to populate missing Strapi cache entries.
- Simplifies author lookup by documentId to use the authors list
- Make dev/cache url accessible from production with correct X-Webhook-Secret header