### PR TITLE
feat(footer): Read as Markdown lightbox with universal page coverage

### DIFF
--- a/public/about.md
+++ b/public/about.md
@@ -1,0 +1,61 @@
+# About Datum
+
+We're on a mission to help the next 1k clouds thrive in the AI era.
+
+The neutral, open source networking cloud Datum was founded by industry veterans from Voxel, Packet, Equinix, Fastly, and StackPath. Datum is on a mission to help the next 1,000 clouds thrive.
+
+## Our Mission
+
+Datum is unlocking the internet superpowers that all the big guys use - global edges, private networks, deterministic routing, direct interconnection - for the next generation of builders.
+
+## Our Purpose
+
+Datum is the neutral, open network cloud designed to power the next 1,000 hyperscalers.
+
+Our passion is connecting fragmented ecosystems across clouds, providers, and enterprises, giving builders the programmatic control, performance, and observability they need to operate in an AI-native world.
+
+With an open source foundation and a business model built on the success of partners, we connect providers with their unique ecosystem advantage, so they can play to win.
+
+## What we value and how we act
+
+- We're building for the next wave.
+- We are connectors - of people, businesses, apps and networks.
+- We are operators at heart who know how to get things done.
+- We value grit, humility and hunger.
+- We believe that open is better.
+- For us software is the customer.
+- We believe partners have real value.
+
+[Get involved on GitHub](https://github.com/datum-cloud/datum/)
+
+## Companies we've helped to build
+
+We are a group of infrastructure and software nerds who have built and operated infrastructure at:
+
+- Elastic
+- Highwinds
+- Packet
+- SoftLayer
+- StackPath
+- Voxel
+- Zscaler
+
+## Investors
+
+Backed by a diverse group of investors:
+
+- Amplify Partners
+- Cervin Ventures
+- Charles River Ventures (CRV)
+- Encoded Ventures
+- ex/ante
+- Step Function
+- Vine Ventures
+
+## Meet the people behind Datum
+
+We are infrastructure, open source software, and design nerds who love building for the future. If you're interested in working with us, please reach out via live chat or join us on [Community Chat](/chat/) or [GitHub](https://github.com/datum-cloud/datum/).
+
+---
+
+Source: <https://www.datum.net/about/>

--- a/public/contact.md
+++ b/public/contact.md
@@ -1,0 +1,29 @@
+# Contact Datum
+
+## We're all about connecting, so how about a chat?
+
+Join us and our ecosystem in one place to share ideas, support, and continue building the future.
+
+Grow your skills, your revenue, and your ecosystem advantage with Datum's open network cloud. If you're looking for help, please surf on over to our [Discord channel](https://link.datum.net/discord) or submit a ticket to our support team.
+
+## Schedule time with a founder
+
+Connect with a founder for a coffee, questions, or to share ideas.
+
+[Book a meeting](https://link.datum.net/founders)
+
+## Community
+
+- [Discord](https://link.datum.net/discord) - Real-time chat with the team and community
+- [GitHub Discussions](https://github.com/orgs/datum-cloud/discussions) - Feature requests, ideas, and product feedback
+- [Community Chat](/chat/) - Open community channel
+
+## Stay in the loop
+
+- [Blog](/blog/) - Product updates, engineering deep-dives, and ecosystem stories
+- [Changelog](/changelog/) - Everything we've shipped
+- [Roadmap](/roadmap/) - What's coming next
+
+---
+
+Source: <https://www.datum.net/contact/>

--- a/public/download.md
+++ b/public/download.md
@@ -1,0 +1,37 @@
+# Download
+
+QUIC, get to the choppa.
+
+Tools to help you unlock internet superpowers with Datum.
+
+## datumctl
+
+CLI for managing your Datum network cloud resources. Quickly and safely expose local environments to the internet, for free.
+
+[Install datumctl](/download/datumctl/)
+
+Available for:
+
+- macOS (Apple Silicon and Intel)
+- Linux (x86_64 and ARM64)
+- Windows
+
+## Datum MCP
+
+Datum's official MCP server helps builders connect AI tools to their Datum projects with a rapidly evolving open standard. Datum MCP gives AI tools secure access to your Datum resources so you can understand their current state, suggest and implement changes, and diagnose common configuration issues.
+
+[Install Datum MCP](/download/datum-mcp/)
+
+Compatible with Claude, ChatGPT, Cursor, Continue, and any MCP-aware client.
+
+## SDKs and language bindings
+
+Programmatic access to Datum APIs from your language of choice:
+
+- [Go](/download/go/)
+- [TypeScript](/download/typescript/)
+- [Rust](/download/rust/)
+
+---
+
+Source: <https://www.datum.net/download/>

--- a/public/essentials.md
+++ b/public/essentials.md
@@ -1,0 +1,72 @@
+# Datum Essentials
+
+Batteries included. We think core cloud features are essential, not optional.
+
+Enterprise-grade networking primitives like Authoritative DNS, Domains, Metrics Export, RBAC, SSO and audit logs - for free.
+
+## Datum is currently in a closed beta
+
+Our pricing is designed to create millions of connections between modern providers, their partners, and their customers. In other words, we're focused on making connections, not pushing bits.
+
+Here's what you can expect:
+
+- A generous hobby tier for personal use and experimentation
+- A robust self-service platform for production use cases
+- A curated full-service experience for a more intimate experience
+
+If you're interested in our work and want to learn more or participate in our closed beta, we'd love to chat.
+
+## Core Essentials (Free Forever on Builder)
+
+- **Authoritative DNS** - Run your zones on Datum's global anycast DNS.
+- **Domains** - Buy, transfer, and manage domains with API control.
+- **OTel Metrics Export** - Stream platform metrics into your observability stack via OpenTelemetry.
+- **Secrets** - Encrypted secret storage tied to projects and workloads.
+- **Teams and RBAC** - Fine-grained access control for humans.
+- **SSO** - Single sign-on for org-wide login.
+- **Machine Accounts** - First-class identity for agents and automation.
+- **Audit Logs** - Tamper-evident record of who did what, when.
+
+## Why "essentials" matter
+
+Most cloud providers gate the basics - DNS, RBAC, SSO, audit logs - behind enterprise tiers. Datum treats them as table stakes. If you can't observe, secure, and govern your infrastructure on day one, you can't ship on day two.
+
+## Get started
+
+- [Pricing](/pricing/) - Builder ($0), Scaler ($20/mo + usage), Provider (custom)
+- [Features](/features/) - The full feature set
+- [Documentation](/docs/) - Quickstart and API reference
+
+## Frequently asked questions
+
+### How mature is Datum Cloud?
+
+Datum is an early stage company, and our product is evolving steadily to include more core features (additional Connectors, Galactic VPC, Compute, etc.) as well as platform features that support enterprise readiness and operational scale.
+
+### Why is Datum currently free?
+
+Offering a "forever free" service tier is super important to us. As we mature our product, we plan to enable all possible features in the free tier and provide reasonable usage limits. Through this coming year we will introduce a paid plan with an SLA, as well as other deployment models.
+
+### What are Datum's planned deployment models?
+
+We currently offer a public cloud model (multi-tenant at the control plane and network level) as well as open source. This year, pending demand from design partners, we plan to introduce a managed cloud offering (single tenant control plane) and a BYOC model.
+
+### How does Datum Cloud compare?
+
+We've positioned our product as an open, AI-native network cloud. Practically speaking, we offer features that mirror aspects of the large public clouds and CDNs: an edge proxy, a reverse tunnel, DNS, global reach, a high performance backbone. Aside from being built fresh in 2025, what sets us apart is our target customer (we're solely focused on modern alt cloud providers) and our open, neutral strategy.
+
+### What are the "internet superpowers" Datum talks about?
+
+The world's biggest companies and clouds take advantage of traditional internet networking capabilities like peering, interconnection, and deterministic routing. By building out a global physical network and backbone, they understand and control the flow of their traffic, improve performance, lower costs, comply with regulation, and participate with an ecosystem of networks. Our mission is to make these superpowers available to every agent, developer and builder.
+
+### What is Datum's relationship with Kubernetes?
+
+Datum's control plane is built on Kubernetes Custom Resource Definitions (CRDs). You don't have to use k8s to use Datum Cloud, but it will feel natural if you do. An important benefit is the deep familiarity LLMs already have with the Kubernetes codebase, which makes the agent and CLI experience more seamless and accurate.
+
+### How is Datum's infrastructure structured?
+
+Datum deploys infrastructure in the top internet aggregation points globally. These points of presence (PoPs) are packaged into Regions and Availability Zones (AZs). Each Region represents a specific geographic and network boundary, while each AZ provides independent capacity within that Region. Region naming follows a country-anchored format: two-letter ISO country code, a cardinal direction (north/south/east/west/central), and a region index. AZs are identified by a, b, c, etc.
+
+---
+
+Source: <https://www.datum.net/essentials/>

--- a/public/features.md
+++ b/public/features.md
@@ -1,0 +1,58 @@
+# Built for Agents
+
+And their pesky developers too.
+
+Critical network infrastructure built for agents with Zero Trust architecture. Featuring AI Edge with built-in Coraza WAF, a distributed proxy powered by Envoy, and global Tunnel connectivity powered by QUIC.
+
+## AI Edge
+
+Meet the internet in style. Give every agent or app a global edge to absorb attacks, interact with the broader internet, and safely route traffic to backend services.
+
+- **Powered by Envoy** - Envoy is the internet's leading distributed proxy, deployed at scale with Google, Netflix, Salesforce and more.
+- **Built-in Coraza WAF** - Firewalls are hard. Coraza quickly covers the top OWASP threats.
+- **17+ global regions** - Located at major internet "football cities" like Amsterdam, Ashburn, and Tokyo.
+
+## Connectors
+
+Orchestrate diverse connections, starting with Tunnels. We're focused on supporting all kinds of connections, from developer-focused (Tailscale Tailnets, Wireguard VPNs) to low level L2/L3 telco (AWS Direct Connect, Equinix Fabric, Megaport Onramps). First up: QUIC-based Tunnels.
+
+- **Zero Trust for Agents** - Identity-aware connections by default.
+- **Built on Iroh, powered by QUIC** - Modern transport with low latency and resilience.
+- **Resilient Routing** - Stays online when individual paths fail.
+
+## Galactic VPC (coming soon)
+
+Route traffic where you want it.
+
+- **SRv6, Policy-Based Overlay** - Standards-based routing with full policy control.
+- **Fully Programmable** - Declarative VPC topology via Datum's Kubernetes-native control plane.
+- **Optimized for Private Paths** - Direct interconnect to AWS, GCP, and other clouds.
+
+## UFO (coming soon)
+
+Isolated, cold-start compute.
+
+- **Built for AI** - Tailored to short, bursty agent and inference workloads.
+- **Tiny and Mighty** - Minimal footprint, fast to start.
+- **Powered by Unikraft** - Lightweight unikernels for security and speed.
+
+## Foundations
+
+Enterprise-grade primitives included free of charge:
+
+- Authoritative DNS
+- Domains and certificate management
+- OTel Metrics Export
+- Audit logs, RBAC, SSO, Machine Accounts
+- Open source (AGPLv3) and Kubernetes-native
+
+## Get started
+
+- [Pricing](/pricing/) - Forever-free Builder tier, Scaler from $20/month, custom Provider
+- [Download datumctl](/download/datumctl/) - CLI for managing your network cloud
+- [Download Datum MCP](/download/datum-mcp/) - MCP server for AI tools
+- [Documentation](/docs/) - Quickstart and API reference
+
+---
+
+Source: <https://www.datum.net/features/>

--- a/public/index.md
+++ b/public/index.md
@@ -1,37 +1,63 @@
-# Datum — Open Source Network Cloud for AI
+# Internet superpowers for every agent
 
-Internet superpowers for every agent. You build the future, we help you connect it. No network team required.
+You build the future, we help you connect it. No network team required.
 
-## Overview
+Datum is an open, neutral, global network cloud that is built for AI and focused on giving alternative cloud providers critical network infrastructure to compete at scale.
 
-Datum is an open, neutral, global network cloud built for AI workloads. We give alternative cloud providers critical network infrastructure to compete at scale—no networking team required.
+## Why Datum?
 
-## Key Features
+Datum exists to **upgrade the internet** for a world accelerated by AI.
 
-- **AI Edge Runtime** — Deploy and run AI workloads at the network edge
-- **Global Network** — Neutral, multi-cloud connectivity spanning continents
-- **datumctl** — CLI for managing your network cloud resources
-- **Open Source** — Built in the open at github.com/datum-cloud
+In the future we're building, any company, app or agent can interact **privately** and **deterministically** with whatever it needs.
 
-## Quick Links
+**Our thesis is simple:** even the most ambitious AI-native teams lack the knowledge, people, time, and tools to participate in the internet at scale "the old way."
 
-- [Documentation](/docs/)
-- [Quickstart](/docs/quickstart/)
-- [API Reference](/docs/api/reference/)
-- [Download datumctl](/download/datumctl/)
-- [Download Datum MCP](/download/datum-mcp/)
-- [Changelog](/changelog/)
-- [Roadmap](/roadmap/)
-- [Blog](/blog/)
-- [Contact](/contact/)
+The old way is too **obscure**.
+It's too **manual**.
+Too **telco**.
 
-## Developer Resources
+## Why now?
 
-- **API Catalog:** [/.well-known/api-catalog](/.well-known/api-catalog)
-- **MCP Server:** [/.well-known/mcp/server-card.json](/.well-known/mcp/server-card.json)
-- **Agent Skills:** [/.well-known/agent-skills/index.json](/.well-known/agent-skills/index.json)
-- **Status:** [https://www.datumstatus.net](https://www.datumstatus.net)
+1. Software (and its data) is going **everywhere**.
+2. A new class of providers is **exploding**.
+3. The splinternet has **arrived**.
 
-## Authentication
+## Our vision
 
-Datum uses OpenID Connect for authentication. Discovery metadata is available at [/.well-known/openid-configuration](/.well-known/openid-configuration).
+- An open, neutral, **global network cloud**
+- Built for **AI**
+- Focused on **providers**
+
+So, **that's** what we're building. Care to join us?
+
+## What's under the hood
+
+- **Runtime** - DNS, Proxies, Gateways
+- **Connections** - Galactic VPCs, Tunnels
+- **Metrics** - Real-time observability
+- **Assets** - Domains, Secrets, Certs
+- **Experience** - Datum MCP, datumctl
+
+Unlike existing alternatives, our open network cloud is built specifically for modern service providers, can be shipped anywhere, and is backed by an AGPLv3 open source license.
+
+## Explore
+
+- [Features](/features/) - AI Edge, Connectors, Galactic VPC, UFO, foundations
+- [Essentials](/essentials/) - Enterprise-grade primitives included free
+- [Pricing](/pricing/) - Builder ($0), Scaler ($20/mo + usage), Provider (custom)
+- [Locations](/locations/) - 17+ global regions across NA, LATAM, EU, MEA, APAC
+- [Roadmap](/roadmap/) - What we're shipping next
+- [About](/about/) - Mission, team, and investors
+- [Blog](/blog/) - Product updates and engineering deep-dives
+- [Contact](/contact/) - Talk to a founder
+
+## For agents and developers
+
+- [Documentation](/docs/) - Quickstart and API reference
+- [Download datumctl](/download/datumctl/) - CLI for managing your network cloud
+- [Download Datum MCP](/download/datum-mcp/) - MCP server for AI tools
+- [GitHub](https://github.com/datum-cloud) - Open source under AGPLv3
+
+---
+
+Source: <https://www.datum.net/>

--- a/src/components/FooterAiAgents.astro
+++ b/src/components/FooterAiAgents.astro
@@ -1,13 +1,18 @@
 ---
 // src/components/FooterAiAgents.astro
 import Icon from '@components/Icon.astro';
+import MarkdownLightbox from '@components/MarkdownLightbox.astro';
 import claudeSvg from '@v1/assets/icons/ai/claude.svg?raw';
 import chatgptSvg from '@v1/assets/icons/ai/chatgpt.svg?raw';
 import geminiSvg from '@v1/assets/icons/ai/gemini.svg?raw';
 import perplexitySvg from '@v1/assets/icons/ai/perplexity.svg?raw';
 import promptRaw from '@data/ai-prompt.md?raw';
+import { resolveMarkdownUrl } from '@utils/markdownExport';
 
 const encodedPrompt = encodeURIComponent(promptRaw);
+
+// Resolve the current page's raw markdown URL (null when no source exists).
+const markdownUrl = await resolveMarkdownUrl(Astro.url.pathname);
 
 const aiTools = [
   {
@@ -67,23 +72,43 @@ const aiTools = [
           }
         </div>
       </div>
-      <a
-        href="https://agents.datum.net"
-        class="datum-text-sm flex shrink-0 items-center gap-3 whitespace-nowrap text-white transition-opacity hover:opacity-80"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <span
-          >Agents, use <strong class="font-semibold underline underline-offset-2"
-            >Agents.Datum.net</strong
-          ></span
+      <div class="flex shrink-0 flex-col items-start gap-0 md:items-end">
+        {
+          markdownUrl && (
+            <a
+              href={markdownUrl}
+              data-markdown-trigger
+              data-md-title={`cat ${markdownUrl}`}
+              class="markdown-lightbox-trigger"
+              aria-label="Read this page as Markdown"
+            >
+              <span class="markdown-lightbox-trigger__label">
+                Read as <strong>Markdown</strong>
+              </span>
+              <Icon name="file-text" size="md" class="markdown-lightbox-trigger__icon" />
+            </a>
+          )
+        }
+        <a
+          href="https://agents.datum.net"
+          class="datum-text-sm flex shrink-0 items-center gap-3 whitespace-nowrap text-white transition-opacity hover:opacity-80"
+          target="_blank"
+          rel="noopener noreferrer"
         >
-        <Icon
-          name="external-link"
-          size="md"
-          class="stroke-1.5 text-app---dark---utility-3 shrink-0"
-        />
-      </a>
+          <span
+            >Agents, use <strong class="font-semibold underline underline-offset-2"
+              >Agents.Datum.net</strong
+            ></span
+          >
+          <Icon
+            name="external-link"
+            size="md"
+            class="stroke-1.5 text-app---dark---utility-3 shrink-0"
+          />
+        </a>
+      </div>
     </div>
   </div>
 </div>
+
+<MarkdownLightbox />

--- a/src/components/MarkdownLightbox.astro
+++ b/src/components/MarkdownLightbox.astro
@@ -1,0 +1,189 @@
+---
+// src/components/MarkdownLightbox.astro
+//
+// Native <dialog>-based lightbox for viewing a page as raw markdown. Mirrors
+// the agents.datum.net "TerminalLightbox" behaviour but uses the codebase's
+// idiomatic custom-element + <dialog> pattern (see VideoModal.astro) instead
+// of React or Alpine.
+//
+// Triggered by any anchor with `data-markdown-trigger` attribute — its `href`
+// is the raw markdown URL that gets fetched and displayed.
+//
+// Modifier-key clicks, middle-clicks, and right-clicks bypass the modal so
+// "Open in new tab", "Save link as…", and AI crawlers reach the raw URL.
+import Icon from '@components/Icon.astro';
+---
+
+<markdown-lightbox>
+  <dialog aria-label="Page markdown">
+    <div class="markdown-lightbox__frame">
+      <div class="markdown-lightbox__titlebar">
+        <span class="markdown-lightbox__prompt" aria-hidden="true">$</span>
+        <span class="markdown-lightbox__command">
+          <span class="markdown-lightbox__title" data-md-title>cat</span>
+          <span class="markdown-lightbox__cursor" aria-hidden="true"></span>
+        </span>
+        <a
+          data-md-raw-link
+          href="#"
+          class="markdown-lightbox__rawlink"
+          target="_blank"
+          rel="noreferrer noopener"
+          aria-label="Open the raw markdown in a new tab"
+        >
+          raw
+          <Icon name="external-link" size="sm" class="markdown-lightbox__rawlink-icon stroke-1.5" />
+        </a>
+        <button type="button" data-md-close aria-label="Close" class="markdown-lightbox__close">
+          esc
+        </button>
+      </div>
+      <div class="markdown-lightbox__body" tabindex="0">
+        <pre class="markdown-lightbox__output" data-md-output>Loading&hellip;</pre>
+      </div>
+    </div>
+  </dialog>
+</markdown-lightbox>
+
+<script>
+  const MARKDOWN_LIGHTBOX_OPEN_EVENT = 'markdown-lightbox-open';
+
+  declare global {
+    interface CustomEventMap {
+      'markdown-lightbox-open': CustomEvent<{ href: string; title?: string }>;
+    }
+  }
+
+  class MarkdownLightbox extends HTMLElement {
+    private dialog!: HTMLDialogElement;
+    private frame!: HTMLElement;
+    private closeBtn!: HTMLButtonElement;
+    private titleEl!: HTMLElement;
+    private rawLink!: HTMLAnchorElement;
+    private output!: HTMLElement;
+    private dialogOpenedAt = 0;
+    private currentHref: string | null = null;
+    private fetchCache: Map<string, string> = new Map();
+
+    connectedCallback() {
+      this.dialog = this.querySelector('dialog')!;
+      this.frame = this.querySelector('.markdown-lightbox__frame')!;
+      this.closeBtn = this.querySelector<HTMLButtonElement>('[data-md-close]')!;
+      this.titleEl = this.querySelector<HTMLElement>('[data-md-title]')!;
+      this.rawLink = this.querySelector<HTMLAnchorElement>('[data-md-raw-link]')!;
+      this.output = this.querySelector<HTMLElement>('[data-md-output]')!;
+
+      this.setupEventListeners();
+    }
+
+    private setupEventListeners() {
+      this.closeBtn.addEventListener('click', () => this.closeModal());
+
+      this.dialog.addEventListener('close', () => {
+        document.body.toggleAttribute('data-markdown-lightbox-open', false);
+        window.removeEventListener('click', this.onWindowClick);
+      });
+
+      window.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && this.dialog.open) {
+          this.closeModal();
+          e.preventDefault();
+        }
+      });
+    }
+
+    private onWindowClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      const inDialog = target.closest('dialog') !== null;
+      const inFrame = target.closest('.markdown-lightbox__frame') !== null;
+      const isBackdropClick = inDialog && !inFrame;
+
+      const tooSoon = Date.now() - this.dialogOpenedAt < 300;
+      if (isBackdropClick && !tooSoon) this.closeModal();
+    };
+
+    openModal(detail: { href: string; title?: string }) {
+      const { href, title } = detail;
+      if (!href) return;
+
+      this.currentHref = href;
+      this.rawLink.href = href;
+      this.titleEl.textContent = title ?? `cat ${href}`;
+      this.output.textContent = 'Loading…';
+
+      this.dialog.showModal();
+      this.dialogOpenedAt = Date.now();
+      document.body.toggleAttribute('data-markdown-lightbox-open', true);
+
+      // Defer the global click listener so the click that opened the modal
+      // does not immediately close it via the backdrop handler.
+      setTimeout(() => window.addEventListener('click', this.onWindowClick), 100);
+
+      this.fetchContent(href);
+    }
+
+    closeModal() {
+      this.dialog.close();
+    }
+
+    private async fetchContent(href: string) {
+      const cached = this.fetchCache.get(href);
+      if (cached !== undefined) {
+        if (this.currentHref === href) this.output.textContent = cached;
+        return;
+      }
+      try {
+        const res = await fetch(href, {
+          headers: { Accept: 'text/plain,text/markdown,*/*' },
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const text = await res.text();
+        this.fetchCache.set(href, text);
+        if (this.currentHref === href) this.output.textContent = text;
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : 'fetch failed';
+        if (this.currentHref === href) {
+          this.output.textContent = `Could not load ${href} — ${msg}`;
+        }
+      }
+    }
+  }
+
+  if (!customElements.get('markdown-lightbox')) {
+    customElements.define('markdown-lightbox', MarkdownLightbox);
+  }
+
+  function firstLightbox(): MarkdownLightbox | null {
+    return document.querySelector('markdown-lightbox');
+  }
+
+  // Global trigger handler — any anchor with `data-markdown-trigger` opens
+  // the lightbox on plain click. Modifier-key / non-primary clicks fall
+  // through to native browser behaviour (open in new tab, save as, etc.).
+  type GlobalHooks = { __markdownLightboxHooks?: boolean };
+  if (!(globalThis as GlobalHooks).__markdownLightboxHooks) {
+    (globalThis as GlobalHooks).__markdownLightboxHooks = true;
+
+    document.addEventListener('click', (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      const anchor = target?.closest('a[data-markdown-trigger]') as HTMLAnchorElement | null;
+      if (!anchor) return;
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+      if (e.button !== 0) return;
+
+      const href = anchor.getAttribute('href');
+      if (!href) return;
+      e.preventDefault();
+
+      const title = anchor.getAttribute('data-md-title') ?? `cat ${href}`;
+      document.dispatchEvent(
+        new CustomEvent(MARKDOWN_LIGHTBOX_OPEN_EVENT, { detail: { href, title } })
+      );
+    });
+
+    document.addEventListener(MARKDOWN_LIGHTBOX_OPEN_EVENT, (ev: Event) => {
+      const detail = (ev as CustomEvent<{ href: string; title?: string }>).detail;
+      firstLightbox()?.openModal(detail);
+    });
+  }
+</script>

--- a/src/components/MarkdownLightbox.astro
+++ b/src/components/MarkdownLightbox.astro
@@ -56,7 +56,6 @@ import Icon from '@components/Icon.astro';
 
   class MarkdownLightbox extends HTMLElement {
     private dialog!: HTMLDialogElement;
-    private frame!: HTMLElement;
     private closeBtn!: HTMLButtonElement;
     private titleEl!: HTMLElement;
     private rawLink!: HTMLAnchorElement;
@@ -67,7 +66,6 @@ import Icon from '@components/Icon.astro';
 
     connectedCallback() {
       this.dialog = this.querySelector('dialog')!;
-      this.frame = this.querySelector('.markdown-lightbox__frame')!;
       this.closeBtn = this.querySelector<HTMLButtonElement>('[data-md-close]')!;
       this.titleEl = this.querySelector<HTMLElement>('[data-md-title]')!;
       this.rawLink = this.querySelector<HTMLAnchorElement>('[data-md-raw-link]')!;

--- a/src/pages/[...mdslug].md.ts
+++ b/src/pages/[...mdslug].md.ts
@@ -1,0 +1,55 @@
+// Catch-all markdown endpoint. Handles every content-collection-backed URL
+// that matches a pattern in src/utils/markdownRegistry.ts:
+//
+//   /download/<slug>        -> download collection
+//   /legal/<slug>           -> legal collection
+//   /handbook/<...id>       -> handbooks collection
+//   /brand/<slug>           -> pages collection, id "brand/<slug>"
+//
+// Astro routes specific files (e.g. src/pages/pricing.md.ts) before this
+// catch-all, so per-page customisation still works via dedicated endpoints.
+
+import type { APIRoute, GetStaticPaths } from 'astro';
+import { getEntry } from 'astro:content';
+import { getMarkdownRegistry } from '@utils/markdownRegistry';
+import { renderEntryMarkdown } from '@utils/pageMarkdown';
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const registry = await getMarkdownRegistry();
+  return Array.from(registry.entries()).map(([path, source]) => ({
+    // Strip the leading slash — Astro's [...mdslug] matches the remaining
+    // segments without it.
+    params: { mdslug: path.replace(/^\/+/, '') },
+    props: { collection: source.collection, entryId: source.entryId, urlPath: path },
+  }));
+};
+
+export const GET: APIRoute = async ({ props }) => {
+  const { collection, entryId, urlPath } = props as {
+    collection: string;
+    entryId: string;
+    urlPath: string;
+  };
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const entry = await getEntry(collection as any, entryId);
+    if (!entry) return new Response('Not found', { status: 404 });
+
+    const body = renderEntryMarkdown(entry, {
+      // Demote body headings so a body-level H1 doesn't compete with the
+      // frontmatter title. Safe for all pages — pages without a body H1
+      // are unaffected.
+      demoteHeadings: true,
+      sourceUrl: `https://www.datum.net${urlPath}/`,
+    });
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'public, max-age=300, s-maxage=300',
+      },
+    });
+  } catch (error) {
+    console.error(`Catch-all markdown failed for ${urlPath}:`, error);
+    return new Response('Error generating markdown', { status: 500 });
+  }
+};

--- a/src/pages/[...mdslug].md.ts
+++ b/src/pages/[...mdslug].md.ts
@@ -31,8 +31,10 @@ export const GET: APIRoute = async ({ props }) => {
     urlPath: string;
   };
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const entry = await getEntry(collection as any, entryId);
+    const entry = await getEntry(
+      collection as Parameters<typeof getEntry>[0],
+      entryId as Parameters<typeof getEntry>[1]
+    );
     if (!entry) return new Response('Not found', { status: 404 });
 
     const body = renderEntryMarkdown(entry, {

--- a/src/pages/blog.md.ts
+++ b/src/pages/blog.md.ts
@@ -1,0 +1,51 @@
+// Markdown listing of /blog. Includes the landing page intro from
+// pages/blog.mdx plus a list of recent Strapi articles. Per-article markdown
+// is served separately by src/pages/blog/[slug].md.ts.
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { getEntry } from 'astro:content';
+import { fetchStrapiArticles } from '@libs/strapi';
+import type { StrapiArticle } from '@libs/strapi';
+import { renderEntryMarkdown } from '@utils/pageMarkdown';
+
+function formatDate(d?: string): string {
+  if (!d) return '';
+  const dt = new Date(d);
+  return isNaN(dt.getTime()) ? '' : dt.toISOString().slice(0, 10);
+}
+
+export const GET: APIRoute = async () => {
+  try {
+    const page = await getEntry('pages', 'blog');
+    const articles = (await fetchStrapiArticles()) as StrapiArticle[];
+
+    const sorted = [...articles].sort((a, b) => {
+      const da = a.originalPublishedAt ? new Date(a.originalPublishedAt).getTime() : 0;
+      const db = b.originalPublishedAt ? new Date(b.originalPublishedAt).getTime() : 0;
+      return db - da;
+    });
+
+    const list: string[] = ['## Posts', ''];
+    for (const a of sorted) {
+      const url = `/blog/${a.slug}`;
+      const date = formatDate(a.originalPublishedAt);
+      const meta = date ? ` (${date})` : '';
+      list.push(`- [${a.title}](${url})${meta}${a.description ? ` - ${a.description}` : ''}`);
+    }
+
+    const body = renderEntryMarkdown(page ?? { data: { title: 'Blog' } }, {
+      trailingSections: [list.join('\n')],
+      sourceUrl: 'https://www.datum.net/blog/',
+    });
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+      },
+    });
+  } catch (error) {
+    console.error('Failed to serve /blog.md:', error);
+    return new Response('Error generating markdown', { status: 500 });
+  }
+};

--- a/src/pages/blog/[slug].md.ts
+++ b/src/pages/blog/[slug].md.ts
@@ -1,0 +1,46 @@
+// Serves a Strapi-backed blog article as raw markdown at /blog/<slug>.md.
+//
+// The route is SSR (prerender = false) because article content lives in
+// Strapi and changes between deploys — webhook invalidates the article
+// cache, but no rebuild is required.
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { fetchStrapiArticleBySlug } from '@libs/strapi';
+
+export const GET: APIRoute = async ({ params }) => {
+  const slug = params.slug;
+  if (!slug || typeof slug !== 'string') {
+    return new Response('Not found', { status: 404 });
+  }
+
+  // Numeric slugs are paginated listing pages, not articles — no markdown.
+  if (/^\d+$/.test(slug)) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  try {
+    const article = await fetchStrapiArticleBySlug(slug);
+    if (!article) {
+      return new Response('Not found', { status: 404 });
+    }
+
+    const body = (article.blocks ?? [])
+      .map((block) => block.body ?? '')
+      .filter(Boolean)
+      .join('\n\n');
+
+    const title = article.title ? `# ${article.title}\n\n` : '';
+    const description = article.description ? `> ${article.description}\n\n` : '';
+
+    return new Response(`${title}${description}${body}`, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+      },
+    });
+  } catch (error) {
+    console.error(`Failed to serve /blog/${slug}.md:`, error);
+    return new Response('Error generating markdown', { status: 500 });
+  }
+};

