### PR TITLE
fix(build): preserve responsive media queries in production CSS

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -115,7 +115,11 @@ export default defineConfig({
       autoTheme: true,
     }),
     playformCompress({
-      CSS: true,
+      // CSS minification disabled: csso@5 (bundled by @playform/compress) drops
+      // MQ Level 4 range syntax `@media (width >= 40rem)`, used by Tailwind v4's
+      // responsive variants and by src/v1/styles/variables-breakpoints.css.
+      // Tailwind v4 already minifies CSS via lightningcss, so this is redundant.
+      CSS: false,
       HTML: true,
       JavaScript: true,
       Image: true,


### PR DESCRIPTION
## Summary

- Production CSS was missing **all** `min-width` media queries, causing every page on www.datum.net to render in mobile-first base styles regardless of viewport.
- Root cause: `@playform/compress` bundles `csso@5.0.5`, which silently drops MQ Level 4 range syntax (`@media (width >= 40rem)`). Tailwind v4's responsive variants (`sm:/md:/lg:/xl:`) and `src/v1/styles/variables-breakpoints.css` both rely on that syntax.
- Fix: disable `CSS: true` in `playformCompress(...)`. Tailwind v4 already minifies CSS via lightningcss, so the playform pass was redundant — and destructive.

## Why local & staging were unaffected

`@playform/compress` only runs during `astro build`. Both the local dev workflow and the staging Docker image use `npm run dev`, which skips the integration entirely. Only the production Docker image (`build` stage → `npm run build`) was passing CSS through csso.

## Verification

Before (live `https://www.datum.net/_astro/index.CcrsnnAI.css`):

```
@media (hover:hover)
@media (prefers-color-scheme:dark)
@media (prefers-reduced-motion:reduce)
```

After (local `npm run build`):

```
@media(hover:hover)
@media(min-width:40rem)
@media(min-width:48rem)
@media(min-width:64rem)
@media(min-width:80rem)
@media(min-width:96rem)
@media(min-width:120rem)
@media(prefers-color-scheme:dark)
@media(prefers-reduced-motion:reduce)
```

## Test plan

- [ ] Deploy to staging and verify responsive layout at ≥768px, ≥1024px, ≥1280px viewports.
- [ ] Spot-check homepage, /pricing, /docs, /blog at desktop and mobile breakpoints.
- [ ] Confirm built CSS bundle still contains `min-width` media queries.
- [ ] Confirm CSS bundle size is still reasonable (lightningcss handles minification).