### PR TITLE
feat: add MaxMind minFraud device tracking script

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -117,6 +117,7 @@ const twitterImageUrl = toAbsoluteUrl(twitterImage?.src ?? imageContent.src);
     <link rel="dns-prefetch" href="https://api.github.com" />
     <link rel="dns-prefetch" href="https://hyperping.com" />
     <link rel="dns-prefetch" href="https://beacon-v2.helpscout.net" />
+    <link rel="dns-prefetch" href="https://device.maxmind.com" />
 
     <!-- Preconnect to critical external domains (loads within ~5s) -->
     <link rel="preconnect" href="https://cdn.usefathom.com" crossorigin />
@@ -364,6 +365,30 @@ const twitterImageUrl = toAbsoluteUrl(twitterImage?.src ?? imageContent.src);
           requestIdleCallback(loadMarker, { timeout: 4000 });
         } else {
           setTimeout(loadMarker, 3000);
+        }
+      })();
+    </script>
+
+    {/* MaxMind minFraud device tracking - feeds fingerprint into signup fraud check */}
+    <script is:inline data-production={isProduction ? 'true' : 'false'} data-account-id="1313245">
+      (function () {
+        var isProduction = document.currentScript.getAttribute('data-production') === 'true';
+        if (!isProduction) return;
+
+        var accountId = document.currentScript.getAttribute('data-account-id');
+        var mmapiws = (window.__mmapiws = window.__mmapiws || {});
+        mmapiws.accountId = accountId;
+
+        function loadMaxMind() {
+          var script = document.createElement('script');
+          script.src = 'https://device.maxmind.com/js/device.js';
+          script.async = true;
+          document.body.appendChild(script);
+        }
+        if ('requestIdleCallback' in window) {
+          requestIdleCallback(loadMaxMind, { timeout: 4000 });
+        } else {
+          setTimeout(loadMaxMind, 3000);
         }
       })();
     </script>

--- a/src/layouts/LayoutSimple.astro
+++ b/src/layouts/LayoutSimple.astro
@@ -42,6 +42,7 @@ const descriptionValue =
     <!-- DNS Prefetch for external domains (low priority hints) -->
     <link rel="dns-prefetch" href="https://api.github.com" />
     <link rel="dns-prefetch" href="https://beacon-v2.helpscout.net" />
+    <link rel="dns-prefetch" href="https://device.maxmind.com" />
 
     <!-- Preconnect to critical external domains (loads within ~5s) -->
     <link rel="preconnect" href="https://cdn.usefathom.com" crossorigin />
@@ -233,6 +234,30 @@ const descriptionValue =
           requestIdleCallback(loadMarker, { timeout: 4000 });
         } else {
           setTimeout(loadMarker, 3000);
+        }
+      })();
+    </script>
+
+    {/* MaxMind minFraud device tracking - feeds fingerprint into signup fraud check */}
+    <script is:inline data-production={isProduction ? 'true' : 'false'} data-account-id="1313245">
+      (function () {
+        var isProduction = document.currentScript.getAttribute('data-production') === 'true';
+        if (!isProduction) return;
+
+        var accountId = document.currentScript.getAttribute('data-account-id');
+        var mmapiws = (window.__mmapiws = window.__mmapiws || {});
+        mmapiws.accountId = accountId;
+
+        function loadMaxMind() {
+          var script = document.createElement('script');
+          script.src = 'https://device.maxmind.com/js/device.js';
+          script.async = true;
+          document.body.appendChild(script);
+        }
+        if ('requestIdleCallback' in window) {
+          requestIdleCallback(loadMaxMind, { timeout: 4000 });
+        } else {
+          setTimeout(loadMaxMind, 3000);
         }
       })();
     </script>


### PR DESCRIPTION
## Merge order (3 of 5)

Part of a cross-repo rollout enabling MaxMind device fingerprinting in the signup fraud check.

1. auth-provider-zitadel — [datum-cloud/zitadel-provider#109](https://github.com/datum-cloud/zitadel-provider/pull/109)
2. fraud — [datum-cloud/fraud#39](https://github.com/datum-cloud/fraud/pull/39)
3. **datum.net** (this PR) — marketing-site fingerprint coverage
4. auth-ui — [datum-cloud/auth-ui#77](https://github.com/datum-cloud/auth-ui/pull/77)
5. infra — [datum-cloud/infra#2412](https://github.com/datum-cloud/infra/pull/2412) — must merge last

Independent of the other PRs — safe to merge any time. Cookies are per-domain, so this just supplements the (required) collection on \`auth.datum.net\`.

---

## Summary

- Add MaxMind device.js snippet (account ID 1313245, production-only) to \`Layout.astro\` and \`LayoutSimple.astro\`, following the existing HelpScout/Marker.io deferred-load pattern.
- Add \`dns-prefetch\` for \`device.maxmind.com\` so the first MaxMind request resolves quickly.

The browser-collected token is read by \`auth-ui\` at signup and forwarded to the existing minFraud check server-side. Cookies are per-domain — this PR is the "marketing supplementary coverage" leg of the rollout; the strictly-required collection happens on \`auth.datum.net\`.

Reuses the same MaxMind account (\`1313245\`) already used by the fraud service, so browser fingerprints correlate with backend scores without extra config.

## Test plan

- [ ] Build site locally and confirm \`device.js\` request fires on \`Layout.astro\` and \`LayoutSimple.astro\` pages in a production build.
- [ ] Verify the \`__mmapiwsid\` cookie is set on \`.datum.net\` after page load.
- [ ] Confirm dev / preview builds do **not** contact MaxMind (production-gated).