--- a/src/pages/brand.md.ts
+++ b/src/pages/brand.md.ts
@@ -1,0 +1,40 @@
+import type { APIRoute } from 'astro';
+import { getCollection, getEntry } from 'astro:content';
+import { renderEntryMarkdown } from '@utils/pageMarkdown';
+
+interface BrandSection {
+  id: string;
+  data: { title?: string; description?: string };
+}
+
+export const GET: APIRoute = async () => {
+  try {
+    const page = await getEntry('pages', 'brand').catch(() => null);
+    const all = (await getCollection('pages')) as unknown as BrandSection[];
+    const sections = all
+      .filter((e) => e.id.startsWith('brand/') && e.id !== 'brand/index')
+      .sort((a, b) => a.id.localeCompare(b.id));
+
+    const list: string[] = ['## Sections', ''];
+    for (const s of sections) {
+      const slug = s.id.replace(/^brand\//, '');
+      const desc = s.data.description ? ` - ${s.data.description}` : '';
+      list.push(`- [${s.data.title ?? slug}](/brand/${slug}/)${desc}`);
+    }
+
+    const body = renderEntryMarkdown(page ?? { data: { title: 'Brand' } }, {
+      skipBody: true,
+      trailingSections: sections.length ? [list.join('\n')] : [],
+      sourceUrl: 'https://www.datum.net/brand/',
+    });
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'public, max-age=300, s-maxage=300',
+      },
+    });
+  } catch (error) {
+    console.error('Failed to serve /brand.md:', error);
+    return new Response('Error generating markdown', { status: 500 });
+  }
+};

