### PR TITLE
fix: resolve OAuth Protected Resource and OIDC discovery metadata (RFC 9728 / OIDC Discovery)

### DIFF
--- a/public/.well-known/oauth-protected-resource
+++ b/public/.well-known/oauth-protected-resource
@@ -1,11 +1,14 @@
 {
-  "resource": "https://api.datum.net",
+  "resource": "https://www.datum.net",
   "authorization_servers": [
     "https://auth.datum.net"
   ],
   "scopes_supported": [
     "openid",
     "profile",
-    "email"
+    "email",
+    "phone",
+    "address",
+    "offline_access"
   ]
 }

--- a/public/.well-known/openid-configuration
+++ b/public/.well-known/openid-configuration
@@ -2,18 +2,114 @@
   "issuer": "https://auth.datum.net",
   "authorization_endpoint": "https://auth.datum.net/oauth/v2/authorize",
   "token_endpoint": "https://auth.datum.net/oauth/v2/token",
+  "introspection_endpoint": "https://auth.datum.net/oauth/v2/introspect",
   "userinfo_endpoint": "https://auth.datum.net/oidc/v1/userinfo",
+  "revocation_endpoint": "https://auth.datum.net/oauth/v2/revoke",
   "end_session_endpoint": "https://auth.datum.net/oidc/v1/end_session",
+  "device_authorization_endpoint": "https://auth.datum.net/oauth/v2/device_authorization",
   "jwks_uri": "https://auth.datum.net/oauth/v2/keys",
-  "response_types_supported": ["code"],
-  "grant_types_supported": ["authorization_code", "refresh_token", "client_credentials"],
-  "subject_types_supported": ["public"],
-  "id_token_signing_alg_values_supported": ["RS256"],
-  "scopes_supported": ["openid", "profile", "email"],
+  "scopes_supported": [
+    "openid",
+    "profile",
+    "email",
+    "phone",
+    "address",
+    "offline_access"
+  ],
+  "response_types_supported": [
+    "code",
+    "id_token",
+    "id_token token"
+  ],
+  "response_modes_supported": [
+    "query",
+    "fragment",
+    "form_post"
+  ],
+  "grant_types_supported": [
+    "authorization_code",
+    "implicit",
+    "refresh_token",
+    "client_credentials",
+    "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    "urn:ietf:params:oauth:grant-type:device_code"
+  ],
+  "subject_types_supported": [
+    "public"
+  ],
+  "id_token_signing_alg_values_supported": [
+    "EdDSA",
+    "RS256",
+    "RS384",
+    "RS512",
+    "ES256",
+    "ES384",
+    "ES512"
+  ],
+  "request_object_signing_alg_values_supported": [
+    "RS256"
+  ],
   "token_endpoint_auth_methods_supported": [
+    "none",
     "client_secret_basic",
     "client_secret_post",
-    "none"
+    "private_key_jwt"
   ],
-  "code_challenge_methods_supported": ["S256"]
+  "token_endpoint_auth_signing_alg_values_supported": [
+    "RS256"
+  ],
+  "revocation_endpoint_auth_methods_supported": [
+    "none",
+    "client_secret_basic",
+    "client_secret_post",
+    "private_key_jwt"
+  ],
+  "revocation_endpoint_auth_signing_alg_values_supported": [
+    "RS256"
+  ],
+  "introspection_endpoint_auth_methods_supported": [
+    "client_secret_basic",
+    "private_key_jwt"
+  ],
+  "introspection_endpoint_auth_signing_alg_values_supported": [
+    "RS256"
+  ],
+  "claims_supported": [
+    "sub",
+    "aud",
+    "exp",
+    "iat",
+    "iss",
+    "auth_time",
+    "nonce",
+    "acr",
+    "amr",
+    "c_hash",
+    "at_hash",
+    "act",
+    "scopes",
+    "client_id",
+    "azp",
+    "preferred_username",
+    "name",
+    "family_name",
+    "given_name",
+    "locale",
+    "email",
+    "email_verified",
+    "phone_number",
+    "phone_number_verified"
+  ],
+  "code_challenge_methods_supported": [
+    "S256"
+  ],
+  "ui_locales_supported": [
+    "ar", "bg", "cs", "de", "en", "es", "fr", "hu", "id",
+    "it", "ja", "ko", "mk", "nl", "pl", "pt", "ro", "ru",
+    "sv", "tr", "uk", "zh"
+  ],
+  "request_parameter_supported": true,
+  "request_uri_parameter_supported": false,
+  "backchannel_logout_supported": true,
+  "backchannel_logout_session_supported": true
 }

