### PR TITLE
fix: align strapi cache key prefixes

### DIFF
--- a/src/libs/strapi/articles.ts
+++ b/src/libs/strapi/articles.ts
@@ -92,13 +92,13 @@ async function graphqlQuery<T>(
 // Short-lived TTL cache (respects STRAPI_CACHE_ENABLED / STRAPI_CACHE_TTL)
 const cache = new Cache('.cache');
 const ARTICLES_CACHE_KEY = 'strapi-articles';
-const ARTICLE_CACHE_PREFIX = 'strapi-article-';
+const ARTICLE_CACHE_PREFIX = 'strapi-articles-';
 
 // Persistent fallback cache — always written on success, never expires.
 // Serves stale data when Strapi is unreachable.
 const fallbackCache = new Cache('.cache/strapi-fallback');
 const FALLBACK_ARTICLES_KEY = 'articles';
-const FALLBACK_ARTICLE_PREFIX = 'article-';
+const FALLBACK_ARTICLE_PREFIX = 'articles-';
 
 /**
  * GraphQL query to fetch all articles (Strapi v5 format, with high limit)

--- a/src/pages/api/cache/strapi.ts
+++ b/src/pages/api/cache/strapi.ts
@@ -7,7 +7,7 @@ import crypto from 'node:crypto';
 import { regenerateStrapiCacheIfMissing } from '@libs/strapi/regenerateCache';
 
 function verifyWebhookSecret(request: Request): boolean {
-  const webhookSecret = process.env.STRAPI_WEBHOOK_SECRET;
+  const webhookSecret = process.env.STRAPI_WEBHOOK_SECRET || import.meta.env.STRAPI_WEBHOOK_SECRET;
 
   if (!webhookSecret) {
     return false;

--- a/src/pages/api/webhooks/strapi-content.ts
+++ b/src/pages/api/webhooks/strapi-content.ts
@@ -25,7 +25,7 @@ interface StrapiWebhookPayload {
 }
 
 function verifyWebhookSecret(request: Request): boolean {
-  const webhookSecret = process.env.STRAPI_WEBHOOK_SECRET;
+  const webhookSecret = process.env.STRAPI_WEBHOOK_SECRET || import.meta.env.STRAPI_WEBHOOK_SECRET;
 
   if (!webhookSecret) {
     console.warn('[Webhook] STRAPI_WEBHOOK_SECRET is not configured');
@@ -91,8 +91,8 @@ function invalidateArticleCache(slug?: string): string[] {
   ];
 
   if (slug) {
-    // per-article: main "strapi-article-{slug}*", fallback "article-{slug}*"
-    deleted.push(...invalidateCache(`strapi-article-${slug}`, `article-${slug}`));
+    // per-article: main "strapi-articles-{slug}*", fallback "articles-{slug}*"
+    deleted.push(...invalidateCache(`strapi-articles-${slug}`, `articles-${slug}`));
   }
 
   return deleted;


### PR DESCRIPTION
- and support import.meta.env for webhook secret
- Rename per-article cache key prefix from 'strapi-article-' to 'strapi-articles-' and fallback prefix from 'article-' to 'articles-' to be consistent with the collection-level ARTICLES_CACHE_KEY naming
- Update verifyWebhookSecret in both strapi cache and webhook handlers to check import.meta.env.STRAPI_WEBHOOK_SECRET in addition to process.env, following the project-wide pattern for env var access