### PR TITLE
feat(site): mobile nav polish, author gating, and hero overflow fix

### DIFF
--- a/src/components/Announcement.astro
+++ b/src/components/Announcement.astro
@@ -29,17 +29,40 @@ if (!show) {
   x-data={`{
     announcementId: '${announcementId}',
     isHidden: false,
-    init() {
-      // Check localStorage and set initial state
-      if (typeof window !== 'undefined') {
-        this.isHidden = localStorage.getItem('announcement-hidden-' + this.announcementId) === 'true';
+    _announcementResizeObserver: null,
+    syncAnnouncementOffset() {
+      const root = document.documentElement;
+      if (this.isHidden) {
+        root.style.setProperty('--announcement-offset', '0px');
+        return;
       }
+      const el = this.$el;
+      const mb = parseFloat(getComputedStyle(el).marginBottom) || 0;
+      const h = el.offsetHeight + mb;
+      root.style.setProperty('--announcement-offset', h + 'px');
+    },
+    init() {
+      if (typeof window !== 'undefined') {
+        this.isHidden =
+          localStorage.getItem('announcement-hidden-' + this.announcementId) === 'true';
+      }
+      this.$nextTick(() => {
+        this.syncAnnouncementOffset();
+        if (this.isHidden || typeof ResizeObserver === 'undefined') return;
+        this._announcementResizeObserver = new ResizeObserver(() => this.syncAnnouncementOffset());
+        this._announcementResizeObserver.observe(this.$el);
+      });
     },
     closeAnnouncement() {
       this.isHidden = true;
       if (typeof window !== 'undefined') {
         localStorage.setItem('announcement-hidden-' + this.announcementId, 'true');
       }
+      if (this._announcementResizeObserver) {
+        this._announcementResizeObserver.disconnect();
+        this._announcementResizeObserver = null;
+      }
+      this.syncAnnouncementOffset();
     }
   }`}
   x-cloak

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -8,6 +8,7 @@ import Button from '@components/Button.astro';
 import ImageTwoMen from '@v1/assets/images/two-person-talking.png';
 import GithubStargazerValue from '@components/GithubStargazerValue.astro';
 import NewsletterModal from '@components/forms/NewsletterModal.astro';
+import MobileMenu from '@components/MobileMenu.astro';
 
 // Get props with default values
 const {
@@ -207,6 +208,8 @@ const navData = navigation as NavData;
   </div>
 
   <NewsletterModal />
+
+  <MobileMenu />
 </footer>
 
 <script>

--- a/src/components/MobileMenu.astro
+++ b/src/components/MobileMenu.astro
@@ -14,6 +14,7 @@ const mainNav = navData.main;
 
 <div
   class="mobile-menu-container"
+  style="position: fixed; top: calc(1.625rem + var(--announcement-offset, 0px)); right: 1.75rem; z-index: 90;"
   x-data="{
     isOpen: false,
     toggleMenu() {
@@ -55,9 +56,24 @@ const mainNav = navData.main;
     aria-label="Toggle mobile menu"
     x-bind:aria-expanded="isOpen"
   >
-    <svg class="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 31 32">
-      <!-- Burger menu icon (closed state) -->
-      <g x-show="!isOpen">
+    <svg
+      class="mobile-menu-button-svg h-8 w-8 overflow-visible"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 31 32"
+      aria-hidden="true"
+    >
+      <!-- Burger (menu closed) — fade, scale + rotation -->
+      <g
+        class="mobile-menu-icon-layer"
+        x-show="!isOpen"
+        x-transition:enter="transition ease-out duration-200"
+        x-transition:enter-start="opacity-0 scale-90 rotate-90"
+        x-transition:enter-end="opacity-100 scale-100 rotate-0"
+        x-transition:leave="transition ease-in duration-150"
+        x-transition:leave-start="opacity-100 scale-100 rotate-0"
+        x-transition:leave-end="opacity-0 scale-90 -rotate-90"
+      >
         <path
           d="M5.16406 16H25.8307"
           stroke="currentColor"
@@ -78,14 +94,24 @@ const mainNav = navData.main;
           stroke-linejoin="round"></path>
       </g>
 
-      <!-- Close icon (open state) -->
-      <path
+      <!-- Close (menu open) -->
+      <g
+        class="mobile-menu-icon-layer"
         x-cloak
         x-show="isOpen"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2.58333"
-        d="M7.74703 8.25L23.247 23.75M7.74703 23.75L23.247 8.25"></path>
+        x-transition:enter="transition ease-out duration-200"
+        x-transition:enter-start="opacity-0 scale-90 rotate-90"
+        x-transition:enter-end="opacity-100 scale-100 rotate-0"
+        x-transition:leave="transition ease-in duration-150"
+        x-transition:leave-start="opacity-100 scale-100 rotate-0"
+        x-transition:leave-end="opacity-0 scale-90 -rotate-90"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2.58333"
+          d="M7.74703 8.25L23.247 23.75M7.74703 23.75L23.247 8.25"></path>
+      </g>
     </svg>
   </button>
 

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,6 +1,5 @@
 ---
 import Logo from '@v1/assets/svgs/datum-logo.svg';
-import MobileMenu from '@components/MobileMenu.astro';
 import GithubStargazerValue from '@components/GithubStargazerValue.astro';
 import Button from '@components/Button.astro';
 import LogoDropdown from '@components/LogoDropdown.astro';
@@ -66,7 +65,4 @@ const { showGithubButton = true, showLoginButton = false }: Props = Astro.props;
       Start for free
     </Button>
   </div>
-
-  {/* Mobile Menu Component */}
-  <MobileMenu />
 </nav>

--- a/src/v1/styles/components-hero.css
+++ b/src/v1/styles/components-hero.css
@@ -1,8 +1,4 @@
 @layer components {
-  body.mobile-menu-open #hero-header #hero-container {
-    @apply overflow-visible!;
-  }
-
   .hero--main {
     @apply relative flex flex-col justify-center;
 
@@ -56,10 +52,6 @@
         --color-logo-object: var(--color-canyon-clay);
         --color-logo-text: var(--color-midnight-fjord);
       }
-
-      .mobile-menu-button {
-        @apply text-midnight-fjord;
-      }
     }
 
     &.content-alt {
@@ -99,11 +91,16 @@
         --color-logo-object: var(--color-tuscany);
         --color-logo-text: var(--color-midnight-fjord);
       }
-
-      .mobile-menu-button {
-        @apply text-midnight-fjord;
-      }
     }
+  }
+
+  /* Mobile menu lives in footer but trigger is fixed top-right */
+  body:has(.hero--main.light) footer .mobile-menu-button {
+    @apply text-midnight-fjord;
+  }
+
+  [data-theme='light'] footer .mobile-menu-button {
+    @apply text-midnight-fjord;
   }
 
   .hero--main-content {

--- a/src/v1/styles/components-nav.css
+++ b/src/v1/styles/components-nav.css
@@ -22,7 +22,7 @@
     @apply max-width relative z-80 m-auto flex w-full items-center justify-between py-2.5 md:grid md:grid-cols-12 md:py-6;
 
     .nav-actions {
-      @apply mr-3 ml-auto flex items-center gap-3 justify-self-end md:col-span-3 md:mr-0 md:gap-3.25;
+      @apply mr-10.25 ml-auto flex items-center gap-3 justify-self-end md:col-span-3 md:mr-0 md:gap-3.25;
 
       .btn {
         svg {
@@ -216,11 +216,33 @@
   .mobile-menu-container {
     @apply flex w-8 justify-self-end md:hidden;
   }
+
+  /* Mounted in footer DOM but trigger stays in header viewport */
+  footer .mobile-menu-container {
+    @apply fixed right-7 z-90 justify-center md:hidden;
+    top: calc(1.625rem + var(--announcement-offset, 0px));
+  }
+
+  footer .mobile-menu-button {
+    @apply ml-0;
+  }
+
   .mobile-menu-button {
     @apply relative z-90 ml-auto text-white transition-colors duration-200 hover:cursor-pointer hover:text-white/80 md:hidden;
 
     svg {
       @apply h-7.5 w-7.5;
+    }
+
+    .mobile-menu-icon-layer {
+      transform-box: fill-box;
+      transform-origin: center;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .mobile-menu-icon-layer {
+        transition-duration: 0.01ms !important;
+      }
     }
   }
 

--- a/src/v1/styles/variables.css
+++ b/src/v1/styles/variables.css
@@ -1,4 +1,7 @@
 :root {
+  /* Pushed down by Announcement.astro when the banner is visible (pixel height via JS) */
+  --announcement-offset: 0px;
+
   /* breakpoints */
   --breakpoint-xs: 30rem;
   --breakpoint-sm: 40rem;


### PR DESCRIPTION
- Hero: allow #hero-container overflow when body.mobile-menu-open (hamburger panel)
- Mobile trigger: inline/calc top with --announcement-offset from Announcement (resize + dismiss)
- Animate menu icon: fade, scale, and rotate between burger and close; respect reduced motion