### PR TITLE
fix(nav): move mobile menu into <template> to hide from crawlers

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -68,9 +68,17 @@ const { showGithubButton = true, showLoginButton = false }: Props = Astro.props;
       </Button>
     </div>
 
-    {/* Mobile Menu Component */}
-    <div aria-hidden="true">
+    {
+      /* Mobile Menu Component — inside <template> so it is inert in static HTML and invisible to crawlers */
+    }
+    <template id="mobile-menu-template">
       <MobileMenu />
-    </div>
+    </template>
+    <div id="mobile-menu-mount"></div>
+    <script>
+      const tpl = document.getElementById('mobile-menu-template') as HTMLTemplateElement;
+      const mount = document.getElementById('mobile-menu-mount');
+      if (tpl && mount) mount.appendChild(tpl.content.cloneNode(true));
+    </script>
   </nav>
 </section>


### PR DESCRIPTION
## Problem

The mobile menu was fully rendered in static HTML, causing ~70% boilerplate noise on short pages (homepage: 5,559 chars total, only 1,642 chars actual content). Confirmed via Firecrawl paid-tier crawl.

A previous attempt wrapped `<MobileMenu />` in `aria-hidden="true"` — this only hides content from screen readers. Crawlers still read every byte. Verified on live site: `href=/features/` appeared 4× in static HTML (2× desktop + 2× mobile).

## Fix

Move `<MobileMenu />` inside a `<template>` tag. Template content is inert in the browser DOM — not rendered, not indexed by crawlers. A small inline script clones it into a mount point client-side so real users still get the full mobile menu.

## Verification

Build output confirms:
- 1 `<nav>` element (was effectively 2)
- 20 mobile links inside `<template>` (inert)
- 0 mobile links outside `<template>` (crawler-visible)

## Test plan

- [ ] Mobile menu still opens and functions correctly on small screens
- [ ] Desktop nav unaffected
- [ ] `curl -s https://www.datum.net/ | grep -c "mobile-menu"` returns a much lower count than before (should be ~2-3 for class names on the mount/template, not 26)

Closes #1222