### PR TITLE
fix(strapi): warm cache after webhook invalidation

### DIFF
--- a/src/pages/api/cache/strapi.ts
+++ b/src/pages/api/cache/strapi.ts
@@ -3,6 +3,7 @@
 export const prerender = false;
 
 import type { APIRoute } from 'astro';
+import crypto from 'node:crypto';
 import { regenerateStrapiCacheIfMissing } from '@libs/strapi/regenerateCache';
 
 function verifyWebhookSecret(request: Request): boolean {
@@ -13,7 +14,19 @@ function verifyWebhookSecret(request: Request): boolean {
   }
 
   const receivedSecret = request.headers.get('X-Webhook-Secret');
-  return receivedSecret === webhookSecret;
+
+  if (!receivedSecret) {
+    return false;
+  }
+
+  const expected = Buffer.from(webhookSecret);
+  const received = Buffer.from(receivedSecret);
+
+  if (expected.length !== received.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(expected, received);
 }
 
 export const POST: APIRoute = async ({ request }) => {

--- a/src/pages/api/webhooks/strapi-content.ts
+++ b/src/pages/api/webhooks/strapi-content.ts
@@ -6,6 +6,9 @@ import type { APIRoute } from 'astro';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { fetchStrapiArticles, fetchStrapiArticleBySlug } from '@libs/strapi/articles';
+import { fetchStrapiAuthors } from '@libs/strapi/authors';
+import { fetchStrapiRoadmaps } from '@libs/strapi/roadmaps';
 
 // Cache at project root (cwd when running dev/build)
 const CACHE_DIR = path.resolve(process.cwd(), '.cache');
@@ -130,6 +133,37 @@ function invalidateRoadmapCache(): string[] {
 }
 
 /**
+ * Warm article cache after invalidation — runs non-blocking so webhook responds fast.
+ * Re-fetching also updates the persistent fallback cache.
+ */
+async function warmArticleCacheAsync(slug?: string): Promise<void> {
+  try {
+    await fetchStrapiArticles();
+    if (slug) {
+      await fetchStrapiArticleBySlug(slug);
+    }
+  } catch (err) {
+    console.error('[Webhook] Cache warming failed for articles:', err);
+  }
+}
+
+async function warmAuthorCacheAsync(): Promise<void> {
+  try {
+    await fetchStrapiAuthors();
+  } catch (err) {
+    console.error('[Webhook] Cache warming failed for authors:', err);
+  }
+}
+
+async function warmRoadmapCacheAsync(): Promise<void> {
+  try {
+    await fetchStrapiRoadmaps();
+  } catch (err) {
+    console.error('[Webhook] Cache warming failed for roadmaps:', err);
+  }
+}
+
+/**
  * POST handler for Strapi webhook
  */
 export const POST: APIRoute = async ({ request }) => {
@@ -201,18 +235,21 @@ export const POST: APIRoute = async ({ request }) => {
         `[Webhook] Invalidated article cache (${deletedFiles.length} files):`,
         deletedFiles
       );
+      void warmArticleCacheAsync(entry?.slug);
     } else if (model === 'author') {
       deletedFiles = invalidateAuthorCache();
       console.log(
         `[Webhook] Invalidated author cache (${deletedFiles.length} files):`,
         deletedFiles
       );
+      void warmAuthorCacheAsync();
     } else if (model === 'roadmap') {
       deletedFiles = invalidateRoadmapCache();
       console.log(
         `[Webhook] Invalidated roadmap cache (${deletedFiles.length} files):`,
         deletedFiles
       );
+      void warmRoadmapCacheAsync();
     } else {
       console.warn(`[Webhook] Unknown model: ${model}`);
     }


### PR DESCRIPTION
- fix timing secret comparison
- Add non-blocking cache warming (void async) in webhook handler after invalidating articles, authors, and roadmap caches so the first user after a Strapi publish never hits a cold cache
- Re-fetch on warming also refreshes the persistent fallback cache, ensuring stale-on-outage data stays up-to-date
- Replace plain string comparison in /api/cache/strapi.ts with crypto.timingSafeEqual to match the timing-attack-safe check already used in /api/webhooks/strapi-content.ts