### PR TITLE
feat(llms): add Agent Skills section, remove blog from llms.txt

### DIFF
--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -302,6 +302,39 @@ datumctl delete httpproxy <name>
 
 ---
 
+## Agent Skills
+
+Datum maintains a [skills repository](https://github.com/datum-cloud/skills) — self-contained instruction sets that teach coding agents (Claude Code, Codex, Cursor, and others) how to interact with Datum Cloud APIs and infrastructure primitives.
+
+### Installation
+
+**Claude Code (plugin marketplace):**
+\`\`\`
+/plugin marketplace add datum-cloud/skills
+\`\`\`
+
+**npx skills CLI:**
+\`\`\`bash
+npx skills add https://github.com/datum-cloud/skills
+\`\`\`
+
+**Cursor:** Add via remote rule settings (point to \`https://github.com/datum-cloud/skills\`).
+
+### Available Skills
+
+| Skill | Purpose |
+|-------|---------|
+| \`ai-edge\` | Manage WAF, authentication, authorization, rate limiting, and traffic policies (TrafficProtectionPolicy, SecurityPolicy, BackendTrafficPolicy) attached to Gateways and HTTPRoutes |
+| \`client-traffic\` | Configure how edge gateways accept client connections — TLS termination, mTLS, HTTP/2, HTTP/3, timeouts, connection limits, real IP detection |
+| \`dns\` | Manage DNS zones and record sets (A, AAAA, CNAME, MX, TXT, ALIAS, CAA, SRV, SVCB, HTTPS, TLSA, etc.) |
+| \`domains\` | Attach and verify domain resources within a project |
+| \`httproute\` | Define HTTP routing rules — path/header/method matching, traffic splitting (canary/A/B/blue-green), redirects, URL rewrites, header manipulation, traffic mirroring |
+| \`metrics-export\` | Configure metrics export pipelines to Grafana Cloud and other observability platforms via Prometheus remote write |
+
+Each skill follows a consistent pattern: list/describe existing resources, create from YAML, apply idempotently, preview before applying, delete safely, and check permissions before acting.
+
+---
+
 ## Further Reading
 
 - Full documentation index: https://www.datum.net/docs/llms.txt

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -2,7 +2,6 @@ import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
 import { site } from 'astro:config/client';
 import { extractDescription, buildUrl, stripHtml } from '@utils/llmsUtils';
-import { fetchStrapiArticles } from '@libs/strapi';
 
 // Note: handbook entries intentionally excluded — internal company ops content
 // is not relevant to AI agents consuming platform documentation.
@@ -34,27 +33,14 @@ export const GET: APIRoute = async () => {
       llmsContent += `- [${pageTitle}](${pageUrl}) - ${description}\n`;
     }
 
-    // Get all blog posts from Strapi sorted by date (newest first)
-    const strapiArticles = await fetchStrapiArticles();
-    const sortedPosts = strapiArticles.sort((a, b) => {
-      const dateA = a.originalPublishedAt ? new Date(a.originalPublishedAt).getTime() : 0;
-      const dateB = b.originalPublishedAt ? new Date(b.originalPublishedAt).getTime() : 0;
-      return dateB - dateA;
-    });
-
-    llmsContent += `\n## Blog\n\n`;
-
-    for (const post of sortedPosts.slice(0, 10)) {
-      const description = post.description || 'No description available';
-      const postUrl = buildUrl(post.slug, 'blog');
-      llmsContent += `- [${post.title}](${postUrl}) - ${description}\n`;
-    }
-
     llmsContent += `\n## Docs\n\n`;
     llmsContent += `- Full documentation index at ${siteUrl}/docs/llms.txt\n`;
 
     llmsContent += `\n## MCP\n\n`;
     llmsContent += `- [Datum Docs MCP](${siteUrl}/docs/mcp) - MCP server for AI agents to search and read Datum documentation (JSON-RPC 2.0 over SSE). Tools: \`search_datum_cloud_docs\`, \`query_docs_filesystem_datum_cloud_docs\`.\n`;
+
+    llmsContent += `\n## Skills\n\n`;
+    llmsContent += `- [Datum Cloud Skills](https://github.com/datum-cloud/skills) - Agent skills for working with Datum Cloud APIs and infrastructure primitives. Install via \`/plugin marketplace add datum-cloud/skills\` (Claude Code), \`npx skills add https://github.com/datum-cloud/skills\` (npx), or remote rule settings (Cursor). Available: ai-edge, client-traffic, dns, domains, httproute, metrics-export.\n`;
 
     llmsContent += `\n## Optional\n\n`;
     llmsContent += `- Full site content at ${siteUrl}/llms-full.txt\n`;


### PR DESCRIPTION
## Summary

- Adds a `## Skills` section to `llms.txt` pointing to [datum-cloud/skills](https://github.com/datum-cloud/skills) with all 3 install methods (Claude Code, npx, Cursor) and the 6 skill names
- Adds a full `## Agent Skills` section to `llms-full.txt` with installation instructions and a table of all 6 skills with descriptions
- Removes the `## Blog` section from `llms.txt` (and the now-unused `fetchStrapiArticles` import)

## Test plan

- [ ] Verify `datum.net/llms.txt` renders the new `## Skills` section with correct install commands
- [ ] Verify `datum.net/llms-full.txt` renders the `## Agent Skills` section with the full skills table
- [ ] Confirm blog section is gone from `llms.txt`
- [ ] Confirm no TypeScript/lint errors in CI