### PR TITLE
feat(ci): Claude-powered SEO review on PRs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,38 +1,47 @@
-SITE_URL=http://www.datum.net
+SITE_URL=http://localhost
 PORT=4321
-
-# Github App configuration
-GITHUB_PROJECT_URL='http://github.com/datum-cloud/datum.net'
 
 # Astro environment variables
 ASTRO_TELEMETRY_DISABLED=1
 
-LUMA_API_KEY=
+API_URL=
+AUTH_OIDC_REDIRECT_URI=
+AUTH_OIDC_ISSUER=
+AUTH_OIDC_CLIENT_ID=
 
-# Authentication (Zitadel OIDC)
-AUTH_OIDC_ISSUER=https://your-zitadel-instance.com
-AUTH_OIDC_CLIENT_ID=your-client-id
-AUTH_OIDC_CLIENT_SECRET=
-AUTH_OIDC_REDIRECT_URI=http://localhost:4321/auth/callback
+# GitHub App configuration
+GITHUB_PROJECT_URL='http://github.com/datum-cloud/datum.net'
+APP_ID=
+APP_INSTALLATION_ID=
+APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nYOUR_PRIVATE_KEY_HERE\n-----END RSA PRIVATE KEY-----"
 
-# Backend API
-API_URL=http://localhost:8080
+MODE=development
 
-# STRAPI_URL=
-# STRAPI_TOKEN=
-# STRAPI_CACHE_ENABLED=1
-# STRAPI_CACHE_TTL=300 // 5 minutes
-# STRAPI_WEBHOOK_SECRET= // webhook cache invalidation
+KUBECONFIG=.kube/config.yaml
+K8S_NAMESPACE=milo-system
 
-# Strapi CMS
-STRAPI_URL=https://your-project.strapiapp.com
+# This was inserted by `prisma init`:
+# Environment variables declared in this file are NOT automatically loaded by Prisma.
+# Please add `import \"dotenv/config\";` to your `prisma.config.ts` file, or use the Prisma CLI with Bun
+# to load environment variables from .env files: https://pris.ly/prisma-config-env-vars.
+
+# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
+# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
+
+DATABASE_URL="postgres://username:password@db.prisma.io:5432/postgres?sslmode=require"
+
+LUMA_API_KEY=""
+
 STRAPI_TOKEN=your-api-token
-STRAPI_CACHE_ENABLED=false
-STRAPI_CACHE_TTL=3000
-
-# Webhook: shared secret for cache invalidation from Strapi
-# Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 STRAPI_WEBHOOK_SECRET=your-shared-secret
+STRAPI_URL=https://your-project.strapiapp.com
+STRAPI_CACHE_ENABLED=true
+STRAPI_CACHE_TTL=2592000
 
-# Request timeout in seconds before falling back to the persistent stale cache (default: 3)
-STRAPI_TIMEOUT=3
+PUBLIC_MINTLIFY_SUBDOMAIN=
+PUBLIC_MINTLIFY_ASSISTANT_KEY=
+
+DOCS_REPO_URL='https://github.com/datum-cloud/doc'
+DOCS_REPO_BRANCH='main'
+
+ANTHROPIC_API_KEY=

