### PR TITLE
feat: update events calendar (remove past) and shop embed configuration

### DIFF
--- a/src/components/events/EventCalendarSection.astro
+++ b/src/components/events/EventCalendarSection.astro
@@ -18,10 +18,10 @@ interface Props {
   past: ContentEvent[];
 }
 
-const { upcoming, past } = Astro.props as Props;
+const { upcoming } = Astro.props as Props;
 
 // All events combined for the calendar
-const allEvents = [...upcoming, ...past];
+const allEvents = [...upcoming];
 
 // Serialize events to JSON for Alpine.js (only fields we need)
 const eventsData = allEvents.map((e) => {

--- a/src/pages/shop/index.astro
+++ b/src/pages/shop/index.astro
@@ -33,38 +33,65 @@ const icon = 'list-restart';
 
     <div class="section--block section--block--pad bg-midnight-fjord dark">
       <div class="sr-element sr-products" data-embed="multiple_products">
-        <script is:inline type="application/json">
+        <script type="application/json" data-config="embed" is:inline>
           {
-            "publishable_key": "sr_live_pk_0ac696797e14d49ca01f523ffb8d962e670f",
+            "publishable_key": "sr_live_pk_e3d2346a89337978de277ee7686dcbe42c70",
             "options": {
               "products_to_display": "all",
               "categories": [],
-              "product_size": "small",
+              "products": [],
+              "exclude_products": [],
+              "exclude_product_categories": [],
               "image_dimension_value": "crop",
-              "image_aspect_ratio": "landscape",
+              "image_aspect_ratio": "portrait",
               "button_style": "standard",
               "variation_style": "on_hover",
               "open_product_in": "in_page",
               "button_position": "inline",
-              "product_default_sorting_order": "product_order",
-              "product_pagination_limit": "4",
-              "hide_out_of_stock": "0"
+              "product_default_sorting_order": "created",
+              "product_pagination_limit": "12",
+              "desktop": {
+                "items_per_row": "4"
+              },
+              "mobile": {
+                "items_per_row": "2"
+              },
+              "hide_out_of_stock": "0",
+              "basket_style": "bubble",
+              "basket_position": "bottom-left"
             },
             "includes": {
+              "show_search_box": "0",
+              "show_sort_by": "0",
+              "show_per_page": "0",
+              "show_category_dropdown": "0",
+              "show_currency_dropdown": "0",
+              "show_language_dropdown": "0",
+              "show_product_filters": "0",
               "show_product_name": "1",
               "show_product_price": "1",
               "show_product_image": "1",
-              "show_product_summary": "1",
+              "show_product_summary": "0",
               "open_modal_on_image_click": "1",
-              "show_view_product_button": "1",
+              "show_view_product_button": "0",
               "show_add_to_cart_button": "1",
-              "show_min_max_order_quantity": "1",
-              "show_sale": "1",
-              "show_free_shipping": "1",
+              "show_min_max_order_quantity": "0",
+              "show_sale": "0",
+              "show_free_shipping": "0",
               "show_new_product": "1",
-              "show_digital_download": "1",
+              "show_digital_download": "0",
+              "show_pwyw": "0",
               "image_swap": "1",
-              "show_button_icons": "1"
+              "show_button_icons": "1",
+              "mobile": {
+                "show_search_box": "0",
+                "show_sort_by": "0",
+                "show_per_page": "0",
+                "show_category_dropdown": "0",
+                "show_currency_dropdown": "0",
+                "show_language_dropdown": "0",
+                "show_product_filters": "0"
+              }
             },
             "product_popup": {
               "show_product_name": "1",
@@ -72,6 +99,7 @@ const icon = 'list-restart';
               "show_product_summary": "1",
               "show_product_description": "1",
               "show_product_image": "1",
+              "show_add_to_cart_button": "1",
               "show_select_quantity": "1",
               "show_image_thumbnails": "1",
               "show_product_reviews": "1",
@@ -88,9 +116,11 @@ const icon = 'list-restart';
               "show_free_shipping": "1",
               "show_new_product": "1",
               "show_digital_download": "1",
+              "show_pwyw": "1",
               "show_product_tabs": "1",
               "image_zoom": "1",
-              "lightbox_gallery": "1"
+              "lightbox_gallery": "1",
+              "show_stock": "0"
             },
             "styles": {
               "align_content": "center",
@@ -105,6 +135,7 @@ const icon = 'list-restart';
               "view_cart_button_color": "#ffffff",
               "product_background": "#ffffff",
               "modal_background": "#ffffff",
+              "button_font_weight": "normal",
               "popup": {
                 "colors": {
                   "product_title": "#333",
@@ -118,7 +149,7 @@ const icon = 'list-restart';
             }
           }
         </script>
-      </div><script is:inline async src="https://cdn.shoprocket.io/loader.js"></script>
+      </div><script async src="https://cdn.shoprocket.io/loader.js" is:inline></script>
     </div>
     <Footer />
   </section>


### PR DESCRIPTION
feat: update events calendar (remove past) and shop embed configuration
- Remove past events from EventCalendarSection calendar display (upcoming only) #1187
- Update Shoprocket embed with new publishable key and revised display options:
  - Switch to portrait image aspect ratio with 4-col/2-col responsive grid
  - Hide product summary, sale badges, free shipping, and digital download labels
  - Add basket bubble widget, PWYW support, and add-to-cart in product popup
  - Hide sort/filter/pagination controls from product listing