### PR TITLE
revert(chat): restore HelpScout Beacon in place of Plain widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,19 +608,17 @@ Most are gated to production (`NODE_ENV=production`) so they do not run during
 | Service   | Purpose                                     | Loader file                  | Production-only |
 | --------- | ------------------------------------------- | ---------------------------- | --------------- |
 | Fathom    | Privacy-friendly analytics + event tracking | `LayoutEmbedScripts.astro`   | No              |
-| Plain     | Live chat / customer support widget         | `LayoutEmbedScripts.astro`   | Yes             |
+| HelpScout | Live chat / customer support widget         | `LayoutEmbedScripts.astro`   | Yes             |
 | Hyperping | Status badge on the site footer             | `LayoutEmbedScripts.astro`   | No              |
 | Marker.io | In-page bug / feedback capture              | `public/scripts/markerio.js` | Yes             |
 | MaxMind   | Device fingerprint for signup fraud signal  | `LayoutEmbedScripts.astro`   | Yes             |
 | WebMCP    | Exposes site tools to AI agents via WebMCP  | `LayoutEmbedScripts.astro`   | No              |
 
-### Plain chat
+### HelpScout Beacon
 
-- App ID is configured in `LayoutEmbedScripts.astro`.
-- Any `<a>` (or other element) with `class="open-plain-chat"` will open the
-  chat widget when clicked.
-- When the Plain widget is open, the Marker.io launcher is hidden to avoid
-  overlapping Plain's close button. Closing the chat restores Marker.
+- Beacon ID is configured in `LayoutEmbedScripts.astro`.
+- Any `<a>` (or other element) with `class="open-beacon"` will open the
+  Beacon widget when clicked.
 
 ### Testing third-party widgets locally
 

--- a/src/components/LayoutEmbedScripts.astro
+++ b/src/components/LayoutEmbedScripts.astro
@@ -1,6 +1,6 @@
 ---
 // src/components/LayoutEmbedScripts.astro
-/** Third-party embed loaders: Fathom events, Plain, Hyperping, Marker.io, MaxMind, WebMCP. */
+/** Third-party embed loaders: Fathom events, HelpScout, Hyperping, Marker.io, MaxMind, WebMCP. */
 
 interface LayoutEmbedScriptsProps {
   isProduction: boolean;
@@ -19,17 +19,17 @@ const { isProduction } = Astro.props as LayoutEmbedScriptsProps;
   });
 </script>
 
