### PR TITLE
feat(home): update hero headline to "Connected infrastructure for AI"

### DIFF
--- a/public/index.md
+++ b/public/index.md
@@ -1,4 +1,4 @@
-# Internet superpowers for every agent
+# Connected infrastructure for AI
 
 You build the future, we help you connect it. No network team required.
 

--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -25,7 +25,7 @@ const { title = '', description = '', class: className } = Astro.props as HeroPr
       role="banner"
     >
       <h1
-        class="datum-text-11xl [&_span]:text-aurora-moss m-auto max-w-190 text-white [text-shadow:0_2px_12px_rgba(0,0,0,0.45)]"
+        class="datum-text-11xl [&_span]:text-aurora-moss m-auto text-white [text-shadow:0_2px_12px_rgba(0,0,0,0.45)] xl:text-[68px] xl:leading-[80px]"
         set:html={marked.parseInline(title)}
       />
       {

--- a/src/content/pages/home.mdx
+++ b/src/content/pages/home.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Internet superpowers for <span>every agent.</span>"
+title: "Connected infrastructure for <span>AI</span>"
 description: "You build the future, we help you connect it.<br>No network team required."
 publishDate: 2025-03-04
 slug: "/"
@@ -10,7 +10,7 @@ meta:
   title: "Datum - Open Source Network Cloud for AI"
   description: "Datum is an open, neutral, global network cloud that is built for AI and focused on giving alternative cloud providers critical network infrastructure to compete at scale, no networking team required!"
   og:
-    title: "Internet superpowers for every agent – no network team required!"
+    title: "Connected infrastructure for AI – no network team required!"
     description: "Designed to power the next wave of innovation"
     image: "./../images/og/home.png"
 ---

--- a/src/v1/styles/components-hero.css
+++ b/src/v1/styles/components-hero.css
@@ -14,6 +14,8 @@
       .nav--main {
         .nav-actions {
           .btn {
+            @apply bg-midnight-fjord/30 backdrop-blur-md;
+
             svg {
               @apply text-potted-olive;
             }


### PR DESCRIPTION
## Summary

- Updates the homepage hero headline to the latest tagline **"Connected infrastructure for AI"** (with **AI** highlighted in aurora-moss), per #1332.
- Adjusts hero sizing so the new, shorter string fits on one line at wide breakpoints — drops the h1 `max-w-190` cap (which was leaving wide side gaps at lg viewports) and shrinks the font at xl to `68px / 80px leading`. At lg and below, copy wraps to two lines, which Ollie confirmed is acceptable.
- Adds a frosted `bg-midnight-fjord/30 backdrop-blur-md` to the home hero's nav action buttons (Sign in / Start for free) so the animated star-beam reads cleanly behind them instead of slicing through the labels.
- Syncs the OG title and the hand-curated `public/index.md` markdown export to the new headline. Other "no network team required" / "every agent" usages across the site were intentionally left alone — flagged separately for a follow-up if Jacob/Ollie want them refreshed.

Closes #1332

## Test plan

- [ ] Run `npm run dev` and load `/`:
  - [ ] Headline reads "Connected infrastructure for AI" with **AI** in aurora-moss green
  - [ ] At xl viewport (≥1280px), the headline sits on a single line
  - [ ] At lg viewport (1024–1279px), the headline wraps to two lines and there are no large empty side gaps around it
  - [ ] At mobile/md, layout is unchanged from before
  - [ ] Sign in / Start for free buttons show a subtle frosted blur as the beam passes behind them
- [ ] View page source / share preview: OG title reads "Connected infrastructure for AI – no network team required!"
- [ ] Hit `/index.md` (Read as Markdown) — H1 matches the new headline