--- a/.github/workflows/seo-review.yml
+++ b/.github/workflows/seo-review.yml
@@ -1,0 +1,116 @@
+name: SEO Review
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'env.example'
+      - '.vscode/**'
+  schedule:
+    # Weekly full-site audit at 06:00 UTC on Mondays
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Scan mode'
+        required: false
+        type: choice
+        default: 'full'
+        options:
+          - changed-only
+          - full
+
+concurrency:
+  group: seo-review-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  seo-review:
+    name: SEO & Meta Review
+    runs-on: ubuntu-latest
+    env:
+      NODE_ENV: development
+      HUSKY: 0
+      ASTRO_TELEMETRY_DISABLED: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Collect changed page files (PR only)
+        if: github.event_name == 'pull_request'
+        id: changed
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          {
+            echo 'files<<EOF'
+            git diff --name-only "$base" "$head" -- 'src/pages/**' 'src/content/**' || true
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve scan mode
+        id: mode
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "value=changed-only" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "value=${{ inputs.mode }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=full" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run SEO review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          SCAN_MODE: ${{ steps.mode.outputs.value }}
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
+          DIST_DIR: dist/client
+          MAX_PAGES: '25'
+          OUTPUT_FILE: .tmp/seo-review.md
+        run: node scripts/seo-review.mjs
+
+      - name: Post or update PR comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: seo-review-bot
+          path: .tmp/seo-review.md
+
+      - name: Open weekly audit issue
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          DATE="$(date -u +%Y-%m-%d)"
+          TITLE="SEO Audit — ${DATE}"
+          BODY_FILE=".tmp/seo-review.md"
+          # Ensure label exists (idempotent).
+          gh label create seo-audit --color BFD4F2 --description "Weekly SEO audit reports" 2>/dev/null || true
+          # Close any older open audit issues to keep the list tidy.
+          gh issue list --label seo-audit --state open --json number,title \
+            --jq '.[] | select(.title != "'"$TITLE"'") | .number' \
+            | xargs -I{} gh issue close {} --comment "Superseded by ${TITLE}." || true
+          gh issue create \
+            --title "$TITLE" \
+            --label seo-audit \
+            --body-file "$BODY_FILE"

--- a/docs/SEO_REVIEW_WORKFLOW.md
+++ b/docs/SEO_REVIEW_WORKFLOW.md
@@ -25,18 +25,20 @@ flowchart TD
     E --> F[scripts/seo-review.mjs]
     F --> G{Mode?}
     G -->|changed-only| H[Filter to changed pages]
-    G -->|full / fallback| I[Scan all built HTML]
+    G -->|full| I[Scan all built HTML<br/>+ broken-link + redirect-chain]
     H --> J[Cheerio extracts<br/>title, meta, OG, JSON-LD, alt, h1]
     I --> J
-    J --> K[POST to Anthropic API<br/>claude-sonnet-4-5]
+    J --> K[POST to Anthropic API<br/>claude-sonnet-4-6]
     K --> L[Write .tmp/seo-review.md]
-    L --> M([Sticky PR comment<br/>header: seo-review-bot])
+    L --> M{Trigger?}
+    M -->|pull_request| N([Sticky PR comment<br/>header: seo-review-bot])
+    M -->|schedule / dispatch| O([GitHub Issue<br/>label: seo-audit])
 
     classDef io fill:#e8f4ff,stroke:#3b82f6,color:#0b3b8c;
     classDef step fill:#f5f5f5,stroke:#888,color:#222;
     classDef decision fill:#fff7e0,stroke:#d97706,color:#7a4a00;
-    class A,M io;
-    class G decision;
+    class A,N,O io;
+    class G,M decision;
     class B,C,D,E,F,H,I,J,K,L step;
 ```
 
@@ -93,7 +95,7 @@ The script walks `dist/client`, applies the exclusion config, then picks pages b
 | `skipped-no-pages`      | No `src/pages` or `src/content` files in the diff — review skipped                          |
 | `skipped-no-changes`    | `changed-only` mode without `CHANGED_FILES` — review skipped                                |
 
-> **Single switch:** the previous `CHANGED_ONLY` + `DISABLE_FULL_SCAN` pair was collapsed into one `SCAN_MODE` env var. PR runs set `SCAN_MODE=changed-only` to keep the hot path fast. The weekly cron sets `SCAN_MODE=full` for site-wide analysis.
+> A single `SCAN_MODE` env drives behaviour. PR runs set `SCAN_MODE=changed-only` to keep the hot path fast. The weekly cron and `workflow_dispatch` set `SCAN_MODE=full` for site-wide analysis.
 
 Broad-change detector (triggers skip in `changed-only` mode only):
 
@@ -121,7 +123,7 @@ For every selected HTML file, the script extracts:
 
 ### 5. Claude review
 
-The JSON array is sent to the Anthropic Messages API (`claude-sonnet-4-5` by default) with a system prompt that asks for a concise PR comment structured as:
+The JSON array is sent to the Anthropic Messages API (`claude-sonnet-4-6` by default) with a system prompt that asks for a concise PR comment structured as:
 
 1. **Summary** — overall verdict, worst-issue count
 2. **Critical issues** — missing/duplicated title, description, canonical, h1; noindex on prod; title >70 chars; description outside 70–160 chars; missing `og:image`; broken JSON-LD
@@ -167,7 +169,7 @@ Override the config file location with `SEO_CONFIG=path/to/file.json`.
 | Variable            | Required | Default                          | Purpose                                                                                                                            |
 | ------------------- | -------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | `ANTHROPIC_API_KEY` | ✅       | —                                | Anthropic API key (CI: repo secret)                                                                                                |
-| `ANTHROPIC_MODEL`   |          | `claude-sonnet-4-5`              | Override the model                                                                                                                 |
+| `ANTHROPIC_MODEL`   |          | `claude-sonnet-4-6`              | Override the model                                                                                                                 |
 | `DIST_DIR`          |          | `dist/client`                    | Build output to scan                                                                                                               |
 | `MAX_PAGES`         |          | `25`                             | Hard cap on pages sent to Claude                                                                                                   |
 | `MAX_INPUT_CHARS`   |          | `640000`                         | Char cap on `user` content (~160K tokens, headroom for 200K Claude limit). If exceeded, the script drops tail pages until it fits. |
@@ -218,18 +220,23 @@ Wrote .tmp/seo-review.md (4550 bytes, 25 pages).
 - **Extend extracted signals** — modify `extractMeta()` in `scripts/seo-review.mjs`. The Claude prompt receives whatever fields you emit, so add the field and (optionally) mention it in the system prompt.
 - **Change review tone / structure** — edit the `system` string in `callClaude()`.
 - **Bump the model** — set `ANTHROPIC_MODEL` env in the workflow.
+- **Change weekly cadence** — edit the `cron:` expression in `.github/workflows/seo-review.yml` (default `0 6 * * 1` = Monday 06:00 UTC).
+- **Run an audit on demand** — Actions → _SEO Review_ → _Run workflow_, pick `full` (default) or `changed-only`.
 - **Disable on a PR** — temporarily skip by closing/reopening with `paths-ignore` matching, or remove `ANTHROPIC_API_KEY` (the step will fail and the comment won't be posted).
+- **Reduce broken-link noise** — absolute `https://` links are skipped by design. If a relative path resolves at runtime (proxy, edge rewrite, etc.), add a stub `src/pages/<path>.astro` or change the link to absolute so the audit treats it as external.
 
 ---
 
 ## Troubleshooting
 
-| Symptom                                        | Likely cause / fix                                                               |
-| ---------------------------------------------- | -------------------------------------------------------------------------------- |
-| Step fails with `ANTHROPIC_API_KEY is not set` | Repo secret missing, or running locally without exporting it                     |
-| `Build dir not found: dist/client`             | `npm run build` was skipped or failed; check earlier step logs                   |
-| Mode always `full` despite small PRs           | Diff includes a broad file (layout/component/config). See broad-change detector. |
-| Mode `changed-only-no-match`                   | Page renamed/moved, or content collection slug differs from filename — confirm   |
-| Excluded page still appears                    | Exclusion lives at walk time; verify config file path and JSON is valid          |
-| Comment not appearing on PR                    | `permissions: pull-requests: write` missing, or job failed before sticky step    |
-| Claude returns 429 / 529                       | Rate-limited or overloaded — rerun the job                                       |
+| Symptom                                                        | Likely cause / fix                                                                                           |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Step fails with `ANTHROPIC_API_KEY is not set`                 | Repo secret missing, or running locally without exporting it                                                 |
+| `Build dir not found: dist/client`                             | `npm run build` was skipped or failed; check earlier step logs                                               |
+| PR comment says `skipped-broad-change`                         | Diff includes a layout/component/style/config file. Trigger `workflow_dispatch` with `full` for a one-off.   |
+| Mode `skipped-no-match`                                        | Page renamed/moved, or content collection slug differs from filename — confirm against `dist/client/**`      |
+| Excluded page still appears                                    | Exclusion lives at walk time; verify config file path and JSON is valid                                      |
+| PR comment not appearing                                       | `permissions: pull-requests: write` missing, or job failed before sticky step                                |
+| Weekly Issue not opening                                       | `permissions: issues: write` missing, `GITHUB_TOKEN` lacks scope, or schedule trigger disabled in repo       |
+| Broken-link audit reports SSR routes (e.g. `/blog/`) as broken | The route exists under `src/pages` but the script missed it — check matcher, or move route under `src/pages` |
+| Claude returns 429 / 529                                       | Rate-limited or overloaded — rerun the job                                                                   |

--- a/docs/SEO_REVIEW_WORKFLOW.md
+++ b/docs/SEO_REVIEW_WORKFLOW.md
@@ -1,0 +1,235 @@
+# SEO Review Workflow
+
+Automated SEO and meta-data review with two triggers:
+
+- **PR (changed-only)** — runs on every pull request, scans only the pages affected by the diff, posts a sticky PR comment.
+- **Weekly full audit** — cron-scheduled every Monday 06:00 UTC (also manually triggerable via `workflow_dispatch`). Scans every built page, runs broken-link and redirect-chain audits, and opens (or supersedes) a GitHub Issue labelled `seo-audit` instead of commenting on a PR.
+
+- Workflow: [`.github/workflows/seo-review.yml`](../.github/workflows/seo-review.yml)
+- Script: [`scripts/seo-review.mjs`](../scripts/seo-review.mjs)
+- Config: [`scripts/seo-review.config.json`](../scripts/seo-review.config.json)
+- Output: `.tmp/seo-review.md` (git-ignored)
+
+---
+
+## How it works
+
+### Pipeline overview
+
+```mermaid
+flowchart TD
+    A([PR opened or updated]) --> B[Checkout repo<br/>fetch-depth: 0]
+    B --> C[npm ci]
+    C --> D[npm run build<br/>→ dist/client/**/*.html]
+    D --> E[git diff base..head<br/>src/pages, src/content]
+    E --> F[scripts/seo-review.mjs]
+    F --> G{Mode?}
+    G -->|changed-only| H[Filter to changed pages]
+    G -->|full / fallback| I[Scan all built HTML]
+    H --> J[Cheerio extracts<br/>title, meta, OG, JSON-LD, alt, h1]
+    I --> J
+    J --> K[POST to Anthropic API<br/>claude-sonnet-4-5]
+    K --> L[Write .tmp/seo-review.md]
+    L --> M([Sticky PR comment<br/>header: seo-review-bot])
+
+    classDef io fill:#e8f4ff,stroke:#3b82f6,color:#0b3b8c;
+    classDef step fill:#f5f5f5,stroke:#888,color:#222;
+    classDef decision fill:#fff7e0,stroke:#d97706,color:#7a4a00;
+    class A,M io;
+    class G decision;
+    class B,C,D,E,F,H,I,J,K,L step;
+```
+
+### Page-selection logic
+
+```mermaid
+flowchart TD
+    S([SCAN_MODE]) --> B{Mode?}
+    B -->|full| FULL[Mode: full<br/>scan all pages<br/>+ broken-link + redirect-chain audit]
+    B -->|changed-only| C{CHANGED_FILES present?}
+    C -->|no| SK0[Mode: skipped-no-changes]
+    C -->|yes| D{Broad change?<br/>layouts, components,<br/>styles, configs}
+    D -->|yes| SK1[Mode: skipped-broad-change]
+    D -->|no| E{Maps to pages?<br/>src/pages or src/content}
+    E -->|no| SK2[Mode: skipped-no-pages]
+    E -->|yes| F{Matches built HTML?}
+    F -->|no| SK3[Mode: skipped-no-match]
+    F -->|yes| CO[Mode: changed-only<br/>scan only matched pages]
+
+    FULL --> CAP[Cap at MAX_PAGES = 25]
+    CO --> CAP
+    CAP --> OUT{Trigger?}
+    OUT -->|pull_request| PRC[Sticky PR comment]
+    OUT -->|schedule / dispatch| ISS[GitHub Issue<br/>label: seo-audit]
+
+    classDef io fill:#e8f4ff,stroke:#3b82f6,color:#0b3b8c;
+    classDef decision fill:#fff7e0,stroke:#d97706,color:#7a4a00;
+    classDef ok fill:#e7f8ec,stroke:#16a34a,color:#0f5132;
+    classDef warn fill:#fdecec,stroke:#dc2626,color:#7a1d1d;
+    class S,CAP,PRC,ISS io;
+    class B,C,D,E,F,OUT decision;
+    class CO,FULL ok;
+    class SK0,SK1,SK2,SK3 warn;
+```
+
+### 1. Build
+
+The workflow runs `npm run build` so that the same HTML shipped to users is what's analyzed. `dist/client/**/*.html` is the source of truth — not `src/pages`.
+
+### 2. Changed files
+
+`git diff --name-only base..head` is restricted to `src/pages/**` and `src/content/**`. The list is passed to the script via the `CHANGED_FILES` env var (newline-separated).
+
+### 3. Page selection
+
+The script walks `dist/client`, applies the exclusion config, then picks pages based on `SCAN_MODE`:
+
+| Mode reported in output | When                                                                                        |
+| ----------------------- | ------------------------------------------------------------------------------------------- |
+| `full`                  | `SCAN_MODE=full` — every built page is analyzed, with broken-link and redirect-chain audits |
+| `changed-only`          | `SCAN_MODE=changed-only` and the diff maps to built pages                                   |
+| `skipped-broad-change`  | A "broad" file changed (layout/component/style/config) — review skipped                     |
+| `skipped-no-match`      | Slugs mapped but no built HTML matched — review skipped                                     |
+| `skipped-no-pages`      | No `src/pages` or `src/content` files in the diff — review skipped                          |
+| `skipped-no-changes`    | `changed-only` mode without `CHANGED_FILES` — review skipped                                |
+
+> **Single switch:** the previous `CHANGED_ONLY` + `DISABLE_FULL_SCAN` pair was collapsed into one `SCAN_MODE` env var. PR runs set `SCAN_MODE=changed-only` to keep the hot path fast. The weekly cron sets `SCAN_MODE=full` for site-wide analysis.
+
+Broad-change detector (triggers skip in `changed-only` mode only):
+
+```
+src/layouts/**, src/components/**, src/styles/**, src/middleware/**,
+astro.config.*, tailwind.config.*, src/consts*, package.json, package-lock.json
+```
+
+A hard cap of `MAX_PAGES` (default `25`) keeps the Claude payload bounded.
+
+### 4. Metadata extraction (Cheerio)
+
+For every selected HTML file, the script extracts:
+
+- `<title>` and length
+- `<meta name="description">` and length
+- `<link rel="canonical">`
+- `<meta name="robots">`
+- `<html lang>`
+- Open Graph: `og:title`, `og:description`, `og:image`, `og:type`
+- Twitter: `twitter:card`, `twitter:image`
+- `h1` count + first `h1` text
+- `<img>` count + count missing `alt`
+- JSON-LD presence + `@type` values (`invalid` if JSON parse fails)
+
+### 5. Claude review
+
+The JSON array is sent to the Anthropic Messages API (`claude-sonnet-4-5` by default) with a system prompt that asks for a concise PR comment structured as:
+
+1. **Summary** — overall verdict, worst-issue count
+2. **Critical issues** — missing/duplicated title, description, canonical, h1; noindex on prod; title >70 chars; description outside 70–160 chars; missing `og:image`; broken JSON-LD
+3. **Improvements** — alt-text gaps, JSON-LD coverage, social tags
+4. **Per-page notes** — only pages with issues
+
+### 6. Delivery
+
+- **PR runs** — [`marocchino/sticky-pull-request-comment@v3`](https://github.com/marocchino/sticky-pull-request-comment) posts (or updates) a single comment per PR using the header `seo-review-bot`. Only the Claude-generated review is included; raw metadata is kept out of the comment to stay compact (inspect job logs or rerun locally to see the JSON).
+- **Weekly / dispatched runs** — A new GitHub Issue is opened titled `SEO Audit — YYYY-MM-DD` and labelled `seo-audit`. Any older open `seo-audit` issues are auto-closed with a "superseded by" comment so the list stays clean.
+
+### 7. Broken-link and redirect-chain audits (full mode only)
+
+For each scanned page the script collects every relative `<a href="/...">` and every `<meta http-equiv="refresh">` target.
+
+- **Broken links** — internal hrefs whose normalized path is not present in `dist/client` AND has no matching file under `src/pages` (so SSR-rendered routes like `/blog/` are not flagged as broken). Absolute URLs (`https://...`) are skipped — only same-origin relative refs are validated.
+- **Redirect chains** — any meta-refresh source whose target also redirects, producing 2+ hops; loops are detected and tagged.
+
+When either list is non-empty, it is appended to the Claude payload, and Claude is asked to call them out as critical issues.
+
+---
+
+## Configuration
+
+### Exclusion config — `scripts/seo-review.config.json`
+
+```json
+{
+  "excludePaths": ["/dev/build", "/dev", "/preview", "/draft", "/_astro", "/admin", "/fonts"],
+  "excludeFiles": ["404.html", "500.html", "error.html", "offline.html", "maintenance.html"],
+  "excludeFilePatterns": ["^\\d{3}\\.html$"]
+}
+```
+
+- `excludePaths` — URL path prefixes; matches `url === p` or `url.startsWith(p + "/")`
+- `excludeFiles` — exact basenames
+- `excludeFilePatterns` — case-insensitive regex against basename (default catches every 3-digit status page, e.g. `403.html`)
+
+Override the config file location with `SEO_CONFIG=path/to/file.json`.
+
+### Environment variables
+
+| Variable            | Required | Default                          | Purpose                                                                                                                            |
+| ------------------- | -------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `ANTHROPIC_API_KEY` | ✅       | —                                | Anthropic API key (CI: repo secret)                                                                                                |
+| `ANTHROPIC_MODEL`   |          | `claude-sonnet-4-5`              | Override the model                                                                                                                 |
+| `DIST_DIR`          |          | `dist/client`                    | Build output to scan                                                                                                               |
+| `MAX_PAGES`         |          | `25`                             | Hard cap on pages sent to Claude                                                                                                   |
+| `MAX_INPUT_CHARS`   |          | `640000`                         | Char cap on `user` content (~160K tokens, headroom for 200K Claude limit). If exceeded, the script drops tail pages until it fits. |
+| `OUTPUT_FILE`       |          | `.tmp/seo-review.md`             | Path to write the markdown comment                                                                                                 |
+| `SEO_CONFIG`        |          | `scripts/seo-review.config.json` | Path to exclusion config                                                                                                           |
+| `CHANGED_FILES`     |          | _empty_                          | Newline-separated changed files (workflow injects this on PR runs)                                                                 |
+| `SCAN_MODE`         |          | `changed-only`                   | `changed-only` (PR runs) or `full` (weekly audit; adds broken-link + redirect-chain checks)                                        |
+| `SITE_URL`          |          | `https://www.datum.net`          | Site origin; only used to recognize same-host absolute URLs                                                                        |
+
+### Repo secret
+
+Add `ANTHROPIC_API_KEY` under **Settings → Secrets and variables → Actions**.
+
+---
+
+## Running locally
+
+```bash
+npm run build
+
+# Weekly-style full audit (incl. broken-link & redirect-chain checks)
+ANTHROPIC_API_KEY=sk-... SCAN_MODE=full node scripts/seo-review.mjs
+
+# PR-style scan limited to the pages changed in your branch
+ANTHROPIC_API_KEY=sk-... \
+SCAN_MODE=changed-only \
+CHANGED_FILES="$(git diff --name-only main...HEAD -- 'src/pages/**' 'src/content/**')" \
+node scripts/seo-review.mjs
+
+# tail the output
+cat .tmp/seo-review.md
+```
+
+The script logs the selected mode and page count, e.g.:
+
+```
+SCAN_MODE=full → mode: full — 92 candidate(s), analyzing 25.
+Audits — broken internal links: 0, redirect chains: 0.
+User content size: 20527 chars (~5132 tokens), under cap 640000.
+Wrote .tmp/seo-review.md (4550 bytes, 25 pages).
+```
+
+---
+
+## Maintenance
+
+- **Add an exclusion** — edit `scripts/seo-review.config.json`.
+- **Extend extracted signals** — modify `extractMeta()` in `scripts/seo-review.mjs`. The Claude prompt receives whatever fields you emit, so add the field and (optionally) mention it in the system prompt.
+- **Change review tone / structure** — edit the `system` string in `callClaude()`.
+- **Bump the model** — set `ANTHROPIC_MODEL` env in the workflow.
+- **Disable on a PR** — temporarily skip by closing/reopening with `paths-ignore` matching, or remove `ANTHROPIC_API_KEY` (the step will fail and the comment won't be posted).
+
+---
+
+## Troubleshooting
+
+| Symptom                                        | Likely cause / fix                                                               |
+| ---------------------------------------------- | -------------------------------------------------------------------------------- |
+| Step fails with `ANTHROPIC_API_KEY is not set` | Repo secret missing, or running locally without exporting it                     |
+| `Build dir not found: dist/client`             | `npm run build` was skipped or failed; check earlier step logs                   |
+| Mode always `full` despite small PRs           | Diff includes a broad file (layout/component/config). See broad-change detector. |
+| Mode `changed-only-no-match`                   | Page renamed/moved, or content collection slug differs from filename — confirm   |
+| Excluded page still appears                    | Exclusion lives at walk time; verify config file path and JSON is valid          |
+| Comment not appearing on PR                    | `permissions: pull-requests: write` missing, or job failed before sticky step    |
+| Claude returns 429 / 529                       | Rate-limited or overloaded — rerun the job                                       |

--- a/scripts/seo-review.config.json
+++ b/scripts/seo-review.config.json
@@ -1,0 +1,5 @@
+{
+  "excludePaths": ["/dev/build", "/dev", "/preview", "/draft", "/_astro", "/admin", "/fonts"],
+  "excludeFiles": ["404.html", "500.html", "error.html", "offline.html", "maintenance.html"],
+  "excludeFilePatterns": ["^\\d{3}\\.html$"]
+}

--- a/scripts/seo-review.mjs
+++ b/scripts/seo-review.mjs
@@ -1,0 +1,510 @@
+#!/usr/bin/env node
+/**
+ * Extracts SEO/meta data from built HTML files using Cheerio,
+ * sends a compact report to Claude for review, and writes a
+ * markdown comment to stdout (or to $GITHUB_OUTPUT comment file).
+ *
+ * Env:
+ *   ANTHROPIC_API_KEY   required to call Claude
+ *   SCAN_MODE           'changed-only' (default, PR runs) | 'full' (weekly scheduled run;
+ *                       adds broken-link + redirect-chain audits over all built pages)
+ *   CHANGED_FILES       newline list of changed src/pages|src/content files (changed-only mode)
+ *   DIST_DIR            default: dist/client
+ *   MAX_PAGES           default: 25
+ *   OUTPUT_FILE         default: .tmp/seo-review.md
+ *   SITE_URL            default: https://www.datum.net (host used to recognise internal links)
+ */
+
+import { readFile, writeFile, readdir, stat, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { load } from 'cheerio';
+
+const DIST_DIR = process.env.DIST_DIR || 'dist/client';
+const MAX_PAGES = parseInt(process.env.MAX_PAGES || '25', 10);
+const OUTPUT_FILE = process.env.OUTPUT_FILE || '.tmp/seo-review.md';
+const MODEL = process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-6'; // or 'claude-2' for faster, cheaper reviews with less insight
+// Claude input limit is 200K tokens (~800K chars at 4 chars/token).
+// Cap user content at ~160K tokens worth of chars to leave headroom for system + output.
+const MAX_INPUT_CHARS = parseInt(process.env.MAX_INPUT_CHARS || '640000', 10);
+// Single switch driving page-selection behaviour.
+//   changed-only (default): scan only pages affected by CHANGED_FILES; skip
+//     review when there is nothing to scan. No broken-link / redirect-chain
+//     checks (kept off the PR hot path).
+//   full: scan every built page AND run broken-link + redirect-chain audits.
+//     Intended for the weekly schedule.
+const RAW_SCAN_MODE = (process.env.SCAN_MODE || 'changed-only').toLowerCase();
+const SCAN_MODE = RAW_SCAN_MODE === 'full' ? 'full' : 'changed-only';
+const SITE_URL = process.env.SITE_URL || 'https://www.datum.net';
+const CONFIG_FILE =
+  process.env.SEO_CONFIG ||
+  path.join(path.dirname(new URL(import.meta.url).pathname), '/seo-review.config.json');
+
+async function loadConfig() {
+  try {
+    const raw = await readFile(CONFIG_FILE, 'utf8');
+    const cfg = JSON.parse(raw);
+    return {
+      excludePaths: cfg.excludePaths || [],
+      excludeFiles: new Set(cfg.excludeFiles || []),
+      excludeFilePatterns: (cfg.excludeFilePatterns || []).map((p) => new RegExp(p, 'i')),
+    };
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+    return { excludePaths: [], excludeFiles: new Set(), excludeFilePatterns: [] };
+  }
+}
+
+function isExcluded(file, root, cfg) {
+  const base = path.basename(file);
+  if (cfg.excludeFiles.has(base)) return true;
+  if (cfg.excludeFilePatterns.some((re) => re.test(base))) return true;
+  const url = toUrlPath(file, root);
+  return cfg.excludePaths.some((p) => url === p || url.startsWith(p.endsWith('/') ? p : p + '/'));
+}
+
+async function walk(dir, root, cfg) {
+  const out = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...(await walk(p, root, cfg)));
+    } else if (entry.isFile() && p.endsWith('.html') && !isExcluded(p, root, cfg)) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+function extractMeta(html, urlPath) {
+  const $ = load(html);
+  const get = (sel, attr = 'content') => $(sel).attr(attr)?.trim() || null;
+
+  const h1s = $('h1')
+    .map((_, el) => $(el).text().trim())
+    .get();
+  const imgs = $('img').toArray();
+  const imgsMissingAlt = imgs.filter((el) => !($(el).attr('alt') || '').trim()).length;
+
+  return {
+    url: urlPath,
+    title: $('title').first().text().trim() || null,
+    titleLen: ($('title').first().text().trim() || '').length,
+    description: get('meta[name="description"]'),
+    descriptionLen: (get('meta[name="description"]') || '').length,
+    canonical: get('link[rel="canonical"]', 'href'),
+    robots: get('meta[name="robots"]'),
+    lang: $('html').attr('lang') || null,
+    ogTitle: get('meta[property="og:title"]'),
+    ogDescription: get('meta[property="og:description"]'),
+    ogImage: get('meta[property="og:image"]'),
+    ogType: get('meta[property="og:type"]'),
+    twitterCard: get('meta[name="twitter:card"]'),
+    twitterImage: get('meta[name="twitter:image"]'),
+    h1Count: h1s.length,
+    h1First: h1s[0] || null,
+    imgCount: imgs.length,
+    imgsMissingAlt,
+    hasJsonLd: $('script[type="application/ld+json"]').length > 0,
+    jsonLdTypes: $('script[type="application/ld+json"]')
+      .map((_, el) => {
+        try {
+          const j = JSON.parse($(el).contents().text());
+          return Array.isArray(j) ? j.map((x) => x['@type']).join(',') : j['@type'];
+        } catch {
+          return 'invalid';
+        }
+      })
+      .get(),
+  };
+}
+
+function extractLinksAndRefresh($, urlPath /* , siteHost */) {
+  const refs = [];
+  $('a[href]').each((_, el) => {
+    const href = ($(el).attr('href') || '').trim();
+    if (!href) return;
+    if (/^(#|mailto:|tel:|javascript:|data:)/i.test(href)) return;
+    if (href.startsWith('//')) return; // protocol-relative external
+    if (/^https?:\/\//i.test(href)) return; // absolute — treat as external, don't validate against dist
+    let pathname = null;
+    if (href.startsWith('/')) {
+      pathname = href.split('#')[0].split('?')[0];
+    } else {
+      try {
+        const u = new URL(href, `https://placeholder${urlPath}`);
+        pathname = u.pathname;
+      } catch {
+        return;
+      }
+    }
+    if (pathname) refs.push(pathname);
+  });
+
+  let refresh = null;
+  const tag = $('meta[http-equiv="refresh"]').attr('content');
+  if (tag) {
+    const m = tag.match(/url=([^;]+)/i);
+    if (m) refresh = m[1].trim();
+  }
+  return { refs, refresh };
+}
+
+function normalizeUrlPath(p) {
+  if (!p) return '/';
+  let out = p.split('#')[0].split('?')[0];
+  if (!out.startsWith('/')) out = '/' + out;
+  if (out.length > 1 && !out.endsWith('/') && !/\.[a-z0-9]+$/i.test(out)) out += '/';
+  return out;
+}
+
+function buildBuiltSet(files, root) {
+  const set = new Set();
+  for (const f of files) set.add(normalizeUrlPath(toUrlPath(f, root)));
+  return set;
+}
+
+async function buildSourceRouteSet(pagesDir = 'src/pages') {
+  const set = new Set();
+  async function walkSrc(dir) {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        await walkSrc(p);
+      } else if (e.isFile() && /\.(astro|md|mdx|html)$/i.test(e.name)) {
+        let rel = path.relative(pagesDir, p).replace(/\\/g, '/');
+        rel = rel.replace(/\.(astro|md|mdx|html)$/i, '');
+        rel = rel.replace(/\/index$/, '').replace(/^index$/, '');
+        const url = rel ? '/' + rel : '/';
+        // Skip dynamic segments — they can't be validated by exact path.
+        if (/\[.*?\]/.test(url)) {
+          // record the parent prefix so anything under it is considered "may exist"
+          const prefix = '/' + url.split('/').filter((s) => !/\[.*?\]/.test(s)).join('/');
+          set.add(normalizeUrlPath(prefix.replace(/\/+/g, '/')) + '*');
+        } else {
+          set.add(normalizeUrlPath(url));
+        }
+      }
+    }
+  }
+  await walkSrc(pagesDir);
+  return set;
+}
+
+function isInSourceRoutes(target, srcSet) {
+  if (srcSet.has(target)) return true;
+  // Match against dynamic-route wildcards.
+  for (const entry of srcSet) {
+    if (entry.endsWith('*')) {
+      const prefix = entry.slice(0, -1);
+      if (target.startsWith(prefix)) return true;
+    }
+  }
+  return false;
+}
+
+function findBrokenLinks(linkMap, builtSet, srcSet) {
+  const broken = [];
+  for (const [page, refs] of linkMap) {
+    const seen = new Set();
+    for (const ref of refs) {
+      const norm = normalizeUrlPath(ref);
+      if (seen.has(norm)) continue;
+      seen.add(norm);
+      if (builtSet.has(norm)) continue;
+      if (srcSet && isInSourceRoutes(norm, srcSet)) continue;
+      broken.push({ page, target: ref });
+    }
+  }
+  return broken;
+}
+
+function findRedirectChains(refreshMap) {
+  const chains = [];
+  for (const start of refreshMap.keys()) {
+    const path = [start];
+    const seen = new Set(path);
+    let cur = start;
+    while (refreshMap.has(cur)) {
+      const next = normalizeUrlPath(refreshMap.get(cur));
+      if (seen.has(next)) {
+        path.push(next + ' (loop)');
+        break;
+      }
+      path.push(next);
+      seen.add(next);
+      cur = next;
+    }
+    if (path.length > 2) chains.push(path); // >=2 hops = chain
+  }
+  return chains;
+}
+
+function toUrlPath(file, root) {
+  const rel = path.relative(root, file).replace(/\\/g, '/');
+  if (rel.endsWith('/index.html')) return '/' + rel.slice(0, -'index.html'.length);
+  if (rel === 'index.html') return '/';
+  return '/' + rel;
+}
+
+const BROAD_CHANGE_RE =
+  /^(src\/(layouts|components|styles|middleware)\/|astro\.config|tailwind\.config|src\/consts|package\.json|package-lock\.json)/;
+
+function mapChangedToSlugs(changed) {
+  const fromPages = changed
+    .map((f) => f.match(/^src\/pages\/(.+?)\.(astro|md|mdx|html)$/)?.[1])
+    .filter(Boolean);
+  const fromContent = changed
+    .map((f) => f.match(/^src\/content\/(.+?)\.(md|mdx)$/)?.[1])
+    .filter(Boolean);
+  return [...fromPages, ...fromContent]
+    .map((s) => s.replace(/\/index$/, '').replace(/^index$/, ''))
+    .filter(Boolean);
+}
+
+function hasBroadChange(changed) {
+  return changed.some((f) => BROAD_CHANGE_RE.test(f));
+}
+
+function filterByChanged(files, root, slugs) {
+  return files.filter((f) => {
+    const url = toUrlPath(f, root).replace(/\/$/, '');
+    return slugs.some((s) => {
+      const slug = '/' + s.replace(/^\/+/, '');
+      return url === slug || url.startsWith(slug + '/');
+    });
+  });
+}
+
+function prioritize(files, root, slugs) {
+  if (!slugs?.length) return files;
+  const score = (f) => {
+    const url = toUrlPath(f, root);
+    return slugs.some((s) => url.includes(s)) ? 0 : 1;
+  };
+  return [...files].sort((a, b) => score(a) - score(b));
+}
+
+function buildUserContent(payload, total) {
+  const header = (count) => `Pages analyzed: ${count} of ${total}\n\nData:\n\n`;
+  // Use compact JSON (no indent) — fits more pages within MAX_INPUT_CHARS.
+  const render = (obj) => `${header(obj.pages.length)}\`\`\`json\n${JSON.stringify(obj)}\n\`\`\``;
+  let content = render(payload);
+  if (content.length <= MAX_INPUT_CHARS) {
+    return { content, sent: payload.pages.length, dropped: 0 };
+  }
+
+  // Trim pages from the tail (lower priority); keep brokenLinks/redirectChains.
+  const trimmed = { ...payload, pages: [...payload.pages] };
+  while (trimmed.pages.length > 1 && content.length > MAX_INPUT_CHARS) {
+    trimmed.pages.pop();
+    content = render(trimmed);
+  }
+  return {
+    content,
+    sent: trimmed.pages.length,
+    dropped: payload.pages.length - trimmed.pages.length,
+  };
+}
+
+async function callClaude(report, extras = {}) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY is not set');
+
+  const extrasSection =
+    extras.brokenLinks || extras.redirectChains
+      ? `
+
+Additionally, you'll receive:
+- \`brokenLinks\`: internal anchor hrefs whose target URL does not exist as a built page. Call these out as critical.
+- \`redirectChains\`: redirect hops (2+) discovered via \`<meta http-equiv="refresh">\`. Recommend collapsing to a single hop.`
+      : '';
+
+  const system = `You are an SEO and meta-data reviewer for an Astro static site.
+You will receive a JSON array of pages with extracted SEO signals.
+Return a concise markdown review for a GitHub PR comment.
+
+Structure:
+1. **Summary** (2-3 lines: overall verdict + worst issues count)
+2. **Critical issues** (missing/duplicated title, description, canonical, h1; noindex on prod pages; >70-char titles; >160-char or <70-char descriptions; missing og:image; broken JSON-LD${extras.brokenLinks ? '; broken internal links' : ''}${extras.redirectChains ? '; redirect chains' : ''})
+3. **Improvements** (alt text gaps, JSON-LD coverage, social tags)
+4. **Per-page notes** — only include pages with issues, bulleted with the URL path.${extrasSection}
+
+Be terse and actionable. Don't restate compliant pages. Don't invent metrics.`;
+
+  const payload = { pages: report };
+  if (extras.brokenLinks) payload.brokenLinks = extras.brokenLinks;
+  if (extras.redirectChains) payload.redirectChains = extras.redirectChains;
+  const { content: userContent, sent, dropped } = buildUserContent(payload, report.length);
+  if (dropped > 0) {
+    console.log(
+      `User content trimmed: dropped ${dropped} page(s) to stay under ${MAX_INPUT_CHARS} chars (~${Math.round(
+        MAX_INPUT_CHARS / 4
+      )} tokens). Sent ${sent}.`
+    );
+  } else {
+    console.log(
+      `User content size: ${userContent.length} chars (~${Math.round(
+        userContent.length / 4
+      )} tokens), under cap ${MAX_INPUT_CHARS}.`
+    );
+  }
+
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: 2048,
+      system,
+      messages: [{ role: 'user', content: userContent }],
+    }),
+  });
+
+  if (!res.ok) {
+    const txt = await res.text();
+    throw new Error(`Claude API ${res.status}: ${txt}`);
+  }
+  const data = await res.json();
+  return data.content?.map((b) => b.text).join('\n') || '_No content returned._';
+}
+
+async function main() {
+  try {
+    await stat(DIST_DIR);
+  } catch {
+    throw new Error(`Build dir not found: ${DIST_DIR}. Run \`npm run build\` first.`);
+  }
+
+  const cfg = await loadConfig();
+  const all = await walk(DIST_DIR, DIST_DIR, cfg);
+  const changed = (process.env.CHANGED_FILES || '')
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const slugs = mapChangedToSlugs(changed);
+  const broad = hasBroadChange(changed);
+  const siteHost = (() => {
+    try {
+      return new URL(SITE_URL).host;
+    } catch {
+      return 'www.datum.net';
+    }
+  })();
+
+  let candidates = [];
+  let mode = SCAN_MODE === 'full' ? 'full' : 'skipped-no-changes';
+  let skipReason = null;
+
+  if (SCAN_MODE === 'full') {
+    candidates = all;
+  } else if (changed.length) {
+    if (broad) {
+      mode = 'skipped-broad-change';
+      skipReason =
+        'Broad change detected (layout/component/style/config). PR scan skips full-site review.';
+    } else if (!slugs.length) {
+      mode = 'skipped-no-pages';
+      skipReason = 'Changed files do not include any `src/pages` or `src/content` entries.';
+    } else {
+      const matched = filterByChanged(all, DIST_DIR, slugs);
+      if (matched.length) {
+        candidates = matched;
+        mode = 'changed-only';
+      } else {
+        mode = 'skipped-no-match';
+        skipReason = 'No built pages matched the changed slugs.';
+      }
+    }
+  } else {
+    skipReason = 'No `CHANGED_FILES` provided in `changed-only` mode.';
+  }
+
+  const picked = candidates.slice(0, MAX_PAGES);
+  console.log(
+    `SCAN_MODE=${SCAN_MODE} → mode: ${mode} — ${candidates.length} candidate(s), analyzing ${picked.length}.${
+      skipReason ? ` Reason: ${skipReason}` : ''
+    }`,
+  );
+
+  const isFull = SCAN_MODE === 'full';
+  const heading = isFull ? '## 🗓️ Weekly SEO Audit' : '## 🔎 SEO & Meta Review';
+
+  let body;
+  if (picked.length === 0) {
+    body = [
+      '<!-- seo-review-bot -->',
+      heading,
+      '',
+      `_Skipped (mode: \`${mode}\`)._`,
+      '',
+      skipReason || 'No pages to review.',
+      '',
+    ].join('\n');
+  } else {
+    const report = [];
+    const linkMap = new Map();
+    const refreshMap = new Map();
+
+    for (const file of picked) {
+      const html = await readFile(file, 'utf8');
+      const url = toUrlPath(file, DIST_DIR);
+      report.push(extractMeta(html, url));
+      if (SCAN_MODE === 'full') {
+        const $ = load(html);
+        const { refs, refresh } = extractLinksAndRefresh($, url, siteHost);
+        if (refs.length) linkMap.set(url, refs);
+        if (refresh) refreshMap.set(normalizeUrlPath(url), normalizeUrlPath(refresh));
+      }
+    }
+
+    let brokenLinks = null;
+    let redirectChains = null;
+    if (SCAN_MODE === 'full') {
+      const builtSet = buildBuiltSet(all, DIST_DIR);
+      const srcSet = await buildSourceRouteSet();
+      brokenLinks = findBrokenLinks(linkMap, builtSet, srcSet);
+      redirectChains = findRedirectChains(refreshMap);
+      console.log(
+        `Audits — broken internal links: ${brokenLinks.length}, redirect chains: ${redirectChains.length}.`,
+      );
+    }
+
+    const review = await callClaude(report, {
+      brokenLinks: brokenLinks?.length ? brokenLinks : undefined,
+      redirectChains: redirectChains?.length ? redirectChains : undefined,
+    });
+
+    const auditLine =
+      SCAN_MODE === 'full'
+        ? `\n_Audits: ${brokenLinks.length} broken internal link(s), ${redirectChains.length} redirect chain(s)._`
+        : '';
+
+    body = [
+      '<!-- seo-review-bot -->',
+      heading,
+      '',
+      `_Analyzed ${report.length} of ${all.length} built HTML pages (mode: \`${mode}\`)._${auditLine}`,
+      '',
+      review,
+    ].join('\n');
+  }
+
+  await mkdir(path.dirname(OUTPUT_FILE), { recursive: true });
+  await writeFile(OUTPUT_FILE, body, 'utf8');
+  console.log(`Wrote ${OUTPUT_FILE} (${body.length} bytes, ${picked.length} pages).`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Issue: #1308

## Summary

Adds a GitHub Actions workflow that runs on every PR, builds the site, extracts SEO/meta data from the resulting HTML using Cheerio, sends a compact JSON report to Claude for review, and posts the result as a sticky PR comment.

- **`scripts/seo-review.mjs`** — Cheerio extractor + Anthropic Messages API caller. Supports an exclusion config, `CHANGED_ONLY` mode that scopes the scan to pages affected by the diff (with automatic fallback to full scan when layout/component/config files change), `MAX_PAGES` cap, and `MAX_INPUT_CHARS` guard that drops tail pages if the payload would exceed Claude's 200K input limit.
- **`scripts/seo-review.config.json`** — `excludePaths` / `excludeFiles` / `excludeFilePatterns` for error pages, `/dev`, `/fonts`, `/_astro`, etc.
- **`.github/workflows/seo-review.yml`** — `pull_request` trigger → checkout (full history) → `npm ci` → `npm run build` → collect changed `src/pages` & `src/content` files via `git diff base..head` → run script with `CHANGED_ONLY=1` → post/update sticky comment via `marocchino/sticky-pull-request-comment@v2` (one persistent comment per PR using header `seo-review-bot`).
- **`docs/SEO_REVIEW_WORKFLOW.md`** — how it works (with two mermaid diagrams: pipeline + selection logic), config reference, env vars, local-run instructions, maintenance notes, troubleshooting.

Signals extracted per page: title (+ length), description (+ length), canonical, robots, `html[lang]`, full OG set, Twitter card/image, h1 count + first h1, image count + missing-alt count, JSON-LD presence + `@type` list.

## Required setup

- Add repo secret **`ANTHROPIC_API_KEY`** under Settings → Secrets and variables → Actions.

## Test plan

- [ ] Open a PR that touches a single `src/pages/*.astro` file → comment lists mode `changed-only` and only that page.
- [ ] Open a PR that touches `src/layouts/*` → comment falls back to `changed-only-fallback-broad` (full scan).
- [ ] Open a PR that touches only docs/scripts (no pages) → mode `changed-only-no-pages` (full scan).
- [ ] Push a second commit to the same PR → existing comment is updated in place (single sticky comment, header `seo-review-bot`).
- [ ] Verify `.tmp/seo-review.md` is generated and not committed (already in `.gitignore`).
- [ ] Local sanity: `npm run build && ANTHROPIC_API_KEY=sk-... node scripts/seo-review.mjs` → produces `.tmp/seo-review.md`.

## Notes

- Local run on `main` already surfaced real issues to address in a follow-up: 7 descriptions >160 chars, `/contact/` missing h1, all `/handbook/*` pages have duplicate h1 ("Handbook" section label is rendered as h1).