-{/* Plain chat open trigger handler */}
+{/* HelpScout Beacon open trigger handler */}
 <script>
   document.addEventListener('DOMContentLoaded', function () {
-    const chatTriggers = document.querySelectorAll('.open-plain-chat');
-    chatTriggers.forEach((trigger) => {
+    const beaconTriggers = document.querySelectorAll('.open-beacon');
+    beaconTriggers.forEach((trigger) => {
       trigger.addEventListener('click', function (e) {
         e.preventDefault();
-        // @ts-expect-error Plain is loaded from chat.cdn-plain.com script
-        if (window.Plain) {
-          // @ts-expect-error Plain is loaded from chat.cdn-plain.com script
-          window.Plain.open();
+        // @ts-expect-error Beacon is loaded from HelpScout script
+        if (window.Beacon) {
+          // @ts-expect-error Beacon is loaded from HelpScout script
+          window.Beacon('open');
         }
       });
     });
@@ -77,36 +77,34 @@ const { isProduction } = Astro.props as LayoutEmbedScriptsProps;
   })();
 </script>
 
-{/* Plain chat widget - Deferred loading on first interaction or 5s timeout */}
+{/* HelpScout Beacon - Deferred loading on first interaction or 5s timeout */}
 <script is:inline data-production={isProduction ? 'true' : 'false'}>
   (function () {
     var isProduction = document.currentScript.getAttribute('data-production') === 'true';
     if (!isProduction) return;
 
-    function loadPlain() {
-      if (window.__plainLoaded) return;
-      window.__plainLoaded = true;
+    function loadHelpScout() {
+      if (window.__helpScoutLoaded) return;
+      window.__helpScoutLoaded = true;
 
+      // Initialize Beacon stub
+      window.Beacon =
+        window.Beacon ||
+        function (method, options, data) {
+          window.Beacon.readyQueue = window.Beacon.readyQueue || [];
+          window.Beacon.readyQueue.push({ method: method, options: options, data: data });
+        };
+      window.Beacon.readyQueue = [];
+
+      // Load HelpScout script
       var script = document.createElement('script');
-      script.async = false;
-      script.src = 'https://chat.cdn-plain.com/index.js';
+      script.type = 'text/javascript';
+      script.async = true;
+      script.src = 'https://beacon-v2.helpscout.net';
       script.onload = function () {
-        if (!window.Plain) return;
-        window.Plain.init({
-          appId: 'liveChatApp_01KRXXHP8PFCMFR1AWJ7QHCXNS',
-        });
-        // Hide the Marker.io launcher while the Plain chat is open so it does
-        // not overlap Plain's close button. Marker exposes hide/show via its
-        // shim queue, so these calls are safe even before Marker has finished
-        // loading.
-        window.Plain.onOpen(function () {
-          if (window.Marker) window.Marker.hide();
-        });
-        window.Plain.onClose(function () {
-          if (window.Marker) window.Marker.show();
-        });
+        window.Beacon('init', '57a7245e-772c-4d51-bdb1-6b898f34f2cb');
       };
-      document.head.appendChild(script);
+      document.body.appendChild(script);
     }
 
     var events = ['mousemove', 'touchstart', 'scroll', 'keydown'];
@@ -118,7 +116,7 @@ const { isProduction } = Astro.props as LayoutEmbedScriptsProps;
       events.forEach(function (e) {
         document.removeEventListener(e, onInteraction);
       });
-      loadPlain();
+      loadHelpScout();
     }
 
     events.forEach(function (e) {
@@ -128,7 +126,7 @@ const { isProduction } = Astro.props as LayoutEmbedScriptsProps;
     setTimeout(function () {
       if (!loaded) {
         loaded = true;
-        loadPlain();
+        loadHelpScout();
       }
     }, 5000);
   })();

--- a/src/content/pages/contact.mdx
+++ b/src/content/pages/contact.mdx
@@ -12,4 +12,4 @@ meta:
     image: "./../images/og/contact.png"
 ---
 
-Grow your skills, your revenue, and your ecosystem advantage with Datum's open network cloud. If you're looking for help, please surf on over to our <a href="https://link.datum.net/discord" target="_blank">Discord channel</a> or submit a ticket to <a href="" class="open-plain-chat">our support team.</a>
+Grow your skills, your revenue, and your ecosystem advantage with Datum's open network cloud. If you're looking for help, please surf on over to our <a href="https://link.datum.net/discord" target="_blank">Discord channel</a> or submit a ticket to <a href="" class="open-beacon">our support team.</a>

--- a/src/content/pages/download.mdx
+++ b/src/content/pages/download.mdx
@@ -7,4 +7,4 @@ meta:
   description: "Tools to help you unlock internet superpowers with Datum"
 ---
 
-Grow your skills, your revenue, and your ecosystem advantage with Datum's open network cloud. If you're looking for help, please surf on over to our <a href="https://link.datum.net/discord" target="_blank">Discord channel</a> or submit a ticket to <a href="" class="open-plain-chat">our support team.</a>
+Grow your skills, your revenue, and your ecosystem advantage with Datum's open network cloud. If you're looking for help, please surf on over to our <a href="https://link.datum.net/discord" target="_blank">Discord channel</a> or submit a ticket to <a href="" class="open-beacon">our support team.</a>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -60,7 +60,7 @@ const twitterImageUrl = toAbsoluteUrl(twitterImage?.src ?? imageContent.src);
     <!-- DNS Prefetch for external domains (low priority hints) -->
     <link rel="dns-prefetch" href="https://api.github.com" />
     <link rel="dns-prefetch" href="https://hyperping.com" />
-    <link rel="dns-prefetch" href="https://chat.cdn-plain.com" />
+    <link rel="dns-prefetch" href="https://beacon-v2.helpscout.net" />
     <link rel="dns-prefetch" href="https://device.maxmind.com" />
 
     <!-- Preconnect to critical external domains (loads within ~5s) -->

--- a/src/layouts/LayoutMinimal.astro
+++ b/src/layouts/LayoutMinimal.astro
@@ -57,7 +57,7 @@ const twitterImageUrl = toAbsoluteUrl(twitterImage?.src ?? imageContent.src);
 
     <link rel="dns-prefetch" href="https://api.github.com" />
     <link rel="dns-prefetch" href="https://hyperping.com" />
-    <link rel="dns-prefetch" href="https://chat.cdn-plain.com" />
+    <link rel="dns-prefetch" href="https://beacon-v2.helpscout.net" />
 
     <link rel="preconnect" href="https://cdn.usefathom.com" crossorigin />
     <link rel="preconnect" href="https://edge.marker.io" crossorigin />

--- a/src/layouts/LayoutSimple.astro
+++ b/src/layouts/LayoutSimple.astro
@@ -45,7 +45,7 @@ const descriptionValue =
 
     <!-- DNS Prefetch for external domains (low priority hints) -->
     <link rel="dns-prefetch" href="https://api.github.com" />
-    <link rel="dns-prefetch" href="https://chat.cdn-plain.com" />
+    <link rel="dns-prefetch" href="https://beacon-v2.helpscout.net" />
     <link rel="dns-prefetch" href="https://device.maxmind.com" />
 
     <!-- Preconnect to critical external domains (loads within ~5s) -->


### PR DESCRIPTION
## Summary

After the Plain testing period the team decided we're not ready for an integration like Plain. Reverts the live-chat widget back to HelpScout Beacon.

- Restores the deferred HelpScout Beacon loader in `LayoutEmbedScripts.astro` (script + readyQueue stub, Beacon ID `57a7245e-772c-4d51-bdb1-6b898f34f2cb`, first-interaction-or-5s defer pattern preserved).
- Renames the `.open-plain-chat` trigger class back to `.open-beacon` on `/contact` and `/download`; click handler now calls `Beacon('open')`.
- Switches DNS-prefetch hints in `Layout.astro`, `LayoutMinimal.astro`, `LayoutSimple.astro` from `chat.cdn-plain.com` to `beacon-v2.helpscout.net`.
- Drops the Plain-specific Marker.io hide/show overlap workaround — it was tied to Plain's close-button placement and is no longer needed.
- Updates the README **Third-party Integrations** table and section (Plain → HelpScout).

Closes #1343

Reverts the chat-widget portion of #1318 and the Marker/Plain coexistence hook from #1319.

## Test plan

- [x] `npm run lint` — green
- [x] `npm run typecheck` — green (0 errors / 0 warnings across 223 files)
- [ ] `npm run build` — succeeds
- [ ] `NODE_ENV=production npm run preview` → visit any page → HelpScout Beacon bubble appears after ~5s or on first interaction
- [ ] DevTools Network: `beacon-v2.helpscout.net` loads; no requests to `chat.cdn-plain.com`
- [ ] Visit `/contact` and `/download` → clicking "our support team" opens the Beacon widget
- [ ] No console errors