### PR TITLE
refactor(nav): replace template clone with server:defer for MobileMenu

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -68,17 +68,7 @@ const { showGithubButton = true, showLoginButton = false }: Props = Astro.props;
       </Button>
     </div>
 
-    {
-      /* Mobile Menu Component — inside <template> so it is inert in static HTML and invisible to crawlers */
-    }
-    <template id="mobile-menu-template">
-      <MobileMenu />
-    </template>
-    <div id="mobile-menu-mount"></div>
-    <script>
-      const tpl = document.getElementById('mobile-menu-template') as HTMLTemplateElement;
-      const mount = document.getElementById('mobile-menu-mount');
-      if (tpl && mount) mount.appendChild(tpl.content.cloneNode(true));
-    </script>
+    {/* Mobile menu — deferred so it is never emitted into static HTML */}
+    <MobileMenu server:defer />
   </nav>
 </section>


### PR DESCRIPTION
Issue: #1242 Swap the manual <template> + cloneNode workaround for Astro's built-in server:defer directive. This defers MobileMenu rendering so it is never emitted into the static HTML payload while removing the boilerplate script tag.