### PR TITLE
Remove /docs redirection

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -61,8 +61,6 @@ const REDIRECTS = {
   '/team': { destination: '/about/', status: 302 },
   '/jobs/': { destination: '/careers/', status: 302 },
   '/community-huddle/': { destination: '/events/', status: 302 },
-  '/docs/': { destination: '/docs/overview/', status: 302 },
-  '/docs': { destination: '/docs/overview/', status: 302 },
   '/docs/roadmap': { destination: '/resources/roadmap/', status: 302 },
   '/docs/tutorials/gateway': { destination: '/docs/tutorials/httpproxy/', status: 302 },
   '/docs/get-started/datum-concepts/': {


### PR DESCRIPTION
We have /docs/ landing content now: https://github.com/datum-cloud/docs/pull/5
So both /docs/ and /docs redirects to /docs/overview/ have been removed