### PR TITLE
feat: mobile nav for legal pages matching brand style

### DIFF
--- a/src/pages/legal/[slug].astro
+++ b/src/pages/legal/[slug].astro
@@ -47,7 +47,7 @@ const sortedLegal = [...allLegal].sort((a, b) => {
 >
   <section class="datum-container">
     <Hero
-      class="light bg-glacier-mist-800 [&_.hero--main-content-title]:max-w-none [&_.hero--main-content-title]:whitespace-nowrap"
+      class="light bg-glacier-mist-800 [&_.hero--main-content-title]:max-w-none"
       title="Privacy Policies and Security Practices"
     />
 
@@ -55,8 +55,50 @@ const sortedLegal = [...allLegal].sort((a, b) => {
       <div class="max-width">
         <div class="legal-layout">
           <!-- Side Nav -->
-          <aside class="legal-sidenav">
-            <nav>
+          <aside
+            class="legal-sidenav"
+            x-data="{ open: false }"
+            @click.away="open = false"
+            @resize.window="if (window.innerWidth >= 768) open = false"
+          >
+            <button
+              class="legal-sidenav-toggle md:hidden"
+              @click="open = !open"
+              :aria-expanded="open"
+              aria-controls="legal-sidenav-menu"
+            >
+              <span class="legal-sidenav-toggle--text">Menu</span>
+              <svg
+                x-show="!open"
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                ><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"
+                ></line><line x1="3" y1="18" x2="21" y2="18"></line></svg
+              >
+              <svg
+                x-show="open"
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                ><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"
+                ></line></svg
+              >
+            </button>
+
+            <nav id="legal-sidenav-menu" x-show="open" x-transition style="display: none;">
               {
                 sortedLegal.map((entry) => (
                   <a
@@ -65,6 +107,7 @@ const sortedLegal = [...allLegal].sort((a, b) => {
                       'legal-sidenav-item',
                       { 'legal-sidenav-item--active': entry.id === page.id },
                     ]}
+                    @click="open = false"
                   >
                     {entry.data.title}
                   </a>

--- a/src/v1/styles/page-legal.css
+++ b/src/v1/styles/page-legal.css
@@ -6,10 +6,24 @@
   }
 
   .legal-sidenav {
-    @apply sticky top-0 w-full shrink-0 self-start overflow-auto pt-8 pr-0 pb-7 md:w-64.75 md:pt-10 md:pr-7 lg:pt-16 xl:pt-20;
+    @apply w-full shrink-0 self-start pt-6 pb-8 md:sticky md:top-0 md:w-64.75 md:overflow-auto md:pt-10 md:pr-7 md:pb-7 lg:pt-16 xl:pt-20;
 
+    /* Mobile toggle button */
+    .legal-sidenav-toggle {
+      @apply flex w-full items-center justify-between border border-gray-200 bg-white p-3 text-left transition-colors duration-200 hover:bg-gray-50 md:hidden;
+
+      .legal-sidenav-toggle--text {
+        @apply datum-text-base font-medium text-gray-900;
+      }
+    }
+
+    /* Nav list — hidden on mobile until toggled, always visible on desktop */
     nav {
-      @apply flex flex-col gap-1;
+      @apply flex flex-col gap-1 rounded-md border border-t-0 border-gray-200 bg-white p-2 md:border-0 md:bg-transparent md:p-0;
+
+      @media (min-width: 768px) {
+        display: flex !important;
+      }
     }
   }
 
@@ -18,6 +32,23 @@
 
     &.legal-sidenav-item--active {
       @apply bg-glacier-mist-800 text-midnight-fjord font-semibold opacity-100;
+    }
+
+    /* Mobile only: match brand nav dropdown style */
+    @media (max-width: 767px) {
+      @apply datum-text-base text-midnight-fjord rounded-none px-3 py-1;
+
+      &:hover {
+        @apply text-canyon-clay---links;
+      }
+
+      &.legal-sidenav-item--active {
+        @apply text-canyon-clay---links bg-transparent;
+
+        &:hover {
+          @apply text-midnight-fjord;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
- Add Alpine.js toggle drawer to legal sidenav (hidden on desktop)
- Mobile dropdown matches brand nav: datum-text-base, canyon-clay active state, full-opacity text, no background highlight on active items
- Toggle button always shows "Menu" label with hamburger/X icon
- Add top/bottom spacing around sidenav block on mobile
- Fix hero title whitespace-nowrap overflow on mobile