### PR TITLE
fix(events): change NY Tech Week Workshop badge to Datum Hosted

### DIFF
--- a/src/content/events/06-2026-ny-tech-week-workshop/index.mdx
+++ b/src/content/events/06-2026-ny-tech-week-workshop/index.mdx
@@ -5,7 +5,7 @@ startAt: "2026-06-04T18:00:00.000Z"
 endAt: "2026-06-04T21:00:00.000Z"
 timezone: America/New_York
 url: "https://partiful.com/e/iThNjIgkemqTJO8dYMeS"
-eventType: external
+eventType: other
 coverImage: ./cover.png
 geoAddress:
   city: New York


### PR DESCRIPTION
## Summary

- Change `eventType` from `external` to `other` on the NY Tech Week Workshop event
- Datum is a co-host, so the badge should show "Datum Hosted" instead of "We'll be there"

Relates to #1214