### PR TITLE
fix(blog): server-render blog listing so new Strapi posts appear immediately

### DIFF
--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,5 +1,6 @@
 ---
 // src/pages/blog.astro
+export const prerender = false;
 
 import '@v1/styles/page-blog.css';
 import Layout from '@layouts/Layout.astro';
@@ -7,7 +8,6 @@ import Hero from '@components/Hero.astro';
 import Footer from '@components/Footer.astro';
 import GlobalSection from '@components/GlobalSection.astro';
 import BlogStrapiIndex from '@components/blog/BlogStrapi.astro';
-import BlogStrapiSkeleton from '@components/blog/BlogStrapiSkeleton.astro';
 import defaultOgImage from '@content/images/og/blog.png';
 import { getCollectionEntry } from '@utils/collectionUtils';
 
@@ -78,9 +78,7 @@ const jsonLd = {
 
     <div class="section--block section--block--pad bg-midnight-fjord dark">
       <div class="max-width">
-        <BlogStrapiIndex server:defer page={1}>
-          <BlogStrapiSkeleton slot="fallback" />
-        </BlogStrapiIndex>
+        <BlogStrapiIndex page={1} />
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

- `/blog/` index page was statically pre-rendered at build time — article list was frozen at last deploy
- New posts published in Strapi appeared at their direct URL (`/blog/[slug]` has `prerender=false`) but never in the listing until a full redeploy
- Fix: add `export const prerender = false` to `blog.astro` — server renders the page on each request, always fetching the latest articles from Strapi

## Why not `server:defer`?

Previous attempt used `server:defer` + skeleton, but that causes issues with Firecrawl and AI crawlers: the deferred island isn't hydrated when the page is scraped, so bots only see the skeleton. With `prerender=false`, the full article list is in the initial HTML response — no JS execution required for crawlers to see content.

## Test plan

- [ ] Visit `/blog/` — confirm `optimizing-our-website-for-ai` post now appears in the listing
- [ ] Confirm pagination pages `/blog/2/` etc. still work
- [ ] Confirm individual post pages still render correctly