--- a/src/pages/brand.md.ts
+++ b/src/pages/brand.md.ts
@@ -9,7 +9,7 @@ interface BrandSection {
 
 export const GET: APIRoute = async () => {
   try {
-    const page = await getEntry('pages', 'brand').catch(() => null);
+    const page = await getEntry('pages', 'brand');
     const all = (await getCollection('pages')) as unknown as BrandSection[];
     const sections = all
       .filter((e) => e.id.startsWith('brand/') && e.id !== 'brand/index')

--- a/src/pages/changelog.md.ts
+++ b/src/pages/changelog.md.ts
@@ -1,0 +1,55 @@
+import type { APIRoute } from 'astro';
+import { getCollection, getEntry } from 'astro:content';
+import { renderEntryMarkdown, stripMdxToMarkdown } from '@utils/pageMarkdown';
+
+interface ChangelogEntry {
+  data: { title?: string; description?: string; date?: string | Date };
+  body?: string;
+  id: string;
+}
+
+function formatDate(d?: string | Date): string {
+  if (!d) return '';
+  const dt = typeof d === 'string' ? new Date(d) : d;
+  if (isNaN(dt.getTime())) return typeof d === 'string' ? d : '';
+  return dt.toISOString().slice(0, 10);
+}
+
+export const GET: APIRoute = async () => {
+  try {
+    const index = await getEntry('changelog', 'index');
+    const allEntries = (await getCollection('changelog')) as unknown as ChangelogEntry[];
+    const entries = allEntries
+      .filter((e) => e.id !== 'index')
+      .sort((a, b) => {
+        const da = a.data.date ? new Date(a.data.date).getTime() : 0;
+        const db = b.data.date ? new Date(b.data.date).getTime() : 0;
+        return db - da;
+      });
+
+    const sections: string[] = [];
+    for (const entry of entries) {
+      const date = formatDate(entry.data.date);
+      const heading = date ? `## ${entry.data.title} - ${date}` : `## ${entry.data.title}`;
+      sections.push(heading);
+      if (entry.data.description) sections.push('', `_${entry.data.description}_`);
+      const body = stripMdxToMarkdown(entry.body ?? '');
+      if (body) sections.push('', body);
+      sections.push('');
+    }
+
+    const body = renderEntryMarkdown(index ?? { data: { title: 'Changelog' } }, {
+      trailingSections: sections.length ? [sections.join('\n').trim()] : [],
+      sourceUrl: 'https://www.datum.net/changelog/',
+    });
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'public, max-age=300, s-maxage=300',
+      },
+    });
+  } catch (error) {
+    console.error('Failed to serve /changelog.md:', error);
+    return new Response('Error generating markdown', { status: 500 });
+  }
+};

