### PR TITLE
fix: render roadmap directly without server defer

### DIFF
--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -1,5 +1,7 @@
 ---
 // src/pages/resources/roadmap.astro
+export const prerender = false;
+
 import '@v1/styles/page-roadmap.css';
 import { getCollectionEntry } from '@utils/collectionUtils';
 
@@ -7,7 +9,6 @@ import Layout from '@layouts/Layout.astro';
 import Hero from '@components/Hero.astro';
 import Footer from '@components/Footer.astro';
 import RoadmapStrapi from '@components/roadmap/RoadmapStrapi.astro';
-import RoadmapStrapiSkeleton from '@components/roadmap/RoadmapStrapiSkeleton.astro';
 
 const page = await getCollectionEntry('pages', 'roadmap');
 
@@ -23,9 +24,7 @@ const description = fm.description;
 
     <div class="section--block bg-glacier-mist-700 pt-0 pb-20">
       <div class="roadmap-container">
-        <RoadmapStrapi server:defer>
-          <RoadmapStrapiSkeleton slot="fallback" />
-        </RoadmapStrapi>
+        <RoadmapStrapi />
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Disable prerendering on `/roadmap`
- Remove `server:defer` and skeleton fallback so `RoadmapStrapi` renders inline

## Test plan
- [ ] Visit `/roadmap` and confirm content renders without skeleton flash
- [ ] Verify Strapi data loads correctly on first paint