### PR TITLE
feat(chat): replace HelpScout Beacon with Plain widget

### DIFF
--- a/src/components/LayoutEmbedScripts.astro
+++ b/src/components/LayoutEmbedScripts.astro
@@ -1,6 +1,6 @@
 ---
 // src/components/LayoutEmbedScripts.astro
-/** Third-party embed loaders: Fathom events, HelpScout, Hyperping, Marker.io, MaxMind, WebMCP. */
+/** Third-party embed loaders: Fathom events, Plain, Hyperping, Marker.io, MaxMind, WebMCP. */
 
 interface LayoutEmbedScriptsProps {
   isProduction: boolean;
@@ -19,17 +19,17 @@ const { isProduction } = Astro.props as LayoutEmbedScriptsProps;
   });
 </script>
 
-{/* HelpScout Beacon open trigger handler */}
+{/* Plain chat open trigger handler */}
 <script>
   document.addEventListener('DOMContentLoaded', function () {
-    const beaconTriggers = document.querySelectorAll('.open-beacon');
-    beaconTriggers.forEach((trigger) => {
+    const chatTriggers = document.querySelectorAll('.open-plain-chat');
+    chatTriggers.forEach((trigger) => {
       trigger.addEventListener('click', function (e) {
         e.preventDefault();
-        // @ts-expect-error Beacon is loaded from HelpScout script
-        if (window.Beacon) {
-          // @ts-expect-error Beacon is loaded from HelpScout script
-          window.Beacon('open');
+        // @ts-expect-error Plain is loaded from chat.cdn-plain.com script
+        if (window.Plain) {
+          // @ts-expect-error Plain is loaded from chat.cdn-plain.com script
+          window.Plain.open();
         }
       });
     });
@@ -77,37 +77,29 @@ const { isProduction } = Astro.props as LayoutEmbedScriptsProps;
   })();
 </script>
 
-{/* HelpScout Beacon - Deferred loading on idle */}
+{/* Plain chat widget - Deferred loading on first interaction or 5s timeout */}
 <script is:inline data-production={isProduction ? 'true' : 'false'}>
   (function () {
     var isProduction = document.currentScript.getAttribute('data-production') === 'true';
     if (!isProduction) return;
 
-    function loadHelpScout() {
-      if (window.__helpScoutLoaded) return;
-      window.__helpScoutLoaded = true;
+    function loadPlain() {
+      if (window.__plainLoaded) return;
+      window.__plainLoaded = true;
 
-      // Initialize Beacon stub
-      window.Beacon =
-        window.Beacon ||
-        function (method, options, data) {
-          window.Beacon.readyQueue = window.Beacon.readyQueue || [];
-          window.Beacon.readyQueue.push({ method: method, options: options, data: data });
-        };
-      window.Beacon.readyQueue = [];
-
-      // Load HelpScout script
       var script = document.createElement('script');
-      script.type = 'text/javascript';
-      script.async = true;
-      script.src = 'https://beacon-v2.helpscout.net';
+      script.async = false;
+      script.src = 'https://chat.cdn-plain.com/index.js';
       script.onload = function () {
-        window.Beacon('init', '57a7245e-772c-4d51-bdb1-6b898f34f2cb');
+        if (window.Plain) {
+          window.Plain.init({
+            appId: 'liveChatApp_01KRXXHP8PFCMFR1AWJ7QHCXNS',
+          });
+        }
       };
-      document.body.appendChild(script);
+      document.head.appendChild(script);
     }
 
-    // Load HelpScout on first user interaction or after 5s
     var events = ['mousemove', 'touchstart', 'scroll', 'keydown'];
     var loaded = false;
 
@@ -117,18 +109,17 @@ const { isProduction } = Astro.props as LayoutEmbedScriptsProps;
       events.forEach(function (e) {
         document.removeEventListener(e, onInteraction);
       });
-      loadHelpScout();
+      loadPlain();
     }
 
     events.forEach(function (e) {
       document.addEventListener(e, onInteraction, { once: true, passive: true });
     });
 
-    // Fallback: load after 5 seconds if no interaction
     setTimeout(function () {
       if (!loaded) {
         loaded = true;
-        loadHelpScout();
+        loadPlain();
       }
     }, 5000);
   })();

--- a/src/content/pages/contact.mdx
+++ b/src/content/pages/contact.mdx
@@ -12,4 +12,4 @@ meta:
     image: "./../images/og/contact.png"
 ---
 
-Grow your skills, your revenue, and your ecosystem advantage with Datum's open network cloud. If you're looking for help, please surf on over to our <a href="https://link.datum.net/discord" target="_blank">Discord channel</a> or submit a ticket to <a href="" class="open-beacon">our support team.</a>
+Grow your skills, your revenue, and your ecosystem advantage with Datum's open network cloud. If you're looking for help, please surf on over to our <a href="https://link.datum.net/discord" target="_blank">Discord channel</a> or submit a ticket to <a href="" class="open-plain-chat">our support team.</a>

--- a/src/content/pages/download.mdx
+++ b/src/content/pages/download.mdx
@@ -7,4 +7,4 @@ meta:
   description: "Tools to help you unlock internet superpowers with Datum"
 ---
 
-Grow your skills, your revenue, and your ecosystem advantage with Datum's open network cloud. If you're looking for help, please surf on over to our <a href="https://link.datum.net/discord" target="_blank">Discord channel</a> or submit a ticket to <a href="" class="open-beacon">our support team.</a>
+Grow your skills, your revenue, and your ecosystem advantage with Datum's open network cloud. If you're looking for help, please surf on over to our <a href="https://link.datum.net/discord" target="_blank">Discord channel</a> or submit a ticket to <a href="" class="open-plain-chat">our support team.</a>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -60,7 +60,7 @@ const twitterImageUrl = toAbsoluteUrl(twitterImage?.src ?? imageContent.src);
     <!-- DNS Prefetch for external domains (low priority hints) -->
     <link rel="dns-prefetch" href="https://api.github.com" />
     <link rel="dns-prefetch" href="https://hyperping.com" />
-    <link rel="dns-prefetch" href="https://beacon-v2.helpscout.net" />
+    <link rel="dns-prefetch" href="https://chat.cdn-plain.com" />
     <link rel="dns-prefetch" href="https://device.maxmind.com" />
 
     <!-- Preconnect to critical external domains (loads within ~5s) -->

--- a/src/layouts/LayoutMinimal.astro
+++ b/src/layouts/LayoutMinimal.astro
@@ -57,7 +57,7 @@ const twitterImageUrl = toAbsoluteUrl(twitterImage?.src ?? imageContent.src);
 
     <link rel="dns-prefetch" href="https://api.github.com" />
     <link rel="dns-prefetch" href="https://hyperping.com" />
-    <link rel="dns-prefetch" href="https://beacon-v2.helpscout.net" />
+    <link rel="dns-prefetch" href="https://chat.cdn-plain.com" />
 
     <link rel="preconnect" href="https://cdn.usefathom.com" crossorigin />
     <link rel="preconnect" href="https://edge.marker.io" crossorigin />

--- a/src/layouts/LayoutSimple.astro
+++ b/src/layouts/LayoutSimple.astro
@@ -45,7 +45,7 @@ const descriptionValue =
 
     <!-- DNS Prefetch for external domains (low priority hints) -->
     <link rel="dns-prefetch" href="https://api.github.com" />
-    <link rel="dns-prefetch" href="https://beacon-v2.helpscout.net" />
+    <link rel="dns-prefetch" href="https://chat.cdn-plain.com" />
     <link rel="dns-prefetch" href="https://device.maxmind.com" />
 
     <!-- Preconnect to critical external domains (loads within ~5s) -->


### PR DESCRIPTION
## Summary

- Swap the HelpScout Beacon live-chat loader for Plain (`chat.cdn-plain.com/index.js`) using the chat ID provided in #1316.
- Rename the legacy `.open-beacon` trigger class to `.open-plain-chat` on the `/contact` and `/download` pages; click handler now calls `Plain.open()`.
- Update DNS-prefetch hints in `Layout.astro`, `LayoutMinimal.astro`, `LayoutSimple.astro` from `beacon-v2.helpscout.net` to `chat.cdn-plain.com`.
- Preserve the existing deferred-load pattern (first user interaction or 5s timeout) so the widget does not block initial render. Production-only gate is unchanged.

Closes #1316

## Test plan

- [ ] `npm run lint` — green
- [ ] `npm run typecheck` — green
- [ ] `npm run build` — succeeds
- [ ] `NODE_ENV=production npm run preview` → visit any page → Plain chat bubble appears after ~5s or on first interaction
- [ ] DevTools Network: `chat.cdn-plain.com/index.js` loads; no requests to `beacon-v2.helpscout.net`
- [ ] Visit `/contact` and `/download` → clicking "our support team" opens the Plain chat widget
- [ ] No console errors