### PR TITLE
fix(server): allow cloud-portal to embed Mintlify-proxied docs in iframe

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -344,6 +344,19 @@ function handleProxy(req, res, target, cache = false) {
     if (!cache) {
       headers['cache-control'] = 'no-cache, no-store, must-revalidate';
     }
+
+    // Allow cloud-portal to embed proxied Mintlify content as an iframe.
+    // Mintlify hard-codes `frame-ancestors 'self' https://dashboard.mintlify.com`
+    // and `X-Frame-Options: DENY`, with no docs.json knob to customize either.
+    delete headers['x-frame-options'];
+    const csp = headers['content-security-policy'];
+    if (typeof csp === 'string') {
+      headers['content-security-policy'] = csp.replace(
+        /frame-ancestors[^;]*/i,
+        "frame-ancestors 'self' https://dashboard.mintlify.com https://cloud.datum.net https://cloud.staging.env.datum.net"
+      );
+    }
+
     res.writeHead(proxyRes.statusCode, headers);
     proxyRes.pipe(res);
   });


### PR DESCRIPTION
## Summary

- Cloud-portal embeds `www.datum.net/docs` in an iframe inside its project bottom bar (Developer Tools → Docs panel). The embed was blocked by Mintlify's response headers, which the proxy was forwarding verbatim.
- Mintlify hard-codes `frame-ancestors 'self' https://dashboard.mintlify.com` in its CSP and `X-Frame-Options: DENY` on every response. There is **no** `docs.json` field, dashboard setting, or other Mintlify configuration that lets a customer customize either — confirmed against Mintlify's [global settings](https://mintlify.com/docs/settings/global), [CSP configuration](https://www.mintlify.com/docs/deploy/csp-configuration) (which is about the *embedder's* CSP, not Mintlify's response), and the changelog (no iframe/embed feature).
- The only place under our control where these headers can be rewritten is the `/docs` reverse-proxy in `server.mjs`. This PR adds 13 lines inside `handleProxy()` to:
  - strip `X-Frame-Options` (deprecated `ALLOW-FROM` is ignored by Chrome/Safari; `frame-ancestors` is the spec-correct mechanism)
  - rewrite the `frame-ancestors` directive in place to: `'self' https://dashboard.mintlify.com https://cloud.datum.net https://cloud.staging.env.datum.net`, preserving every other Mintlify CSP directive

## Why this scope

The patch lives inside `handleProxy()`, so it applies to every Mintlify-proxied path (`/docs`, `/docs/*`, `/_mintlify`, `/.well-known/vercel/*`, `/.well-known/skills/*`, `/.well-known/agent-skills/*`, `/skill.md`, `/mintlify-assets/_next/static`). All these routes share the same Mintlify-CSP problem, and `handleProxy()` is only used for Mintlify upstreams today.

## Notes

- If Mintlify ever drops `frame-ancestors` from its default CSP, the regex won't match and the rewrite silently no-ops. Worth re-running `curl -I` against the Mintlify upstream when their platform changes.
- Allowed origins are limited to `cloud.datum.net` and `cloud.staging.env.datum.net` — other environments (local dev, ad-hoc previews) are not allowed by this change.

## Ref
https://github.com/datum-cloud/cloud-portal/issues/1227