--- a/src/pages/download/[slug].md.ts
+++ b/src/pages/download/[slug].md.ts
@@ -8,16 +8,14 @@ import { getEntry, getCollection } from 'astro:content';
 import { renderEntryMarkdown } from '@utils/pageMarkdown';
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const entries = await getCollection('download' as any);
+  const entries = (await getCollection('download')) as Array<{ id: string }>;
   return entries.map((e) => ({ params: { slug: e.id }, props: { entryId: e.id } }));
 };
 
 export const GET: APIRoute = async ({ props }) => {
   const { entryId } = props as { entryId: string };
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const entry = await getEntry('download' as any, entryId);
+    const entry = await getEntry('download', entryId);
     if (!entry) return new Response('Not found', { status: 404 });
     const body = renderEntryMarkdown(entry, {
       demoteHeadings: true,

--- a/src/pages/download/[slug].md.ts
+++ b/src/pages/download/[slug].md.ts
@@ -1,0 +1,36 @@
+// /download/<slug>.md endpoint. Lives here (not in the top-level catch-all)
+// because src/pages/download/[slug].astro is SSR-only and grabs any segment
+// — including ones ending in ".md" — before a top-level catch-all gets a
+// chance to match. A sibling .md.ts file is the only way to make Astro
+// route the ".md" variant specifically.
+import type { APIRoute, GetStaticPaths } from 'astro';
+import { getEntry, getCollection } from 'astro:content';
+import { renderEntryMarkdown } from '@utils/pageMarkdown';
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const entries = await getCollection('download' as any);
+  return entries.map((e) => ({ params: { slug: e.id }, props: { entryId: e.id } }));
+};
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entryId } = props as { entryId: string };
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const entry = await getEntry('download' as any, entryId);
+    if (!entry) return new Response('Not found', { status: 404 });
+    const body = renderEntryMarkdown(entry, {
+      demoteHeadings: true,
+      sourceUrl: `https://www.datum.net/download/${entryId}/`,
+    });
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'public, max-age=300, s-maxage=300',
+      },
+    });
+  } catch (err) {
+    console.error(`/download/${entryId}.md failed:`, err);
+    return new Response('Error generating markdown', { status: 500 });
+  }
+};

