### PR TITLE
fix(nav): burger-to-X morph, essentials highlight

### DIFF
--- a/src/components/MobileMenu.astro
+++ b/src/components/MobileMenu.astro
@@ -66,38 +66,12 @@ const mainNav = navData.main;
       x-bind:class="{ 'mobile-menu-icon--open': isOpen }"
       fill="none"
       stroke="currentColor"
-      viewBox="0 0 31 32"
+      viewBox="0 0 30 30"
+      aria-hidden="true"
     >
-      <!-- Burger menu icon (closed state) -->
-      <g x-show="!isOpen">
-        <path
-          d="M5.16406 16H25.8307"
-          stroke="currentColor"
-          stroke-width="2.58333"
-          stroke-linecap="round"
-          stroke-linejoin="round"></path>
-        <path
-          d="M5.16406 23.75H20.6641"
-          stroke="currentColor"
-          stroke-width="2.58333"
-          stroke-linecap="round"
-          stroke-linejoin="round"></path>
-        <path
-          d="M5.16406 8.25H25.8307"
-          stroke="currentColor"
-          stroke-width="2.58333"
-          stroke-linecap="round"
-          stroke-linejoin="round"></path>
-      </g>
-
-      <!-- Close icon (open state) -->
-      <path
-        x-cloak
-        x-show="isOpen"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2.58333"
-        d="M7.74703 8.25L23.247 23.75M7.74703 23.75L23.247 8.25"></path>
+      <path class="burger-top" d="M4 7h22" stroke-width="2.5" stroke-linecap="round"></path>
+      <path class="burger-mid" d="M4 15h22" stroke-width="2.5" stroke-linecap="round"></path>
+      <path class="burger-bot" d="M4 23h22" stroke-width="2.5" stroke-linecap="round"></path>
     </svg>
   </button>
 

--- a/src/pages/essentials.astro
+++ b/src/pages/essentials.astro
@@ -154,11 +154,23 @@ const jsonLd = {
         );
       }
 
+      // Fire immediately if the container is already (partially) visible on load.
+      const rect = container.getBoundingClientRect();
+      if (rect.top < window.innerHeight && rect.bottom > 0) {
+        highlight();
+      }
+
+      // On mobile the grid stacks into a single column and can exceed the viewport
+      // height by 3×+, making a 0.4 threshold geometrically unreachable. Clamp it
+      // to 90% of the max visible fraction so it always fires.
+      const maxVisible = window.innerHeight / rect.height;
+      const effectiveThreshold = Math.min(threshold, maxVisible * 0.9);
+
       new IntersectionObserver(
         (entries) => {
           if (entries[0].isIntersecting) highlight();
         },
-        { threshold }
+        { threshold: effectiveThreshold }
       ).observe(container);
 
       new IntersectionObserver(

--- a/src/v1/styles/components-nav.css
+++ b/src/v1/styles/components-nav.css
@@ -220,11 +220,48 @@
     @apply relative z-90 ml-auto text-white transition-colors duration-200 hover:cursor-pointer hover:text-white/80 md:hidden;
 
     .mobile-menu-icon {
-      @apply h-7.5 w-7.5 transition-transform duration-300 ease-in-out;
+      @apply h-7.5 w-7.5;
+
+      /* viewBox is 30×30, rendered at 30×30px → 1 SVG unit = 1 CSS px, no ambiguity */
+      .burger-top,
+      .burger-mid,
+      .burger-bot {
+        transition:
+          transform 0.3s ease-in-out,
+          opacity 0.2s ease-in-out;
+      }
+      .burger-top {
+        transform-origin: 15px 7px;
+      }
+      .burger-mid {
+        transform-origin: 15px 15px;
+      }
+      .burger-bot {
+        transform-origin: 15px 23px;
+      }
     }
 
     .mobile-menu-icon--open {
-      @apply rotate-90;
+      /* CSS applies right-to-left: rotate in place, then translateY in screen space */
+      /* Top bar: center (15,7) → rotate → still (15,7) → +8px → (15,15) = SVG center */
+      .burger-top {
+        transform: translateY(8px) rotate(45deg);
+      }
+      .burger-mid {
+        opacity: 0;
+        transform: scaleX(0);
+      }
+      .burger-bot {
+        transform: translateY(-8px) rotate(-45deg);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .burger-top,
+      .burger-mid,
+      .burger-bot {
+        transition-duration: 0.01ms !important;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- **Burger → X morph animation** — Replaced the `x-show` toggle (snap between two icon states) with a smooth CSS morph. Three always-present `<path>` elements in a square `30×30` viewBox (so 1 SVG unit = 1 CSS px, no aspect-ratio ambiguity). Per-path `transform-origin` set to each bar's own center; top and bottom bars `translateY + rotate(±45deg)` converge to a geometrically perfect X at the SVG center, middle bar fades out. Respects `prefers-reduced-motion`.

- **Essentials icon highlight never firing on mobile** — `IntersectionObserver` used `threshold: 0.4`, requiring 40% of the grid to be visible simultaneously. With 12 items stacked in a single column on mobile the grid reaches ~2000px — geometrically impossible to hit 40% on a 667px viewport. Now clamps threshold to 90% of the max visible fraction, and also triggers immediately on load if the grid is already partially in the viewport.

## Test plan
- [ ] Mobile: tapping burger smoothly morphs to X and back
- [ ] Desktop: nav layout unchanged, desktop menu unaffected
- [ ] `/essentials/` on mobile: icon highlights animate on page load and on scroll-in