### PR TITLE
fix: Disable prefers-color-scheme for code block

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -22,6 +22,7 @@ const lucideCopyIconSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" he
 
 const expressiveCodeConfig = {
   themes: ['github-light', 'github-dark'],
+  useDarkModeMediaQuery: false,
   styleOverrides: {
     borderRadius: '0.5rem',
     frames: {


### PR DESCRIPTION
On Firefox/Linux with a dark system theme, Expressive Code's generated media query overrides Starlight's theme toggle. This causes the code block background to follow the OS dark preference while the text color follows the page's data-theme selector, resulting in dark text on a dark background.

Setting useDarkModeMediaQuery: false removes the media query entirely, so both background and text color are controlled exclusively by Starlight's data-theme attribute.

Co-Authored-By: richardhenwood <1310402+richardhenwood@users.noreply.github.com>

Issue: https://github.com/datum-cloud/datum.net/issues/1082