### PR TITLE
fix(nav): mark parent nav item active when child page is active

### DIFF
--- a/src/components/NavMenu.astro
+++ b/src/components/NavMenu.astro
@@ -60,7 +60,7 @@ function hasActiveChild(sections: NavData['main'][0]['children'], currentPath: s
           >
             <a
               href={item.href}
-              class={`nav-menu-link ${isActive ? 'link--active' : ''}`}
+              class={`nav-menu-link ${isParentActive ? 'link--active' : ''}`}
               target={item.isExternal ? '_blank' : undefined}
               rel={item.isExternal ? 'noopener noreferrer' : undefined}
               data-astro-prefetch={item.isExternal ? undefined : 'hover'}


### PR DESCRIPTION
Use isParentActive instead of isActive for the parent link's link--active class so parent menu items (e.g. Resources) show active when a child page (e.g. /blog/, /events/) is active. #1065