### PR TITLE
fix(locations): change Chile label to Santiago

### DIFF
--- a/src/data/locations.json
+++ b/src/data/locations.json
@@ -46,7 +46,7 @@
   },
   {
     "regionCode": "cl-central-1",
-    "metro": "Chile",
+    "metro": "Santiago",
     "latitude": -33.4489,
     "longitude": -70.6693,
     "mapX": 27.0,

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -203,7 +203,7 @@ Datum operates at major internet peering points (IXPs) globally. Region naming f
 | us-central-1   | Dallas              |
 | us-west-1      | San Jose, CA        |
 | ca-east-1      | Toronto             |
-| cl-central-1   | Chile               |
+| cl-central-1   | Santiago            |
 | br-east-1      | São Paolo           |
 | nl-west-1      | Amsterdam           |
 | de-central-1   | Frankfurt           |


### PR DESCRIPTION
## Summary

- Change Chile region label to Santiago to align with city-level naming convention used across all other locations

Closes #1236