### PR TITLE
chore: hide /hello route with 404

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -493,6 +493,30 @@ const server = createServer((req, res) => {
     };
   }
 
+  // Hidden/disabled routes — serve the Astro 404 page with a 404 status
+  if (url === '/hello' || url === '/hello/') {
+    const notFoundPath = join(CLIENT_DIR, '404.html');
+    if (existsSync(notFoundPath)) {
+      const stat = statSync(notFoundPath);
+      res.writeHead(404, {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'no-store',
+        'X-Robots-Tag': 'noindex, nofollow',
+        'Content-Length': stat.size,
+        Link: AGENT_LINK_HEADERS,
+      });
+      if (req.method === 'HEAD') {
+        res.end();
+      } else {
+        createReadStream(notFoundPath).pipe(res);
+      }
+      return;
+    }
+    res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Not Found');
+    return;
+  }
+
   // Health check endpoints for Kubernetes probes
   if (url === '/healthz' || url === '/livez' || url === '/readyz') {
     res.writeHead(200, { 'Content-Type': 'text/plain' });


### PR DESCRIPTION
## Summary
- Block `/hello` and `/hello/` at the server level by serving the Astro 404 page (`dist/client/404.html`) with a 404 status.
- Adds `X-Robots-Tag: noindex, nofollow` and `Cache-Control: no-store` on the response.
- Page source under `src/pages/hello.astro` and `src/components/hello/*` is intentionally preserved for future re-enablement.

## Test plan
- [ ] `curl -I https://www.datum.net/hello` returns `404` with `X-Robots-Tag: noindex, nofollow`
- [ ] `curl -I https://www.datum.net/hello/` returns `404`
- [ ] Response body is the styled Astro 404 page
- [ ] Other routes unaffected (spot-check `/`, `/about`, `/docs`)