### PR TITLE
feat(geo): llms.txt and robots.txt AEO improvements

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -51,6 +51,9 @@ export default defineConfig({
     }),
     robotsTxt({
       sitemap: 'https://www.datum.net/sitemap.xml',
+      transform(content) {
+        return `${content}\n# LLMs\nLLMs-txt: https://www.datum.net/llms.txt\nLLMs-full-txt: https://www.datum.net/llms-full.txt\n`;
+      },
       policy: [
         // Explicit allow for major AI crawlers (no crawl delay)
         { userAgent: 'GPTBot', allow: '/' },

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -1,7 +1,4 @@
 import type { APIRoute } from 'astro';
-import { getCollection } from 'astro:content';
-import { cleanContent, formatDate, buildUrl, stripHtml } from '@utils/llmsUtils';
-import { fetchStrapiArticles } from '@libs/strapi';
 
 // ---------------------------------------------------------------------------
 // Static curated content — maintained by GTM / SEO team
@@ -313,84 +310,8 @@ datumctl delete httpproxy <name>
 
 `;
 
-// ---------------------------------------------------------------------------
-// Dynamic content — auto-generated from Strapi blog and handbook
-// ---------------------------------------------------------------------------
-export const GET: APIRoute = async () => {
-  try {
-    let dynamicContent = '';
-
-    // Blog posts from Strapi
-    const strapiArticles = await fetchStrapiArticles();
-    const sortedPosts = strapiArticles.sort((a, b) => {
-      const dateA = a.originalPublishedAt ? new Date(a.originalPublishedAt).getTime() : 0;
-      const dateB = b.originalPublishedAt ? new Date(b.originalPublishedAt).getTime() : 0;
-      return dateB - dateA;
-    });
-
-    dynamicContent += `---\n\n## Blog\n\n`;
-    for (const post of sortedPosts) {
-      dynamicContent += `### ${stripHtml(post.title)}\n\n`;
-      dynamicContent += `URL: ${buildUrl(post.slug, 'blog')}\n\n`;
-      if (post.originalPublishedAt) {
-        dynamicContent += `Date: ${formatDate(post.originalPublishedAt)}\n\n`;
-      }
-      if (post.description) {
-        dynamicContent += `Description: ${stripHtml(post.description)}\n\n`;
-      }
-      dynamicContent += '---\n\n';
-    }
-
-    // Handbook full content
-    const handbooks = await getCollection('handbooks', ({ data }) => !data.draft);
-
-    const handbookCategories: { [key: string]: typeof handbooks } = {};
-    handbooks.forEach((handbook) => {
-      const category = handbook.id.split('/')[0];
-      if (!handbookCategories[category]) {
-        handbookCategories[category] = [];
-      }
-      handbookCategories[category].push(handbook);
-    });
-
-    dynamicContent += `## Handbook\n\n`;
-
-    for (const category in handbookCategories) {
-      const categoryName = category.charAt(0).toUpperCase() + category.slice(1);
-      dynamicContent += `### ${categoryName}\n\n`;
-
-      const sortedHandbooks = handbookCategories[category].sort((a, b) => {
-        const orderA = a.data.sidebar?.order || 999;
-        const orderB = b.data.sidebar?.order || 999;
-        return orderA - orderB;
-      });
-
-      for (const handbook of sortedHandbooks) {
-        dynamicContent += `#### ${stripHtml(handbook.data.title)}\n\n`;
-        dynamicContent += `URL: ${buildUrl(handbook.id, 'handbook')}\n\n`;
-
-        if (handbook.data.description) {
-          dynamicContent += `Description: ${stripHtml(handbook.data.description)}\n\n`;
-        }
-
-        if (handbook.data.lastModified) {
-          dynamicContent += `Updated: ${handbook.data.lastModified}\n\n`;
-        }
-
-        try {
-          dynamicContent += cleanContent(handbook.body) + '\n\n';
-        } catch (error) {
-          dynamicContent += `[Content processing error: ${error}]\n\n`;
-        }
-        dynamicContent += '---\n\n';
-      }
-    }
-
-    return new Response(STATIC_CONTENT + dynamicContent, {
-      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
-    });
-  } catch (error) {
-    console.error('Failed to generate llms-full.txt:', error);
-    return new Response(`Error generating llms-full.txt: ${error}`, { status: 500 });
-  }
+export const GET: APIRoute = () => {
+  return new Response(STATIC_CONTENT, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
 };

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -4,6 +4,9 @@ import { site } from 'astro:config/client';
 import { extractDescription, buildUrl, stripHtml } from '@utils/llmsUtils';
 import { fetchStrapiArticles } from '@libs/strapi';
 
+// Note: handbook entries intentionally excluded — internal company ops content
+// is not relevant to AI agents consuming platform documentation.
+
 export const GET: APIRoute = async () => {
   try {
     // Get project info
@@ -39,47 +42,10 @@ export const GET: APIRoute = async () => {
 
     llmsContent += `\n## Blog\n\n`;
 
-    for (const post of sortedPosts) {
+    for (const post of sortedPosts.slice(0, 10)) {
       const description = post.description || 'No description available';
       const postUrl = buildUrl(post.slug, 'blog');
       llmsContent += `- [${post.title}](${postUrl}) - ${description}\n`;
-    }
-
-    // Get all handbook entries
-    const handbooks = await getCollection('handbooks', ({ data }) => !data.draft);
-
-    // Group handbooks by category
-    const handbookCategories: { [key: string]: typeof handbooks } = {};
-
-    handbooks.forEach((handbook) => {
-      const category = handbook.id.split('/')[0];
-      if (!handbookCategories[category]) {
-        handbookCategories[category] = [];
-      }
-      handbookCategories[category].push(handbook);
-    });
-
-    llmsContent += `\n## Handbook\n\n`;
-
-    // Add handbook entries by category
-    for (const category in handbookCategories) {
-      const categoryName = category.charAt(0).toUpperCase() + category.slice(1);
-      llmsContent += `\n### ${categoryName}\n\n`;
-
-      // Sort by sidebar order if available
-      const sortedHandbooks = handbookCategories[category].sort((a, b) => {
-        const orderA = a.data.sidebar?.order || 999;
-        const orderB = b.data.sidebar?.order || 999;
-        return orderA - orderB;
-      });
-
-      for (const handbook of sortedHandbooks) {
-        const description =
-          handbook.data.description ||
-          extractDescription(handbook.body, 'No description available');
-        const handbookUrl = buildUrl(handbook.id, 'handbook');
-        llmsContent += `- [${handbook.data.title}](${handbookUrl}) - ${description}\n`;
-      }
     }
 
     llmsContent += `\n## Docs\n\n`;


### PR DESCRIPTION
## Summary

- Add `LLMs-txt` and `LLMs-full-txt` directives to `robots.txt` via transform hook — emerging convention for AI crawler discoverability (mirrors `Sitemap:` pattern)
- Strip handbook and blog content from `llms-full.txt` — internal ops content and marketing narratives degrade AEO signal-to-noise ratio; file is now purely static GTM-authored platform reference
- Simplify `llms-full.txt` GET handler to a single static `Response` (no dynamic fetching needed)
- Drop handbook from `llms.txt` — not relevant to AI agents using the platform
- Limit blog posts in `llms.txt` to 10 most recent (links only, SEO discovery)

#1202

## Test plan

- [ ] `https://www.datum.net/robots.txt` contains `LLMs-txt:` and `LLMs-full-txt:` directives
- [ ] `https://www.datum.net/llms-full.txt` contains only static platform reference — no blog posts, no handbook entries
- [ ] `https://www.datum.net/llms.txt` contains at most 10 blog entries and no handbook section