### PR TITLE
Use non-null assertion when setting bg color

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -255,7 +255,7 @@ const navData = navigation as NavData;
       const b = Math.round(lerp(c[2], n[2], phaseT));
 
       const rgb = `rgb(${r},${g},${b})`;
-      el.style.backgroundColor = rgb;
+      el!.style.backgroundColor = rgb;
       if (elBg) (elBg as HTMLElement).style.backgroundColor = rgb;
       if (elTxt)
         elTxt.style.color = `rgb(${Math.round(r * 0.55)},${Math.round(g * 0.55)},${Math.round(b * 0.55)})`;


### PR DESCRIPTION
Add a TypeScript non-null assertion (el!) before accessing style.backgroundColor in src/components/Footer.astro to satisfy strict null checking. This is a type-level fix only and does not change runtime behavior; other background/text element assignments remain unchanged.