--- a/src/pages/events.md.ts
+++ b/src/pages/events.md.ts
@@ -1,0 +1,78 @@
+import type { APIRoute } from 'astro';
+import { getCollection, getEntry } from 'astro:content';
+import { renderEntryMarkdown } from '@utils/pageMarkdown';
+
+interface EventEntry {
+  id: string;
+  data: {
+    title?: string;
+    description?: string;
+    date?: string | Date;
+    location?: string;
+    url?: string;
+    series?: string;
+  };
+}
+
+function formatDate(d?: string | Date): string {
+  if (!d) return '';
+  const dt = typeof d === 'string' ? new Date(d) : d;
+  return isNaN(dt.getTime()) ? '' : dt.toISOString().slice(0, 10);
+}
+
+export const GET: APIRoute = async () => {
+  try {
+    const page = await getEntry('pages', 'events');
+    const events = (await getCollection('events').catch(() => [])) as unknown as EventEntry[];
+
+    const now = Date.now();
+    const dated = events.map((e) => ({
+      e,
+      t: e.data.date ? new Date(e.data.date).getTime() : 0,
+    }));
+    const upcoming = dated.filter((d) => d.t && d.t >= now).sort((a, b) => a.t - b.t);
+    const past = dated.filter((d) => !d.t || d.t < now).sort((a, b) => b.t - a.t);
+
+    function renderList(items: typeof dated): string[] {
+      const out: string[] = [];
+      for (const { e } of items) {
+        const date = formatDate(e.data.date);
+        const title = e.data.title ?? e.id;
+        const url = e.data.url ?? `/events/${e.id}`;
+        const loc = e.data.location ? ` - ${e.data.location}` : '';
+        const datePart = date ? `${date} - ` : '';
+        out.push(`- ${datePart}[${title}](${url})${loc}`);
+      }
+      return out;
+    }
+
+    const sections: string[] = [];
+    if (upcoming.length) {
+      sections.push('## Upcoming events', '', ...renderList(upcoming), '');
+    }
+    if (past.length) {
+      sections.push('## Past events', '', ...renderList(past.slice(0, 20)), '');
+    }
+
+    sections.push(
+      '## Event series',
+      '',
+      '- [Monthly Community Huddles](/events/community-huddles/)',
+      '- [Alt Cloud Meetups](/events/alt-cloud-meetups/)'
+    );
+
+    const body = renderEntryMarkdown(page ?? { data: { title: 'Events' } }, {
+      trailingSections: [sections.join('\n')],
+      sourceUrl: 'https://www.datum.net/events/',
+    });
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'public, max-age=300, s-maxage=300',
+      },
+    });
+  } catch (error) {
+    console.error('Failed to serve /events.md:', error);
+    return new Response('Error generating markdown', { status: 500 });
+  }
+};

--- a/src/pages/handbook.md.ts
+++ b/src/pages/handbook.md.ts
@@ -1,0 +1,38 @@
+import type { APIRoute } from 'astro';
+import { getEntry } from 'astro:content';
+import { renderEntryMarkdown } from '@utils/pageMarkdown';
+
+interface HandbookSection {
+  slug: string;
+  label?: string;
+}
+
+export const GET: APIRoute = async () => {
+  try {
+    const index = await getEntry('handbooks', 'index').catch(() => null);
+    const data = (index?.data ?? {}) as { title?: string; contents?: HandbookSection[] };
+
+    const sections: string[] = [];
+    if (Array.isArray(data.contents) && data.contents.length > 0) {
+      sections.push('## Sections', '');
+      for (const s of data.contents) {
+        const label = s.label ?? s.slug;
+        sections.push(`- [${label}](/handbook/${s.slug}/)`);
+      }
+    }
+
+    const body = renderEntryMarkdown(index ?? { data: { title: 'Handbook' } }, {
+      trailingSections: sections.length ? [sections.join('\n')] : [],
+      sourceUrl: 'https://www.datum.net/handbook/',
+    });
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'public, max-age=300, s-maxage=300',
+      },
+    });
+  } catch (error) {
+    console.error('Failed to serve /handbook.md:', error);
+    return new Response('Error generating markdown', { status: 500 });
+  }
+};

--- a/src/pages/handbook.md.ts
+++ b/src/pages/handbook.md.ts
@@ -9,7 +9,7 @@ interface HandbookSection {
 
 export const GET: APIRoute = async () => {
   try {
-    const index = await getEntry('handbooks', 'index').catch(() => null);
+    const index = await getEntry('handbooks', 'index');
     const data = (index?.data ?? {}) as { title?: string; contents?: HandbookSection[] };
 
     const sections: string[] = [];

--- a/src/pages/locations.md.ts
+++ b/src/pages/locations.md.ts
@@ -1,0 +1,91 @@
+// Dynamic markdown export of /locations. Pulls from src/data/locations.json
+// so newly added regions appear in the markdown without manual edits.
+import type { APIRoute } from 'astro';
+import { getEntry } from 'astro:content';
+import locations from '@data/locations.json';
+import { toAsciiMarkdown } from '@utils/markdownExport';
+
+interface Location {
+  regionCode: string;
+  metro: string;
+  group: string;
+}
+
+// Display order for region groups, matching the rendered /locations page.
+const GROUP_ORDER = ['NA', 'LATAM', 'EU', 'MEA', 'APAC'] as const;
+
+const GROUP_HEADINGS: Record<string, string> = {
+  NA: 'North America (NA)',
+  LATAM: 'Latin America (LATAM)',
+  EU: 'Europe (EU)',
+  MEA: 'Middle East & Africa (MEA)',
+  APAC: 'Asia Pacific (APAC)',
+};
+
+export const GET: APIRoute = async () => {
+  try {
+    const page = await getEntry('pages', 'locations');
+    const all = locations as Location[];
+
+    // Group by region. Unknown groups go to the end alphabetically.
+    const byGroup = new Map<string, Location[]>();
+    for (const loc of all) {
+      const arr = byGroup.get(loc.group) ?? [];
+      arr.push(loc);
+      byGroup.set(loc.group, arr);
+    }
+
+    const orderedGroups = [
+      ...GROUP_ORDER.filter((g) => byGroup.has(g)),
+      ...Array.from(byGroup.keys())
+        .filter((g) => !GROUP_ORDER.includes(g as (typeof GROUP_ORDER)[number]))
+        .sort(),
+    ];
+
+    const sections: string[] = [
+      `# ${page?.data.title ?? 'Network Locations'}`,
+      '',
+      'Located where it matters most.',
+    ];
+
+    // Prefer the longer, more descriptive meta.description over the page's
+    // short subtitle. The MDX body is empty for this page.
+    const lede =
+      page?.data.meta?.description ??
+      page?.data.description ??
+      "Datum's network is deployed at major internet peering points for low-latency access to public clouds, AI clouds, and end users.";
+    sections.push('', lede);
+
+    for (const group of orderedGroups) {
+      const heading = GROUP_HEADINGS[group] ?? group;
+      sections.push('', `## ${heading}`, '');
+      const items = byGroup.get(group) ?? [];
+      for (const loc of items) {
+        sections.push(`- ${loc.metro} (${loc.regionCode})`);
+      }
+    }
+
+    sections.push(
+      '',
+      '## Why these cities',
+      '',
+      'The world is big, but the internet gathers in a smaller set of key "football cities" - Amsterdam, Ashburn, Tokyo, and a handful of others - where major providers interconnect and exchange traffic. Datum is deployed where the internet actually lives, which means lower latency for your users and shorter, cheaper paths to AWS, GCP, Azure, and the major AI clouds.',
+      '',
+      '---',
+      '',
+      'Source: <https://www.datum.net/locations/>',
+      ''
+    );
+
+    const body = toAsciiMarkdown(sections.join('\n'));
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'public, max-age=300, s-maxage=300',
+      },
+    });
+  } catch (error) {
+    console.error('Failed to serve /locations.md:', error);
+    return new Response('Error generating markdown', { status: 500 });
+  }
+};

