### PR TITLE
chore: add June huddle recap details and normalize events URL

### DIFF
--- a/src/content/events/04-2026-boston-alt-cloud-meetup-april-2026/index.mdx
+++ b/src/content/events/04-2026-boston-alt-cloud-meetup-april-2026/index.mdx
@@ -16,7 +16,6 @@ geoAddress:
   fullAddress: Industrious, 131 Dartmouth St 3rd Floor, Boston, MA 02116, USA
 geoLatitude: 42.347041399999995
 geoLongitude: -71.0753582
-youtubeUrl: "https://www.youtube.com/watch?v=IiWFPgR2ygY"
 ---
 
 *   5:30pm - Doors open, drinks / mingling

--- a/src/content/events/04-2026-nyc-alt-cloud-meetup-april-2026/index.mdx
+++ b/src/content/events/04-2026-nyc-alt-cloud-meetup-april-2026/index.mdx
@@ -17,7 +17,6 @@ geoAddress:
   description: 10th Floor - Inspire Lounge
 geoLatitude: 40.7084525
 geoLongitude: -74.0107196
-youtubeUrl: "https://www.youtube.com/watch?v=IiWFPgR2ygY"
 ---
 
 *   5:00pm - Doors open, drinks, mingling

--- a/src/content/events/05-2026-boston-alt-cloud-meetup-may-2026/index.mdx
+++ b/src/content/events/05-2026-boston-alt-cloud-meetup-may-2026/index.mdx
@@ -9,7 +9,6 @@ eventType: alt-cloud-meetup
 coverImage: ./cover.png
 geoAddress:
   address: TBD - Boston
-youtubeUrl: "https://www.youtube.com/watch?v=IiWFPgR2ygY"
 ---
 
 *   5:30pm - Doors open, drinks, mingling

--- a/src/content/events/05-2026-may-datum-monthly-community-huddle/index.mdx
+++ b/src/content/events/05-2026-may-datum-monthly-community-huddle/index.mdx
@@ -9,6 +9,7 @@ eventType: community-huddle
 coverImage: ./cover.png
 meetingUrl: "https://us06web.zoom.us/j/82253289187?pwd=HvB2ZgSeIXofKW2pbheYCYFclvnu5b.1"
 zoomMeetingUrl: "https://us06web.zoom.us/j/82253289187?pwd=HvB2ZgSeIXofKW2pbheYCYFclvnu5b.1"
+youtubeUrl: "https://youtu.be/WLEzo6_wWnw"
 ---
 
 - Release 1.4 Recap (Thuerk)

--- a/src/content/events/05-2026-nyc-alt-cloud-meetup-may-2026/index.mdx
+++ b/src/content/events/05-2026-nyc-alt-cloud-meetup-may-2026/index.mdx
@@ -17,7 +17,6 @@ geoAddress:
   description: 10th Floor - Inspire Lounge
 geoLatitude: 40.7084525
 geoLongitude: -74.0107196
-youtubeUrl: "https://www.youtube.com/watch?v=IiWFPgR2ygY"
 ---
 
 *   6:00pm - Tony Perez "Big Iron, Tiny Fish"

--- a/src/content/events/06-2026-june-datum-monthly-community-huddle/index.mdx
+++ b/src/content/events/06-2026-june-datum-monthly-community-huddle/index.mdx
@@ -9,6 +9,9 @@ eventType: community-huddle
 coverImage: ./cover.png
 meetingUrl: "https://us06web.zoom.us/j/81882732147?pwd=TOsMxTvZrJJgNjTQIucbyT8qrg1Fyd.1"
 zoomMeetingUrl: "https://us06web.zoom.us/j/81882732147?pwd=TOsMxTvZrJJgNjTQIucbyT8qrg1Fyd.1"
+youtubeUrl: "https://youtu.be/WLEzo6_wWnw"
 ---
 
-* To be announced
+- Release 1.5 Recap (TimBL)
+- Release 1.6 Preview (Katherine)
+- Demos!

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -25,7 +25,7 @@ const jsonLd = {
     {
       '@type': 'WebPage',
       '@id': 'https://www.datum.net/events/#webpage',
-      url: 'https://www.datum.net/events/',
+      url: 'https://www.datum.net/events',
       name: 'Datum Events – Meetups, Conferences & Community Gatherings',
       description:
         'Datum holds regular community events throughout the US and online, covering Datum Cloud, alternative cloud infrastructure, and AI-native networking technologies.',
@@ -44,7 +44,7 @@ const jsonLd = {
       location: [
         {
           '@type': 'VirtualLocation',
-          url: 'https://www.datum.net/events/',
+          url: 'https://www.datum.net/events',
         },
         {
           '@type': 'Place',
@@ -72,7 +72,7 @@ const jsonLd = {
         ariaLabel="Event categories"
         mobileLabel="Event category"
         items={[
-          { label: 'All events', href: '/events/', exact: true },
+          { label: 'All events', href: '/events', exact: true },
           { label: 'Community Huddles', href: '/events/community-huddles' },
           { label: 'Alt Cloud Meetups', href: '/events/alt-cloud-meetups' },
         ]}


### PR DESCRIPTION
## Summary
- Add YouTube recording URL and agenda recap (1.5 recap, 1.6 preview, demos) to the June 2026 Community Huddle event
- Normalize `/events/` → `/events` in events index JSON-LD and nav link

## Test plan
- [ ] Verify June huddle event page renders YouTube link and agenda
- [ ] Verify events index page loads and "All events" tab links to `/events`