### PR TITLE
fix(roadmap): apply gap between title and description in previous variant

### DIFF
--- a/src/components/roadmap/RoadmapRow.astro
+++ b/src/components/roadmap/RoadmapRow.astro
@@ -21,12 +21,7 @@ const summaryHtml = showSummary ? marked.parse(roadmap.summary as string) : '';
     <span class="roadmap-month--text">{getMonthAbbreviation(roadmap.releaseDate)}</span>
   </div>
   <a href={roadmap.githubUrl} target="_blank" rel="noopener noreferrer" class="roadmap-content">
-    <div
-      class:list={[
-        'roadmap-content--text',
-        variant === 'upcoming' && 'roadmap-content--text--upcoming',
-      ]}
-    >
+    <div class="roadmap-content--text">
       <h3 class="roadmap-content--title">{roadmap.title}</h3>
       {roadmap.description && <p class="roadmap-content--description">{roadmap.description}</p>}
       {showSummary && <div class="roadmap-content--summary" set:html={summaryHtml} />}

--- a/src/v1/styles/components-roadmap.css
+++ b/src/v1/styles/components-roadmap.css
@@ -47,27 +47,15 @@
   }
 
   .roadmap-content--text {
-    @apply text-midnight-fjord flex w-full flex-1 flex-col items-start gap-0 lg:w-full lg:flex-initial;
-  }
-
-  .roadmap-content--text--upcoming {
-    @apply gap-4;
-
-    .roadmap-content--title {
-      @apply font-semibold;
-    }
-
-    .roadmap-content--description {
-      @apply datum-text-sm;
-    }
+    @apply text-midnight-fjord flex w-full flex-1 flex-col items-start gap-4 lg:w-full lg:flex-initial;
   }
 
   .roadmap-content--title {
-    @apply font-alliance datum-text-xl w-full;
+    @apply font-alliance datum-text-xl w-full font-semibold;
   }
 
   .roadmap-content--description {
-    @apply font-alliance datum-text-base w-full opacity-60;
+    @apply font-alliance datum-text-sm w-full opacity-60;
   }
 
   .roadmap-content--summary {


### PR DESCRIPTION
## Summary
- Changed base `.roadmap-content--text` from `gap-0` to `gap-4` so the `previous` variant matches the spacing already present in the `upcoming` variant.

## Test plan
- [ ] Visually verify the roadmap page: previous-variant rows now have spacing between title and description matching upcoming rows.
- [ ] Confirm no regression in upcoming-variant spacing.