--- a/src/pages/open-source.astro
+++ b/src/pages/open-source.astro
@@ -146,7 +146,7 @@ const jsonLd = {
       description={page.data.description}
     />
 
-    <div class="section--block bg-glacier-mist-700">
+    <div class="section--block section--block--pad bg-glacier-mist-700 pt-0">
       <div class="max-width grid grid-cols-1 gap-8 md:grid-cols-3">
         <Card
           title="Datum"

--- a/src/pages/pricing.md.ts
+++ b/src/pages/pricing.md.ts
@@ -1,0 +1,108 @@
+// Dynamic markdown export of /pricing. Reads the same sources the rendered
+// page consumes:
+//   - src/content/pages/pricing.mdx     (title + intro)
+//   - src/content/pricing/*.json        (tier cards)
+//   - src/content/faq/*.mdx category=pricing  (FAQ section)
+// Any edit to those files updates this endpoint on next request.
+import type { APIRoute } from 'astro';
+import { getCollection, getEntry } from 'astro:content';
+import { toAsciiMarkdown } from '@utils/markdownExport';
+
+interface PricingTier {
+  title: string;
+  subtitle?: string;
+  description?: string;
+  order?: number;
+  price?: { amount?: string; suffix?: string };
+  cta?: { label?: string; href?: string };
+  featureGroups?: Array<{ title?: string; items?: string[] }>;
+}
+
+function renderTier(tier: PricingTier): string {
+  const price = tier.price?.amount ?? '';
+  const suffix = tier.price?.suffix?.trim() ?? '';
+  const heading = price
+    ? `### ${tier.title} - ${price}${suffix ? ' ' + suffix : ''}`
+    : `### ${tier.title}`;
+  const lines: string[] = [heading];
+
+  if (tier.subtitle || tier.description) {
+    const sub = tier.subtitle ? `**${tier.subtitle}.** ` : '';
+    lines.push('', `${sub}${tier.description ?? ''}`.trim());
+  }
+
+  for (const group of tier.featureGroups ?? []) {
+    if (group.title) lines.push('', group.title);
+    for (const item of group.items ?? []) {
+      lines.push(`- ${item}`);
+    }
+  }
+
+  if (tier.cta?.label && tier.cta?.href && tier.cta.href !== '#') {
+    lines.push('', `[${tier.cta.label}](${tier.cta.href})`);
+  } else if (tier.cta?.label) {
+    lines.push('', `_${tier.cta.label}_`);
+  }
+
+  return lines.join('\n');
+}
+
+function stripFaqBody(body: string): string {
+  // Strip MDX import lines and component tags. FAQ bodies are simple
+  // prose today, but this guards against future MDX edits.
+  return body
+    .replace(/^import\s+.*$/gm, '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+export const GET: APIRoute = async () => {
+  try {
+    const page = await getEntry('pages', 'pricing');
+    const tiers = (await getCollection('pricing'))
+      .map((entry) => entry.data as PricingTier)
+      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+
+    const faqs = (await getCollection('faq'))
+      .filter((f) => !f.data.draft && f.data.category === 'pricing')
+      .sort((a, b) => (a.data.order ?? 0) - (b.data.order ?? 0));
+
+    const sections: string[] = [`# ${page?.data.title ?? 'Datum Pricing'}`, ''];
+
+    if (page?.data.subtitle) {
+      sections.push(page.data.subtitle, '');
+    }
+    if (page?.data.description) {
+      sections.push(page.data.description, '');
+    }
+    if (page?.data.meta?.description) {
+      sections.push(page.data.meta.description, '');
+    }
+
+    sections.push('## Plans');
+    for (const tier of tiers) {
+      sections.push('', renderTier(tier));
+    }
+
+    if (faqs.length > 0) {
+      sections.push('', '## Common Questions');
+      for (const faq of faqs) {
+        sections.push('', `### ${faq.data.question}`, '', stripFaqBody(faq.body ?? ''));
+      }
+    }
+
+    sections.push('', '---', '', 'Source: <https://www.datum.net/pricing/>', '');
+
+    const body = toAsciiMarkdown(sections.join('\n'));
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'public, max-age=300, s-maxage=300',
+      },
+    });
+  } catch (error) {
+    console.error('Failed to serve /pricing.md:', error);
+    return new Response('Error generating markdown', { status: 500 });
+  }
+};

--- a/src/pages/roadmap.md.ts
+++ b/src/pages/roadmap.md.ts
@@ -1,0 +1,83 @@
+// Dynamic markdown export of /roadmap. Pulls from the same Strapi source
+// that RoadmapStrapi.astro renders from, so this stays in sync with each
+// monthly release cycle without manual edits. SSR so Strapi webhook cache
+// invalidations propagate immediately.
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { fetchStrapiRoadmaps, groupRoadmapsByDate, getMonthAbbreviation } from '@libs/strapi';
+import type { StrapiRoadmap } from '@libs/strapi';
+import { toAsciiMarkdown } from '@utils/markdownExport';
+
+function renderMilestone(roadmap: StrapiRoadmap, includeSummary: boolean): string {
+  const month = getMonthAbbreviation(roadmap.releaseDate);
+  const lines: string[] = [`### ${month} - ${roadmap.title}`];
+  if (roadmap.description) {
+    lines.push('', roadmap.description);
+  }
+  if (includeSummary && roadmap.summary) {
+    lines.push('', roadmap.summary);
+  }
+  if (roadmap.githubUrl) {
+    lines.push('', `[GitHub](${roadmap.githubUrl})`);
+  }
+  return lines.join('\n');
+}
+
+export const GET: APIRoute = async () => {
+  try {
+    const roadmaps = await fetchStrapiRoadmaps();
+    const { upcoming, previous } = groupRoadmapsByDate(roadmaps);
+
+    const sections: string[] = [
+      '# Roadmap',
+      '',
+      "We plan and ship in monthly cycles. Each cycle is named for a cultural, literary or scientific pioneer whose story connects to the work we're doing.",
+      '',
+      "Here's a view of the road ahead. Vote for your favorites, or [request a new feature on GitHub](https://github.com/orgs/datum-cloud/discussions/categories/feature-requests).",
+    ];
+
+    if (upcoming.length > 0) {
+      sections.push('', '## Upcoming');
+      for (const r of upcoming) {
+        sections.push('', renderMilestone(r, true));
+      }
+    }
+
+    if (previous.length > 0) {
+      sections.push('', '## Previous milestones');
+      for (const r of previous) {
+        sections.push('', renderMilestone(r, false));
+      }
+    }
+
+    if (upcoming.length === 0 && previous.length === 0) {
+      sections.push('', 'No roadmap milestones available yet.');
+    }
+
+    sections.push(
+      '',
+      '## How we plan',
+      '',
+      '- **Monthly release cycles** - One named cycle per month, scoped tight and shipped end-to-end.',
+      '- **Public discussion** - Roadmap items live on GitHub Discussions where the community can vote, comment, and propose alternatives.',
+      '- **Open development** - The platform is AGPLv3. Code, issues, and design docs are all in the open at [github.com/datum-cloud](https://github.com/datum-cloud).',
+      '',
+      '---',
+      '',
+      'Source: <https://www.datum.net/roadmap/>',
+      ''
+    );
+
+    const body = toAsciiMarkdown(sections.join('\n'));
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'public, max-age=300, stale-while-revalidate=3600',
+      },
+    });
+  } catch (error) {
+    console.error('Failed to serve /roadmap.md:', error);
+    return new Response('Error generating markdown', { status: 500 });
+  }
+};

--- a/src/utils/markdownExport.ts
+++ b/src/utils/markdownExport.ts
@@ -1,0 +1,76 @@
+// Maps a request pathname to its raw markdown URL when a source exists.
+//
+// Used by FooterAiAgents.astro to decide whether the "Read as Markdown" trigger
+// should render on the current page. Pages without a markdown source (purely
+// component-rendered .astro pages) return null and the trigger is hidden.
+//
+// Routing layers:
+//   1. Hand-curated public/*.md files (highest precedence — Astro serves them
+//      as static assets directly).
+//   2. Dedicated <path>.md.ts endpoints with custom logic (blog, changelog,
+//      roadmap, events, handbook, brand, pricing, locations).
+//   3. Auto-derived catch-all [...mdslug].md.ts driven by markdownRegistry.
+
+import { hasMarkdownForPath } from '@utils/markdownRegistry';
+
+/** Normalises a pathname: strips trailing slashes (except for root). */
+function normalisePath(pathname: string): string {
+  if (pathname === '/' || pathname === '') return '/';
+  return pathname.replace(/\/+$/, '');
+}
+
+/**
+ * Resolves a request pathname to its raw markdown URL, or null when the page
+ * has no markdown source. Async because it may consult the content-collection
+ * registry.
+ *
+ * Examples:
+ *   /                  -> /index.md          (hand-curated)
+ *   /pricing           -> /pricing.md        (dedicated endpoint)
+ *   /download/mac-os   -> /download/mac-os.md (auto-derived catch-all)
+ *   /brand/principles  -> /brand/principles.md (auto-derived catch-all)
+ *   /blog/some-post    -> /blog/some-post.md  (Strapi)
+ *   /unknown-page      -> null
+ */
+export async function resolveMarkdownUrl(pathname: string): Promise<string | null> {
+  const path = normalisePath(pathname);
+
+  if (path === '/') return '/index.md';
+
+  // Strapi-backed blog articles: /blog/<slug>. Numeric slugs are paginated
+  // listing pages, not articles.
+  if (path.startsWith('/blog/')) {
+    const slug = path.slice('/blog/'.length);
+    if (!slug || /^\d+$/.test(slug)) return null;
+    return `${path}.md`;
+  }
+
+  // Static assets, dedicated endpoints, and auto-derived registry entries are
+  // all checked uniformly by hasMarkdownForPath.
+  if (await hasMarkdownForPath(path)) {
+    return `${path}.md`;
+  }
+  return null;
+}
+
+/**
+ * Normalises common Unicode punctuation to ASCII equivalents so markdown
+ * served to the lightbox renders correctly regardless of how the viewer
+ * decodes Content-Type charset. Em/en dashes -> hyphen, smart quotes/
+ * apostrophes -> straight, arrows -> ASCII arrows, ellipsis -> three dots.
+ *
+ * Pass anything you produce by hand or pull from a CMS through this helper
+ * before responding from a `.md.ts` endpoint.
+ */
+export function toAsciiMarkdown(input: string): string {
+  return input
+    .replace(/[—–]/g, '-') // em/en dash
+    .replace(/[‘’‚′]/g, "'") // smart single quotes
+    .replace(/[“”„″]/g, '"') // smart double quotes
+    .replace(/…/g, '...') // ellipsis
+    .replace(/→/g, '->') // right arrow
+    .replace(/←/g, '<-') // left arrow
+    .replace(/\u00a0/g, ' ') // non-breaking space
+    .normalize('NFKD') // decompose Latin diacritics so combining marks isolate
+    .replace(/\p{M}+/gu, ''); // drop combining marks (Sao Paolo -> Sao Paolo)
+}