--- a/server.mjs
+++ b/server.mjs
@@ -65,6 +65,8 @@ const AGENT_LINK_HEADERS = [
 const WELL_KNOWN_CONTENT_TYPES = {
   '/.well-known/api-catalog': 'application/linkset+json',
   '/.well-known/oauth-protected-resource': 'application/json',
+  '/.well-known/openid-configuration': 'application/json',
+  '/.well-known/oauth-authorization-server': 'application/json',
 };
 
 // Redirect configuration with Cache-Control: no-cache
@@ -161,9 +163,6 @@ const AUTH_TARGET = 'https://auth.datum.net';
 // Reverse proxy routes: requests matching prefix are forwarded to the target host.
 // Per Mintlify reverse-proxy docs: https://mintlify.com/docs/deploy/reverse-proxy
 const PROXY_ROUTES = [
-  // OAuth/OIDC discovery — proxy to the auth server so agents can discover auth endpoints
-  { prefix: '/.well-known/openid-configuration', target: AUTH_TARGET, cache: false },
-  { prefix: '/.well-known/oauth-authorization-server', target: AUTH_TARGET, cache: false },
   // Mintlify static assets — long-lived cache allowed
   { prefix: '/mintlify-assets/_next/static', target: MINTLIFY_TARGET, cache: true },
   // Core docs path


### PR DESCRIPTION
## Summary

Fixes two failing [isitagentready.com](https://isitagentready.com) checks that didn't end up fixed in #1279.

<img width="700" alt="agent-readiness-https---www-datum-net" src="https://github.com/user-attachments/assets/7bcace3e-ce37-4fe3-b7bb-22bf1f1dd85f" />


---

### Fix 1 — OAuth Protected Resource Metadata (RFC 9728)

**Check:** `checks.discovery.oauthProtectedResource`
**Was:** `fail` — _"origin mismatch"_

The `/.well-known/oauth-protected-resource` file was being served correctly (HTTP 200, `application/json`, `Access-Control-Allow-Origin: *`) but the scanner rejected it because the `resource` field was `https://api.datum.net`.

Per [RFC 9728 §3](https://www.rfc-editor.org/rfc/rfc9728#section-3), the `resource` value must be the identifier of the protected resource that *publishes* the metadata document — i.e. the origin being scanned. Scanners validate this as an origin match.

**Changes to `public/.well-known/oauth-protected-resource`:**
- `resource`: `https://api.datum.net` → `https://www.datum.net`
- `scopes_supported`: synced to full list from `auth.datum.net` (adds `phone`, `address`, `offline_access`)

---

### Fix 2 — OAuth/OIDC Discovery Metadata (OIDC Discovery / RFC 8414)

**Check:** `checks.discovery.oauthDiscovery`
**Was:** `fail` — _"openid-configuration returned 404"_

`/.well-known/openid-configuration` and `/.well-known/oauth-authorization-server` were in `PROXY_ROUTES` and forwarded to `auth.datum.net`. This broke because `handleProxy` passes `x-forwarded-host: www.datum.net` (the original request host), and Zitadel uses `x-forwarded-host` to identify its instance — so it couldn't match `www.datum.net` and returned:

```
unable to set instance using origin {website.prod.env.datum.net, auth.datum.net https}
```

The static files in `public/.well-known/` already existed from #1279 but were never reached because the proxy intercepted every request first.

**Changes to `server.mjs`:**
- Removed the two broken `AUTH_TARGET` proxy routes for `/.well-known/openid-configuration` and `/.well-known/oauth-authorization-server`
- Added both paths to `WELL_KNOWN_CONTENT_TYPES` so the existing static-file handler serves them with `Content-Type: application/json`, `Cache-Control: public, max-age=3600`, and `Access-Control-Allow-Origin: *` — identical to how `oauth-protected-resource` already works

**Changes to `public/.well-known/openid-configuration`:**
- Synced to the full metadata advertised by `auth.datum.net` (adds `introspection_endpoint`, `revocation_endpoint`, `device_authorization_endpoint`; full alg/auth-method/claims lists; backchannel logout flags)

---

### Verification (post-deploy)

```bash
curl -s -X POST https://isitagentready.com/api/scan \
  -H 'Content-Type: application/json' \
  -d '{"url": "https://www.datum.net"}' \
  | jq '.checks.discovery | {oauthProtectedResource: .oauthProtectedResource.status, oauthDiscovery: .oauthDiscovery.status}'
# expected: { "oauthProtectedResource": "pass", "oauthDiscovery": "pass" }
```