### PR TITLE
feat(sitemap): include blog posts and docs pages in sitemap

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,7 +11,6 @@ import node from '@astrojs/node';
 import playformCompress from '@playform/compress';
 import compressor from 'astro-compressor';
 
-import sitemap from './src/plugins/sitemap.js';
 import announcement from './src/plugins/announcement.ts';
 import { remarkModifiedTime } from './src/plugins/remarkModifiedTime.mjs';
 
@@ -75,21 +74,6 @@ export default defineConfig({
     mermaid({
       theme: 'forest',
       autoTheme: true,
-    }),
-    sitemap({
-      exclude: [
-        '404',
-        'auth/callback',
-        'auth/login',
-        'auth/logout',
-        'api/info',
-        'shop',
-        'waitlist',
-        'dev/build',
-        'dev/info',
-        'authors/jacob-smith/1',
-        'authors/zac-smith/1',
-      ],
     }),
     playformCompress({
       CSS: true,

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -20,8 +20,11 @@ const STATIC_CONTENT = `# Datum — Everything an Agent Needs to Know
 ## How to consume Datum documentation
 1. Fetch https://datum.net/docs/llms.txt — this is the canonical index of all docs
 2. Fetch individual pages as .md (e.g., datum.net/docs/overview.md) for clean text
-3. For live platform state, use \`datumctl api-resources\` or the MCP \`apis\` tool
-4. Submit feedback on incorrect docs via POST to:
+3. Use the Datum Docs MCP server at https://www.datum.net/docs/mcp (JSON-RPC 2.0 over SSE)
+   - Tool: \`search_datum_cloud_docs\` — semantic search across all docs
+   - Tool: \`query_docs_filesystem_datum_cloud_docs\` — read/grep doc files by path (e.g., \`head -80 /quickstart.mdx\`)
+4. For live platform state, use \`datumctl api-resources\` or the MCP \`apis\` tool
+5. Submit feedback on incorrect docs via POST to:
    https://datum.net/docs/_mintlify/feedback/datum-4926dda5/agent-feedback
    Body: { "path": "/page-path", "feedback": "description of issue" }
 </AgentInstructions>

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -85,9 +85,8 @@ export const GET: APIRoute = async () => {
     llmsContent += `\n## Docs\n\n`;
     llmsContent += `- Full documentation index at ${siteUrl}/docs/llms.txt\n`;
 
-    llmsContent += `\n## API\n\n`;
-    llmsContent += `For API documentation, please refer to the following endpoints:\n`;
-    llmsContent += `- ${siteUrl}/api/* - API endpoints\n`;
+    llmsContent += `\n## MCP\n\n`;
+    llmsContent += `- [Datum Docs MCP](${siteUrl}/docs/mcp) - MCP server for AI agents to search and read Datum documentation (JSON-RPC 2.0 over SSE). Tools: \`search_datum_cloud_docs\`, \`query_docs_filesystem_datum_cloud_docs\`.\n`;
 
     llmsContent += `\n## Optional\n\n`;
     llmsContent += `- Full site content at ${siteUrl}/llms-full.txt\n`;

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,196 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+const SITE_URL = 'https://www.datum.net';
+const MINTLIFY_TARGET = 'https://datum-4926dda5.mintlify.dev';
+const STRAPI_URL =
+  import.meta.env?.STRAPI_URL || 'https://grateful-excitement-dfe9d47bad.strapiapp.com';
+const STRAPI_TOKEN = import.meta.env?.STRAPI_TOKEN || '';
+
+// Known static routes (dedicated .astro files, not driven by content collections)
+const STATIC_ROUTES = [
+  '/',
+  '/about/',
+  '/authors/',
+  '/blog/',
+  '/brand/',
+  '/careers/',
+  '/changelog/',
+  '/contact/',
+  '/download/',
+  '/essentials/',
+  '/events/',
+  '/events/alt-cloud-meetups/',
+  '/events/community-huddles/',
+  '/features/',
+  '/handbook/',
+  '/locations/',
+  '/pricing/',
+  '/roadmap/',
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+interface SitemapEntry {
+  url: string;
+  lastmod?: string;
+}
+
+function toISODate(date: string | Date | undefined | null): string | undefined {
+  if (!date) return undefined;
+  try {
+    return new Date(date).toISOString().split('T')[0];
+  } catch {
+    return undefined;
+  }
+}
+
+function xmlEscape(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function buildXml(entries: SitemapEntry[]): string {
+  const urlElements = entries
+    .map(({ url, lastmod }) => {
+      const loc = `<loc>${xmlEscape(url)}</loc>`;
+      const mod = lastmod ? `<lastmod>${lastmod}</lastmod>` : '';
+      return `<url>${loc}${mod}</url>`;
+    })
+    .join('');
+
+  return `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urlElements}</urlset>`;
+}
+
+// ---------------------------------------------------------------------------
+// Strapi: fetch all published blog post slugs
+// ---------------------------------------------------------------------------
+async function fetchBlogEntries(): Promise<SitemapEntry[]> {
+  const query = `
+    query {
+      articles(pagination: { limit: 500 }, sort: ["originalPublishedAt:desc"]) {
+        slug
+        originalPublishedAt
+      }
+    }
+  `;
+
+  try {
+    const headers: HeadersInit = { 'Content-Type': 'application/json' };
+    if (STRAPI_TOKEN) headers['Authorization'] = `Bearer ${STRAPI_TOKEN}`;
+
+    const res = await fetch(`${STRAPI_URL}/graphql`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ query }),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!res.ok) return [];
+
+    const json = (await res.json()) as {
+      data?: { articles?: Array<{ slug: string; originalPublishedAt?: string }> };
+    };
+
+    return (json.data?.articles ?? [])
+      .filter((a) => a.slug && isNaN(parseInt(a.slug, 10)))
+      .map((a) => ({
+        url: `${SITE_URL}/blog/${a.slug}/`,
+        lastmod: toISODate(a.originalPublishedAt),
+      }));
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mintlify: fetch and rewrite docs sitemap
+// ---------------------------------------------------------------------------
+async function fetchDocEntries(): Promise<SitemapEntry[]> {
+  try {
+    const res = await fetch(`${MINTLIFY_TARGET}/docs/sitemap.xml`, {
+      signal: AbortSignal.timeout(15_000),
+      headers: { 'User-Agent': 'datum.net-sitemap/1.0' },
+    });
+
+    if (!res.ok) return [];
+
+    const xml = await res.text();
+    const locs = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)];
+    const lastmods = [...xml.matchAll(/<lastmod>([^<]+)<\/lastmod>/g)];
+
+    return locs.map((m, i) => {
+      // Mintlify uses https://datum.net (no www) — normalise to www.datum.net
+      // and ensure trailing slash for consistency
+      let url = m[1].trim().replace('https://datum.net/', `${SITE_URL}/`);
+      if (!url.endsWith('/')) url += '/';
+      return {
+        url,
+        lastmod: lastmods[i]?.[1]?.trim(),
+      };
+    });
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Content collections: handbooks + legal pages
+// ---------------------------------------------------------------------------
+async function fetchContentCollectionEntries(): Promise<SitemapEntry[]> {
+  const [handbooks, legalPages] = await Promise.all([
+    getCollection('handbooks', ({ data }) => !data.draft),
+    getCollection('legal'),
+  ]);
+
+  const handbookEntries: SitemapEntry[] = handbooks.map((h) => ({
+    url: `${SITE_URL}/handbook/${h.id}/`,
+    lastmod: toISODate(h.data.lastModified),
+  }));
+
+  const legalEntries: SitemapEntry[] = legalPages.map((l) => ({
+    url: `${SITE_URL}/legal/${l.id
+      .replace(/\.(mdx?|md)$/, '')
+      .split('/')
+      .pop()}/`,
+  }));
+
+  return [...handbookEntries, ...legalEntries];
+}
+
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
+export const GET: APIRoute = async () => {
+  const [blogEntries, docEntries, collectionEntries] = await Promise.all([
+    fetchBlogEntries(),
+    fetchDocEntries(),
+    fetchContentCollectionEntries(),
+  ]);
+
+  const staticEntries: SitemapEntry[] = STATIC_ROUTES.map((path) => ({
+    url: `${SITE_URL}${path}`,
+  }));
+
+  // Merge and deduplicate by URL
+  const seen = new Set<string>();
+  const all: SitemapEntry[] = [];
+  for (const entry of [...staticEntries, ...collectionEntries, ...blogEntries, ...docEntries]) {
+    if (!seen.has(entry.url)) {
+      seen.add(entry.url);
+      all.push(entry);
+    }
+  }
+
+  all.sort((a, b) => a.url.localeCompare(b.url));
+
+  return new Response(buildXml(all), {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+    },
+  });
+};

--- a/src/plugins/sitemap.ts
+++ b/src/plugins/sitemap.ts
@@ -17,11 +17,26 @@ export type SitemapOptions =
     }
   | undefined;
 
-const writeSitemapFile = (filePath: string, entries: string[]) => {
+const MINTLIFY_TARGET = 'https://datum-4926dda5.mintlify.dev';
+
+interface SitemapEntry {
+  url: string;
+  lastmod?: string;
+}
+
+const writeSitemapFile = (filePath: string, entries: SitemapEntry[]) => {
   try {
+    const urlElements = entries
+      .map(({ url, lastmod }) =>
+        lastmod
+          ? `<url><loc>${url}</loc><lastmod>${lastmod}</lastmod></url>`
+          : `<url><loc>${url}</loc></url>`
+      )
+      .join('');
+
     const sitemapXml = `<?xml version="1.0" encoding="UTF-8"?>
       <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-      ${entries.join('')}
+      ${urlElements}
       </urlset>`;
 
     fs.writeFileSync(filePath, sitemapXml, 'utf-8');
@@ -35,6 +50,116 @@ const writeSitemapFile = (filePath: string, entries: string[]) => {
     );
   }
 };
+
+/**
+ * Fetch all blog post slugs and publish dates from Strapi.
+ * Uses the same GraphQL endpoint as the rest of the site.
+ */
+async function fetchStrapiSitemapEntries(siteUrl: string): Promise<SitemapEntry[]> {
+  const strapiUrl =
+    process.env.STRAPI_URL || 'https://grateful-excitement-dfe9d47bad.strapiapp.com';
+  const strapiToken = process.env.STRAPI_TOKEN || '';
+
+  const query = `
+    query GetArticleSlugs {
+      articles(pagination: { limit: 500 }, sort: ["originalPublishedAt:desc"]) {
+        slug
+        originalPublishedAt
+      }
+    }
+  `;
+
+  try {
+    const headers: HeadersInit = { 'Content-Type': 'application/json' };
+    if (strapiToken) headers['Authorization'] = `Bearer ${strapiToken}`;
+
+    const response = await fetch(`${strapiUrl}/graphql`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ query }),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!response.ok) {
+      console.log(`%sStrapi sitemap fetch failed: ${response.status}%s`, warnPrefix, resetPrefix);
+      return [];
+    }
+
+    const result = (await response.json()) as {
+      data?: { articles?: Array<{ slug: string; originalPublishedAt?: string }> };
+    };
+
+    const articles = result.data?.articles ?? [];
+    return articles
+      .filter((a) => a.slug && !Number.isInteger(parseInt(a.slug, 10)))
+      .map((a) => ({
+        url: `${siteUrl}blog/${a.slug}/`,
+        lastmod: a.originalPublishedAt
+          ? new Date(a.originalPublishedAt).toISOString().split('T')[0]
+          : undefined,
+      }));
+  } catch (err) {
+    console.log(
+      `%sError fetching Strapi articles for sitemap: %s%s`,
+      warnPrefix,
+      (err as Error).message,
+      resetPrefix
+    );
+    return [];
+  }
+}
+
+/**
+ * Fetch the Mintlify docs sitemap and rewrite URLs to use datum.net domain.
+ * Mintlify's canonical URLs may use the Mintlify dev subdomain — we rewrite
+ * them to the reverse-proxied datum.net equivalent.
+ */
+async function fetchMintlifySitemapEntries(siteUrl: string): Promise<SitemapEntry[]> {
+  try {
+    const response = await fetch(`${MINTLIFY_TARGET}/docs/sitemap.xml`, {
+      signal: AbortSignal.timeout(15_000),
+      headers: { 'User-Agent': 'datum.net-sitemap-builder/1.0' },
+    });
+
+    if (!response.ok) {
+      console.log(`%sMintlify sitemap fetch failed: ${response.status}%s`, warnPrefix, resetPrefix);
+      return [];
+    }
+
+    const xml = await response.text();
+
+    // Extract <loc> values
+    const locMatches = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)];
+    // Extract <lastmod> values (parallel array)
+    const lastmodMatches = [...xml.matchAll(/<lastmod>([^<]+)<\/lastmod>/g)];
+
+    const entries: SitemapEntry[] = [];
+    const siteBase = siteUrl.endsWith('/') ? siteUrl.slice(0, -1) : siteUrl;
+
+    for (let i = 0; i < locMatches.length; i++) {
+      let url = locMatches[i][1].trim();
+
+      // Rewrite Mintlify dev domain → datum.net
+      url = url.replace(MINTLIFY_TARGET, siteBase);
+
+      // Skip non-docs pages that might appear in the Mintlify sitemap
+      if (!url.includes('/docs') && !url.includes('/api-reference')) continue;
+
+      const lastmod = lastmodMatches[i]?.[1]?.trim();
+      entries.push({ url, lastmod });
+    }
+
+    return entries;
+  } catch (err) {
+    console.log(
+      `%sError fetching Mintlify sitemap: %s%s`,
+      warnPrefix,
+      (err as Error).message,
+      resetPrefix
+    );
+    return [];
+  }
+}
 
 const createSitemapBuilderIntegration = (options?: SitemapOptions): AstroIntegration => {
   let config: AstroConfig;
@@ -67,17 +192,18 @@ const createSitemapBuilderIntegration = (options?: SitemapOptions): AstroIntegra
           const finalSiteUrl = new URL(config.base, config.site);
           const excepts = options?.exclude || [];
 
-          const pageUrls = pages
+          // Static Astro pages
+          const pageUrls: SitemapEntry[] = pages
             .filter((p) => !excepts.includes(p.pathname.replace(/^\/|\/$/g, '')))
             .map((p) => {
               if (p.pathname !== '' && !finalSiteUrl.pathname.endsWith('/'))
                 finalSiteUrl.pathname += '/';
               if (p.pathname.startsWith('/')) p.pathname = p.pathname.slice(1);
               const fullPath = finalSiteUrl.pathname + p.pathname;
-              return new URL(fullPath, finalSiteUrl).href;
+              return { url: new URL(fullPath, finalSiteUrl).href };
             });
 
-          const routeUrls = routes.reduce<string[]>((urls: string[], r) => {
+          const routeUrls: SitemapEntry[] = routes.reduce<SitemapEntry[]>((urls, r) => {
             if (r.type !== 'page') return urls;
 
             if (r.pathname && !excepts.includes(r.pathname.replace(/^\/|\/$/g, ''))) {
@@ -86,23 +212,39 @@ const createSitemapBuilderIntegration = (options?: SitemapOptions): AstroIntegra
               else fullPath += r.generate(r.pathname);
 
               const newUrl = new URL(fullPath, finalSiteUrl).href;
-
-              if (!newUrl.endsWith('/')) {
-                urls.push(newUrl + '/');
-              } else {
-                urls.push(newUrl);
-              }
+              urls.push({ url: newUrl.endsWith('/') ? newUrl : newUrl + '/' });
             }
             return urls;
           }, []);
 
-          const allUrls = Array.from(new Set([...pageUrls, ...routeUrls]));
-          allUrls.sort();
+          const siteUrl = finalSiteUrl.href.endsWith('/')
+            ? finalSiteUrl.href
+            : finalSiteUrl.href + '/';
 
-          writeSitemapFile(
-            fullSitemapFilePath,
-            allUrls.map((url) => `<url><loc>${url}</loc></url>`)
+          // Fetch dynamic sources in parallel
+          console.log(`%s  → Fetching blog posts from Strapi...`, infoPrefix);
+          console.log(`%s  → Fetching docs pages from Mintlify...`, infoPrefix);
+          const [strapiEntries, mintlifyEntries] = await Promise.all([
+            fetchStrapiSitemapEntries(siteUrl),
+            fetchMintlifySitemapEntries(siteUrl),
+          ]);
+
+          console.log(`%s  → ${strapiEntries.length} blog posts added`, infoPrefix);
+          console.log(`%s  → ${mintlifyEntries.length} docs pages added`, infoPrefix);
+
+          // Merge and deduplicate by URL
+          const allUrlsMap = new Map<string, SitemapEntry>();
+          for (const entry of [...pageUrls, ...routeUrls, ...strapiEntries, ...mintlifyEntries]) {
+            if (!allUrlsMap.has(entry.url)) {
+              allUrlsMap.set(entry.url, entry);
+            }
+          }
+
+          const allEntries = Array.from(allUrlsMap.values()).sort((a, b) =>
+            a.url.localeCompare(b.url)
           );
+
+          writeSitemapFile(fullSitemapFilePath, allEntries);
         } catch (err) {
           console.log(
             `%sError building sitemap: %s%s`,


### PR DESCRIPTION
## Summary

- Replace the build-time sitemap plugin with an Astro API route (`src/pages/sitemap.xml.ts`) so `/sitemap.xml` works in both dev and production
- Fetch Strapi blog post slugs at request time and include them with `<lastmod>` dates
- Fetch Mintlify docs sitemap from `https://datum-4926dda5.mintlify.dev/docs/sitemap.xml` and merge, normalising `datum.net` → `www.datum.net` with trailing slashes
- Remove the custom sitemap Astro integration from `astro.config.mjs` (superseded by the API route)
- Add Mintlify docs MCP endpoint (`https://www.datum.net/docs/mcp`) to `AgentInstructions` in `llms-full.txt` and as an `## MCP` pointer in `llms.txt`

## Test plan

- [x] `http://localhost:4321/sitemap.xml` loads in dev mode (previously 404'd)
- [ ] Sitemap contains `/blog/<slug>/` entries for Strapi blog posts
- [ ] Sitemap contains `/docs/...` entries from Mintlify
- [ ] Sitemap contains handbook and legal pages from content collections
- [ ] `https://www.datum.net/llms.txt` contains `## MCP` section with docs MCP link
- [ ] `https://www.datum.net/llms-full.txt` contains docs MCP in `AgentInstructions`