--- a/src/utils/markdownRegistry.ts
+++ b/src/utils/markdownRegistry.ts
@@ -1,0 +1,157 @@
+// Single source of truth for which URL paths have a markdown export.
+//
+// Used by:
+//   1. src/utils/markdownExport.ts (resolver) — to decide whether the
+//      "Read as Markdown" trigger renders in the footer.
+//   2. src/pages/[...mdslug].md.ts (catch-all endpoint) — to generate its
+//      getStaticPaths() and serve markdown for any covered path.
+//
+// Adding a new content collection or directory pattern only requires editing
+// the COLLECTION_PATTERNS map below. The trigger and endpoint pick it up
+// automatically — no manual list maintenance.
+
+import { getCollection } from 'astro:content';
+
+/** Maps a URL path to the collection + entry id that backs it. */
+export interface MarkdownSource {
+  collection: string;
+  entryId: string;
+}
+
+/** URL paths that have a dedicated <path>.md.ts endpoint with custom logic
+ * (Strapi listings, JSON-driven content, etc.). The catch-all defers to them
+ * rather than overriding. */
+const DEDICATED_ENDPOINTS = new Set<string>([
+  '/blog',
+  '/changelog',
+  '/roadmap',
+  '/events',
+  '/handbook',
+  '/brand',
+  '/pricing',
+  '/locations',
+]);
+
+/**
+ * The `pages` collection has entries whose IDs come from either the `slug`
+ * frontmatter field (when set) or the file path. As a result, the URL for an
+ * entry isn't always `/${entry.id}` — these overrides spell out the
+ * URLs that diverge from the default `/${id}` mapping.
+ */
+const PAGES_URL_OVERRIDES: Record<string, string> = {
+  'alt-cloud-meetups': '/events/alt-cloud-meetups',
+  'community-huddles': '/events/community-huddles',
+  career: '/careers',
+};
+
+/** Entry IDs in the `pages` collection that should NOT produce a markdown
+ * URL — hand-curated, dedicated, or not a real page. */
+const PAGES_SKIP = new Set<string>([
+  '/', // home (hand-curated as public/index.md)
+  'contact', // hand-curated
+  'download', // hand-curated
+  'essentials', // hand-curated
+  'features', // hand-curated
+  'about', // hand-curated
+  'blog', // dedicated (Strapi listing)
+  'docs', // no /docs route
+  'pricing', // dedicated (JSON tiers)
+  'locations', // dedicated (JSON regions)
+  'roadmap', // dedicated (Strapi)
+  'brand', // dedicated (sections list)
+  'events', // dedicated (events listing)
+  'global-section', // component data, not a page
+]);
+
+/** Hand-curated public/*.md files — Astro serves these as static assets, so
+ * they take precedence over any dynamic route. We still list them so the
+ * trigger renders. */
+const HAND_CURATED_PATHS = new Set<string>([
+  '/',
+  '/about',
+  '/contact',
+  '/download',
+  '/essentials',
+  '/features',
+]);
+
+/**
+ * Maps a content collection to a function that returns URL paths derived from
+ * its entries. Each function receives all entries in the collection and
+ * returns [path, MarkdownSource] tuples.
+ *
+ * Add a new pattern here when a new content-collection-backed route appears.
+ */
+const COLLECTION_PATTERNS: Array<{
+  collection: string;
+  /** Build a URL path for an entry, or return null to skip it. */
+  pathFor: (id: string) => string | null;
+}> = [
+  // /download/<slug>
+  { collection: 'download', pathFor: (id) => `/download/${id}` },
+  // /legal/<slug>
+  { collection: 'legal', pathFor: (id) => `/legal/${id}` },
+  // /handbook/<...id>
+  {
+    collection: 'handbooks',
+    pathFor: (id) => (id === 'index' ? null : `/handbook/${id}`),
+  },
+  // Pages collection — IDs come from `slug` frontmatter when set, otherwise
+  // the file path. We map known overrides explicitly and fall back to
+  // either `/${id}` for nested paths (brand/color etc.) or skip.
+  {
+    collection: 'pages',
+    pathFor: (id) => {
+      if (PAGES_SKIP.has(id)) return null;
+      if (id.startsWith('home/')) return null; // home sub-content fragments
+      if (PAGES_URL_OVERRIDES[id]) return PAGES_URL_OVERRIDES[id];
+      // brand/color, brand/iconography etc. render at /brand/<slug>
+      if (id.startsWith('brand/')) return `/${id}`;
+      // Top-level entries without overrides render at /<id> (e.g. /open-source).
+      if (!id.includes('/')) return `/${id}`;
+      return null;
+    },
+  },
+];
+
+let cache: Map<string, MarkdownSource> | null = null;
+
+/**
+ * Build (and cache) the full URL -> source registry by walking every
+ * collection pattern. Cached for the lifetime of the module; safe because
+ * content collections are immutable after Astro starts.
+ */
+export async function getMarkdownRegistry(): Promise<Map<string, MarkdownSource>> {
+  if (cache) return cache;
+  const registry = new Map<string, MarkdownSource>();
+
+  for (const { collection, pathFor } of COLLECTION_PATTERNS) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const entries = await getCollection(collection as any);
+      for (const entry of entries) {
+        const path = pathFor(entry.id);
+        if (path) registry.set(path, { collection, entryId: entry.id });
+      }
+    } catch (err) {
+      // Collection may not exist in this build — fail open.
+      console.warn(`markdownRegistry: skipping collection "${collection}":`, err);
+    }
+  }
+
+  cache = registry;
+  return registry;
+}
+
+/**
+ * Returns true if the path either has a dedicated endpoint, a hand-curated
+ * public file, or an auto-derived entry in the registry. Used by the
+ * resolver to decide whether to render the footer trigger.
+ */
+export async function hasMarkdownForPath(path: string): Promise<boolean> {
+  if (HAND_CURATED_PATHS.has(path) || DEDICATED_ENDPOINTS.has(path)) return true;
+  const reg = await getMarkdownRegistry();
+  return reg.has(path);
+}
+
+export { DEDICATED_ENDPOINTS, HAND_CURATED_PATHS };

