### PR TITLE
Features map tweak, Fathom events, Top bar typo fix

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -43,7 +43,7 @@ export default defineConfig({
     announcement({
       show: true,
       label: 'Free download',
-      text: 'Take your local.host global with our Alpha http desktop app',
+      text: 'Take your localhost global with our Alpha http desktop app',
       href: '/download/',
       icon: {
         name: 'arrow-right',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15213,7 +15213,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/components/Announcement.astro
+++ b/src/components/Announcement.astro
@@ -49,7 +49,7 @@ if (!show) {
 >
   <label>{label}</label>
   <p class="pr-3 md:pr-0">
-    <a href={href}
+    <a href={href} data-fathom-event="Top banner click"
       >{text}
       {icon && <Icon name={icon.name} size={icon.size || 'sm'} class="hidden md:inline-flex" />}</a
     >

--- a/src/content/download/linux.mdx
+++ b/src/content/download/linux.mdx
@@ -28,4 +28,5 @@ import Button from '@components/Button.astro';
     target="_blank"
     iconPosition="right"
     icon={{ name: 'download', size: 'md' }}
+    data-fathom-event="Download page: Linux"
   />

--- a/src/content/download/mac-os.mdx
+++ b/src/content/download/mac-os.mdx
@@ -38,6 +38,7 @@ import Button from '@components/Button.astro';
     target="_blank"
     iconPosition="right"
     icon={{ name: 'download', size: 'md' }}
+    data-fathom-event="Download page: Mac"
   />
   </TabItem>
 </Tabs>

--- a/src/content/download/windows.mdx
+++ b/src/content/download/windows.mdx
@@ -28,4 +28,5 @@ import Button from '@components/Button.astro';
     target="_blank"
     iconPosition="right"
     icon={{ name: 'download', size: 'md' }}
+    data-fathom-event="Download page: Windows"
   />

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -271,17 +271,26 @@ const jsonLd = {
                 <div class="features-cta-links">
                   <div class="features-cta-link">
                     <Icon name="apple" size="md" />
-                    <a href="https://www.datum.net/download/mac-os/">mac</a>
+                    <a
+                      href="https://www.datum.net/download/mac-os/"
+                      data-fathom-event="Features page: Download Mac">mac</a
+                    >
                   </div>
 
                   <div class="features-cta-link">
                     <Icon name="windows" size="md" />
-                    <a href="https://www.datum.net/download/windows/">Windows</a>
+                    <a
+                      href="https://www.datum.net/download/windows/"
+                      data-fathom-event="Features page: Download Windows">Windows</a
+                    >
                   </div>
 
                   <div class="features-cta-link">
                     <Icon name="linux" size="md" />
-                    <a href="https://www.datum.net/download/linux/">Linux</a>
+                    <a
+                      href="https://www.datum.net/download/linux/"
+                      data-fathom-event="Features page: Download Linux">Linux</a
+                    >
                   </div>
                 </div>
               </div>
@@ -471,189 +480,91 @@ const jsonLd = {
     //   ym(d) = ln(tan(π/4 + d·π/360));  top=ym(65), bot=ym(-65)
     //   y = (top - ym(lat)) / (top - bot)
     const NODES = [
-      // North America
-      { id: 'vancouver', x: 0.158, y: 0.173, primary: false }, // -123.1, 49.3
-      { id: 'seattle', x: 0.16, y: 0.194, primary: false }, // -122.3, 47.6
-      { id: 'la', x: 0.172, y: 0.287, primary: false }, // -118.2, 34.0
-      { id: 'phoenix', x: 0.189, y: 0.292, primary: false }, // -112.1, 33.4
-      { id: 'denver', x: 0.209, y: 0.251, primary: false }, // -104.9, 39.7
-      { id: 'dallas', x: 0.231, y: 0.299, primary: false }, // -96.8,  32.8
-      { id: 'chicago', x: 0.257, y: 0.231, primary: false }, // -87.6,  41.9
-      { id: 'toronto', x: 0.279, y: 0.215, primary: false }, // -79.4,  43.7
-      { id: 'ashburn', x: 0.286, y: 0.257, primary: true }, // -77.0,  39.0
-      { id: 'nyc', x: 0.294, y: 0.242, primary: false }, // -74.0,  40.7
-      { id: 'atlanta', x: 0.266, y: 0.289, primary: false }, // -84.4,  33.7
-      { id: 'miami', x: 0.277, y: 0.343, primary: false }, // -80.2,  25.8
-      // Latin America
-      { id: 'mexico', x: 0.225, y: 0.385, primary: false }, // -99.1,  19.4
-      { id: 'bogota', x: 0.294, y: 0.471, primary: false }, // -74.1,   4.7
-      { id: 'saopaulo', x: 0.371, y: 0.639, primary: false }, // -46.6, -23.5
-      { id: 'santiago', x: 0.304, y: 0.705, primary: false }, // -70.7, -33.5
-      { id: 'buenosaires', x: 0.338, y: 0.713, primary: false }, // -58.4, -34.6
-      // Europe
-      { id: 'lisbon', x: 0.475, y: 0.26, primary: false }, // -9.1,  38.7
-      { id: 'madrid', x: 0.49, y: 0.245, primary: false }, // -3.7,  40.4
-      { id: 'london', x: 0.5, y: 0.15, primary: true }, // -0.1,  51.5
-      { id: 'paris', x: 0.506, y: 0.179, primary: false }, //  2.3,  48.9
-      { id: 'amsterdam', x: 0.514, y: 0.137, primary: true }, //  4.9,  52.4
-      { id: 'frankfurt', x: 0.524, y: 0.164, primary: false }, //  8.7,  50.0
-      { id: 'zurich', x: 0.524, y: 0.197, primary: false }, //  8.5,  47.4
-      { id: 'milan', x: 0.526, y: 0.225, primary: false }, //  9.2,  45.5
-      { id: 'vienna', x: 0.546, y: 0.187, primary: false }, // 16.4,  48.2
-      { id: 'warsaw', x: 0.558, y: 0.139, primary: false }, // 21.0,  52.2
-      { id: 'stockholm', x: 0.55, y: 0.073, primary: false }, // 18.1,  59.3
-      // Middle East & Africa
-      { id: 'istanbul', x: 0.581, y: 0.239, primary: false }, // 29.0,  41.0
-      { id: 'dubai', x: 0.654, y: 0.347, primary: false }, // 55.3,  25.2
-      { id: 'lagos', x: 0.51, y: 0.461, primary: false }, //  3.4,   6.5
-      { id: 'nairobi', x: 0.602, y: 0.507, primary: false }, // 36.8,  -1.3
-      { id: 'johannesburg', x: 0.578, y: 0.657, primary: false }, // 28.2, -26.2
-      // South & Central Asia
-      { id: 'karachi', x: 0.686, y: 0.348, primary: false }, // 67.1,  24.9
-      { id: 'delhi', x: 0.714, y: 0.327, primary: false }, // 77.2,  28.6
-      { id: 'mumbai', x: 0.703, y: 0.387, primary: false }, // 72.9,  19.1
-      { id: 'bangalore', x: 0.716, y: 0.423, primary: false }, // 77.6,  13.0
-      { id: 'chennai', x: 0.723, y: 0.423, primary: false }, // 80.3,  13.0
-      { id: 'kolkata', x: 0.745, y: 0.364, primary: false }, // 88.3,  22.6
-      // Southeast Asia
-      { id: 'bangkok', x: 0.779, y: 0.418, primary: false }, // 100.5, 13.8
-      { id: 'kualalumpur', x: 0.782, y: 0.481, primary: false }, // 101.7,  3.1
-      { id: 'singapore', x: 0.788, y: 0.492, primary: false }, // 103.8,  1.35
-      { id: 'jakarta', x: 0.797, y: 0.535, primary: false }, // 106.8, -6.2
-      // East Asia
-      { id: 'hongkong', x: 0.817, y: 0.366, primary: false }, // 114.2, 22.3
-      { id: 'beijing', x: 0.823, y: 0.249, primary: false }, // 116.4, 39.9
-      { id: 'taipei', x: 0.838, y: 0.35, primary: false }, // 121.5, 25.0
-      { id: 'shanghai', x: 0.838, y: 0.309, primary: false }, // 121.5, 31.2
-      { id: 'seoul', x: 0.853, y: 0.27, primary: false }, // 127.0, 37.6
-      { id: 'osaka', x: 0.876, y: 0.282, primary: false }, // 135.5, 34.7
-      { id: 'tokyo', x: 0.888, y: 0.275, primary: true }, // 139.7, 35.7
-      // Oceania — pixel-calibrated to land dot clusters in image
-      { id: 'perth', x: 0.822, y: 0.722, primary: false }, // 115.8, -32.0
-      { id: 'sydney', x: 0.92, y: 0.695, primary: false }, // 151.2, -33.9
+      // North America (NA)
+      { id: 'san_jose', x: 0.161, y: 0.265, primary: false }, // -121.9, 37.3
+      { id: 'dallas', x: 0.231, y: 0.299, primary: false }, //  -96.8, 32.8
+      { id: 'toronto', x: 0.279, y: 0.215, primary: false }, //  -79.4, 43.7
+      { id: 'ashburn', x: 0.286, y: 0.257, primary: true }, //  -77.0, 39.0
+      { id: 'nyc', x: 0.294, y: 0.242, primary: false }, //  -74.0, 40.7
+      // Latin America (LATAM)
+      { id: 'santiago', x: 0.304, y: 0.639, primary: false }, //  -70.7, -33.5
+      { id: 'saopaulo', x: 0.371, y: 0.639, primary: false }, //  -46.6, -23.5
+      // Europe (EU)
+      { id: 'london', x: 0.5, y: 0.2, primary: true }, //   -0.1, 51.5
+      { id: 'amsterdam', x: 0.514, y: 0.2, primary: true }, //    4.9, 52.4
+      { id: 'frankfurt', x: 0.524, y: 0.25, primary: false }, //    8.7, 50.1
+      // Middle East & Africa (MEA)
+      { id: 'dubai', x: 0.654, y: 0.347, primary: false }, //   55.3, 25.2
+      { id: 'johannesburg', x: 0.578, y: 0.639, primary: false }, //   28.0, -26.2
+      // Asia Pacific (APAC)
+      { id: 'mumbai', x: 0.703, y: 0.387, primary: false }, //   72.9, 19.1
+      { id: 'singapore', x: 0.788, y: 0.492, primary: false }, //  103.8,  1.3
+      { id: 'sydney', x: 0.92, y: 0.695, primary: false }, //  151.2, -33.9
+      { id: 'tokyo', x: 0.888, y: 0.275, primary: true }, //  139.7, 35.7
     ] as const;
 
     const EDGES: [string, string][] = [
-      // NA west coast spine
-      ['vancouver', 'seattle'],
-      ['seattle', 'la'],
-      ['la', 'phoenix'],
-      ['la', 'denver'],
-      ['denver', 'dallas'],
-      ['dallas', 'chicago'],
-      ['la', 'chicago'],
-      // NA east coast cluster
-      ['chicago', 'toronto'],
+      // NA internal
+      ['san_jose', 'dallas'],
+      ['san_jose', 'toronto'],
+      ['dallas', 'toronto'],
+      ['dallas', 'ashburn'],
+      ['toronto', 'ashburn'],
+      ['ashburn', 'nyc'],
       ['toronto', 'nyc'],
-      ['nyc', 'ashburn'],
-      ['ashburn', 'atlanta'],
-      ['atlanta', 'miami'],
-      ['miami', 'ashburn'],
-      // Trans-atlantic backbone
+      // Trans-atlantic
       ['ashburn', 'london'],
-      ['nyc', 'london'],
-      ['miami', 'madrid'],
-      // Europe mesh
-      ['london', 'paris'],
+      ['nyc', 'amsterdam'],
+      // Europe triangle
       ['london', 'amsterdam'],
-      ['paris', 'amsterdam'],
-      ['paris', 'frankfurt'],
       ['amsterdam', 'frankfurt'],
-      ['frankfurt', 'zurich'],
-      ['zurich', 'milan'],
-      ['frankfurt', 'vienna'],
-      ['vienna', 'warsaw'],
-      ['amsterdam', 'stockholm'],
-      ['stockholm', 'warsaw'],
-      ['frankfurt', 'warsaw'],
-      ['madrid', 'lisbon'],
-      ['madrid', 'paris'],
-      // Europe → Middle East
-      ['frankfurt', 'istanbul'],
-      ['istanbul', 'dubai'],
-      // Europe → Africa
-      ['madrid', 'lagos'],
-      ['london', 'lagos'],
-      ['nairobi', 'dubai'],
-      ['nairobi', 'johannesburg'],
-      ['lagos', 'nairobi'],
-      // Europe → Asia
-      ['frankfurt', 'mumbai'],
+      ['london', 'frankfurt'],
+      // Europe → MEA
+      ['frankfurt', 'dubai'],
+      ['amsterdam', 'johannesburg'],
+      // Europe → APAC
       ['london', 'mumbai'],
-      ['istanbul', 'karachi'],
-      // South Asia
-      ['karachi', 'mumbai'],
-      ['karachi', 'delhi'],
-      ['delhi', 'mumbai'],
-      ['delhi', 'kolkata'],
-      ['mumbai', 'bangalore'],
-      ['bangalore', 'chennai'],
-      ['chennai', 'kolkata'],
-      ['kolkata', 'bangkok'],
-      // Southeast Asia
-      ['mumbai', 'singapore'],
-      ['bangkok', 'singapore'],
-      ['singapore', 'jakarta'],
-      ['singapore', 'kualalumpur'],
-      ['kualalumpur', 'jakarta'],
-      // East Asia mesh
-      ['singapore', 'hongkong'],
-      ['hongkong', 'taipei'],
-      ['hongkong', 'shanghai'],
-      ['taipei', 'osaka'],
-      ['shanghai', 'beijing'],
-      ['shanghai', 'osaka'],
-      ['beijing', 'seoul'],
-      ['seoul', 'osaka'],
-      ['osaka', 'tokyo'],
-      // Trans-pacific
-      ['la', 'tokyo'],
-      ['seattle', 'tokyo'],
-      // Oceania
-      ['sydney', 'singapore'],
-      ['perth', 'singapore'],
-
-      ['perth', 'sydney'],
-      ['tokyo', 'sydney'],
-      // Latin America
-      ['miami', 'mexico'],
-      ['mexico', 'bogota'],
-      ['bogota', 'saopaulo'],
-      ['saopaulo', 'santiago'],
-      ['saopaulo', 'buenosaires'],
-      ['santiago', 'buenosaires'],
-      // Africa → South America (cable route)
-      ['lagos', 'saopaulo'],
-      ['johannesburg', 'saopaulo'],
-      // Dubai → Asia
+      // MEA internal
       ['dubai', 'mumbai'],
-      ['dubai', 'singapore'],
+      ['dubai', 'johannesburg'],
+      // APAC
+      ['mumbai', 'singapore'],
+      ['singapore', 'sydney'],
+      ['singapore', 'tokyo'],
+      ['sydney', 'tokyo'],
+      // Trans-pacific
+      ['san_jose', 'tokyo'],
+      // Latin America
+      ['ashburn', 'saopaulo'],
+      ['saopaulo', 'santiago'],
+      // South Atlantic cable
+      ['johannesburg', 'saopaulo'],
     ];
 
     // Nodes eligible for red alert events — spread across regions
     const ALERT_NODE_IDS = [
-      'la',
       'ashburn',
-      'london',
-      'frankfurt',
-      'mumbai',
-      'tokyo',
-      'singapore',
-      'sydney',
+      'nyc',
+      'dallas',
+      'san_jose',
       'saopaulo',
+      'london',
+      'amsterdam',
+      'frankfurt',
       'dubai',
       'johannesburg',
-      'bogota',
-      'shanghai',
-      'istanbul',
+      'mumbai',
+      'singapore',
+      'sydney',
+      'tokyo',
     ];
 
     // ─── Global position offset ─────────────────────────────────────────────
     // Shift the entire node group without touching individual coordinates.
     // OFFSET_X / OFFSET_Y are fractions of canvas width/height (0–1 scale).
     // Examples: +0.05 moves all nodes 5% right/down, -0.05 moves left/up.
-    const OFFSET_X = -0.015; // ← edit me
-    const OFFSET_Y = 0.1; // ← edit me
+    const OFFSET_X = -0.019; // ← edit me
+    const OFFSET_Y = 0.13; // ← edit me
     // ────────────────────────────────────────────────────────────────────────
 
     // aurora-moss: #e6f59f  |  blush-quartz: #ecd0d0


### PR DESCRIPTION
- Add "Top banner click" to Announcement banner link
- Add "Download page: Mac/Windows/Linux" to download page buttons
- Add "Features page: Download Mac/Windows/Linux" to features page links
- Reduce map animation to 16 canonical PoP nodes (NA, LATAM, EU, MEA, APAC) with simplified edge topology
- Top bar typo fix local.host