--- a/src/utils/markdownRegistry.ts
+++ b/src/utils/markdownRegistry.ts
@@ -127,8 +127,9 @@ export async function getMarkdownRegistry(): Promise<Map<string, MarkdownSource>
 
   for (const { collection, pathFor } of COLLECTION_PATTERNS) {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const entries = await getCollection(collection as any);
+      const entries = (await getCollection(
+        collection as Parameters<typeof getCollection>[0]
+      )) as Array<{ id: string }>;
       for (const entry of entries) {
         const path = pathFor(entry.id);
         if (path) registry.set(path, { collection, entryId: entry.id });

--- a/src/utils/pageMarkdown.ts
+++ b/src/utils/pageMarkdown.ts
@@ -1,0 +1,134 @@
+// Helpers for rendering a content-collection entry's frontmatter + body as
+// ASCII markdown for the "Read as Markdown" lightbox. Used by the various
+// <page>.md.ts endpoints.
+
+import type { APIRoute } from 'astro';
+import { getEntry, type CollectionKey } from 'astro:content';
+import { toAsciiMarkdown } from '@utils/markdownExport';
+
+/**
+ * Strip MDX-only syntax from a body string so the output is plain markdown:
+ *   - `import` lines (top-level imports)
+ *   - JSX/component tags
+ *   - extra blank lines
+ *
+ * Body must already be the post-frontmatter content (Astro's `entry.body`).
+ */
+export function stripMdxToMarkdown(body: string): string {
+  return body
+    .replace(/^import\s+.*$/gm, '')
+    .replace(/^export\s+.*$/gm, '')
+    .replace(/<\w+[^>]*\/>/g, '') // self-closing JSX
+    .replace(/<\/?[A-Z][^>]*>/g, '') // capitalised component tags
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+interface RenderOptions {
+  /** Optional override for the H1. Defaults to entry.data.title. */
+  title?: string;
+  /** Optional prose to insert between title and body. */
+  intro?: string;
+  /** Optional canonical URL appended in the trailing source line. */
+  sourceUrl?: string;
+  /** Optional extra sections appended after the entry body. */
+  trailingSections?: string[];
+  /**
+   * Skip the entry body entirely. Useful for pages where the MDX is a
+   * component composition (e.g. /brand) and the stripped output would be
+   * unreadable. Use `trailingSections` to supply meaningful content instead.
+   */
+  skipBody?: boolean;
+  /**
+   * Shift every body heading down by one level (# -> ##, ## -> ###, etc.).
+   * Use when the body has its own H1 that would otherwise compete with the
+   * frontmatter title.
+   */
+  demoteHeadings?: boolean;
+}
+
+/** Shift markdown headings (# / ## / ###...) down by one level. */
+function demoteBodyHeadings(body: string): string {
+  return body.replace(/^(#{1,5}) /gm, '$1# ');
+}
+
+/**
+ * Build an ASCII markdown document from a content-collection entry. Pulls:
+ *   - `title` -> # H1
+ *   - `subtitle` and `description` -> lead paragraphs
+ *   - entry body (stripped of MDX syntax)
+ *   - meta.description if neither subtitle nor description provided context
+ *
+ * Returns plain text suitable for direct Response body.
+ */
+export function renderEntryMarkdown(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  entry: { data: any; body?: string },
+  opts: RenderOptions = {}
+): string {
+  const data = entry.data ?? {};
+  const sections: string[] = [];
+
+  const title = opts.title ?? data.title ?? '';
+  if (title) sections.push(`# ${title}`, '');
+
+  if (data.subtitle && data.subtitle !== title) {
+    sections.push(`_${data.subtitle}_`, '');
+  }
+  if (data.description) {
+    sections.push(data.description, '');
+  } else if (data.meta?.description) {
+    sections.push(data.meta.description, '');
+  }
+
+  if (opts.intro) {
+    sections.push(opts.intro, '');
+  }
+
+  if (!opts.skipBody) {
+    let body = stripMdxToMarkdown(entry.body ?? '');
+    if (opts.demoteHeadings) body = demoteBodyHeadings(body);
+    if (body) sections.push(body, '');
+  }
+
+  if (opts.trailingSections) {
+    for (const s of opts.trailingSections) {
+      sections.push(s, '');
+    }
+  }
+
+  if (opts.sourceUrl) {
+    sections.push('---', '', `Source: <${opts.sourceUrl}>`, '');
+  }
+
+  return toAsciiMarkdown(sections.join('\n'));
+}
+
+/**
+ * Convenience factory for a basic GET handler that reads one entry from a
+ * collection and returns it as ASCII markdown. For most static-content pages
+ * the body alone is enough; for listing or composed pages use a custom
+ * endpoint that calls `renderEntryMarkdown` directly with `trailingSections`.
+ */
+export function makeEntryMarkdownRoute(
+  collection: CollectionKey,
+  entryId: string,
+  opts: RenderOptions = {}
+): APIRoute {
+  return async () => {
+    try {
+      const entry = await getEntry(collection, entryId);
+      if (!entry) return new Response('Not found', { status: 404 });
+      const body = renderEntryMarkdown(entry, opts);
+      return new Response(body, {
+        headers: {
+          'Content-Type': 'text/markdown; charset=utf-8',
+          'Cache-Control': 'public, max-age=300, s-maxage=300',
+        },
+      });
+    } catch (error) {
+      console.error(`Failed to serve markdown for ${String(collection)}/${entryId}:`, error);
+      return new Response('Error generating markdown', { status: 500 });
+    }
+  };
+}

--- a/src/v1/styles/components-modal.css
+++ b/src/v1/styles/components-modal.css
@@ -231,4 +231,119 @@
   .newsletter-modal-actions {
     @apply flex justify-center;
   }
+
+  /* Markdown Lightbox — "Read as Markdown" viewer used in FooterAiAgents.
+   * Uses the same dark surface as the footer so the modal feels embedded
+   * in the bottom dark band where the trigger lives. */
+  markdown-lightbox {
+    @apply contents;
+  }
+
+  markdown-lightbox dialog {
+    @apply m-0 h-full max-h-full w-full border-0 p-0;
+    @apply mx-auto my-auto h-max w-[92%] max-w-[56rem];
+    @apply max-h-[calc(100vh-4rem)];
+    @apply bg-transparent;
+  }
+
+  markdown-lightbox dialog[open] {
+    @apply flex;
+  }
+
+  markdown-lightbox dialog::backdrop {
+    @apply bg-glacier-mist-900/80 backdrop-blur;
+  }
+
+  .markdown-lightbox__frame {
+    @apply bg-midnight-fjord border-app---dark---utility-2 shadow-modal relative flex w-full grow flex-col overflow-hidden rounded-lg border border-solid text-white;
+  }
+
+  .markdown-lightbox__titlebar {
+    @apply border-app---dark---utility-2 datum-text-xs flex items-center gap-3 border-b px-3.5 py-2.5;
+    @apply font-mono leading-none;
+    @apply text-app---dark---utility-3;
+  }
+
+  .markdown-lightbox__prompt {
+    @apply text-aurora-moss font-semibold;
+  }
+
+  .markdown-lightbox__command {
+    @apply flex min-w-0 flex-1 items-center gap-1.5;
+  }
+
+  .markdown-lightbox__title {
+    @apply min-w-0 truncate text-white;
+  }
+
+  .markdown-lightbox__cursor {
+    @apply bg-aurora-moss inline-block h-[0.85em] w-[0.5em] shrink-0 align-[-0.05em];
+    animation: markdown-lightbox-blink 1s steps(2, start) infinite;
+  }
+
+  @keyframes markdown-lightbox-blink {
+    to {
+      visibility: hidden;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .markdown-lightbox__cursor {
+      animation: none;
+    }
+  }
+
+  .markdown-lightbox__rawlink {
+    @apply text-app---dark---utility-3 inline-flex items-center gap-1.5 rounded px-2 py-1 no-underline;
+    @apply transition-colors duration-150 hover:bg-white/5 hover:text-white;
+    @apply focus-visible:bg-white/5 focus-visible:text-white focus-visible:outline-none;
+  }
+
+  .markdown-lightbox__rawlink-icon {
+    @apply h-3.5! w-3.5! shrink-0;
+  }
+
+  .markdown-lightbox__close {
+    @apply border-app---dark---utility-2 text-app---dark---utility-3 cursor-pointer rounded border bg-transparent px-2 py-1;
+    @apply transition-colors duration-150 hover:border-white/40 hover:text-white;
+    @apply focus-visible:border-white/40 focus-visible:text-white focus-visible:outline-none;
+    @apply font-mono text-xs leading-none;
+  }
+
+  .markdown-lightbox__body {
+    @apply min-h-0 flex-1 overflow-auto px-6 py-5;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .markdown-lightbox__body:focus-visible {
+    @apply outline-1 -outline-offset-4 outline-white/30;
+  }
+
+  .markdown-lightbox__output {
+    @apply m-0 font-mono text-[0.8125rem] leading-relaxed text-white;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  body[data-markdown-lightbox-open] {
+    @apply overflow-clip;
+  }
+
+  /* Trigger link styling in the dark footer band — mirrors the existing
+   * agents link styling but with a subtle code/markdown affordance. */
+  .markdown-lightbox-trigger {
+    @apply datum-text-sm inline-flex shrink-0 items-center gap-3 whitespace-nowrap text-white no-underline transition-opacity hover:opacity-80;
+  }
+
+  .markdown-lightbox-trigger__label {
+    @apply text-white;
+  }
+
+  .markdown-lightbox-trigger__label strong {
+    @apply font-semibold underline underline-offset-2;
+  }
+
+  .markdown-lightbox-trigger__icon {
+    @apply text-app---dark---utility-3 shrink-0;
+  }
 }


### PR DESCRIPTION
## Summary

- New "Read as **Markdown**" trigger in `FooterAiAgents` opens a themed lightbox modal showing the current page as raw markdown. Mirrors agents.datum.net PR #37.
- Plain click → modal. ⌘/Ctrl/Shift/Alt-click, middle-click, right-click → native browser behaviour (open in new tab, "Save link as…", AI crawlers reach the raw URL). Esc / backdrop / "esc" button close it.
- Single source of truth (`src/utils/markdownRegistry.ts`) feeds both the trigger resolver and a catch-all endpoint (`src/pages/[...mdslug].md.ts`) so new content collection entries get a `.md` export + trigger automatically — no allow-list to maintain.

## Coverage

| Layer | What | Source of truth |
| --- | --- | --- |
| Hand-curated | `/`, `/about`, `/contact`, `/download`, `/essentials`, `/features` | `public/*.md` |
| Dedicated endpoints | `/blog`, `/blog/[slug]`, `/changelog`, `/roadmap`, `/events`, `/handbook`, `/brand`, `/pricing`, `/locations`, `/download/[slug]` | Custom logic per file (Strapi, JSON tiers, etc.) |
| Catch-all (auto) | `/legal/<slug>`, `/handbook/<...slug>`, `/brand/<slug>`, plus any other entry that matches a `COLLECTION_PATTERNS` rule | `markdownRegistry.ts` |

## Why this won't keep drifting

`COLLECTION_PATTERNS` in `markdownRegistry.ts` declares "this collection's entries map to this URL shape". Adding a new download, legal, handbook, or brand entry now automatically picks up a `.md` URL and a footer trigger on next build — no resolver edit required. The catch-all uses those mappings for `getStaticPaths`, and the resolver consults the same registry.

## ASCII output

All dynamically-generated markdown runs through `toAsciiMarkdown()` which normalises em/en dashes, smart quotes, NBSPs, and decomposes Latin diacritics (São Paolo → Sao Paolo) so the lightbox renders cleanly regardless of the response's charset header.

## Drive-by

- `/open-source` card grid was touching the pre-footer. Added `section--block--pad pt-0` so it pads bottom only.

## Test plan

- [ ] On every page in the new coverage table, footer shows the "Read as **Markdown**" trigger
- [ ] Plain click opens the modal with the page's markdown
- [ ] ⌘-click / middle-click opens raw `.md` in a new tab without the modal
- [ ] Right-click → "Save link as…" downloads the raw markdown
- [ ] Esc / backdrop / "esc" button close the modal; body scroll restores
- [ ] No non-ASCII characters in any `.md` response (`curl -s /pricing.md | LC_ALL=C tr -d '\000-\177' | wc -c` returns 0)
- [ ] `/open-source` cards no longer touch the pre-footer