### PR TITLE
feat: add GET /api/cache/:name for full cache JSON

### DIFF
--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -221,7 +221,7 @@ Page components and routing (file-based routing):
 - `api/` - API routes
 - `api/auth/login.ts` - Login API endpoint
 - `api/user.ts` - User API endpoint
-- `api/cache/index.ts` / `api/cache/strapi.ts` - Cache inspection (**GET**) and Strapi regenerate (**POST**); see [STRAPI_CACHE_API.md](./STRAPI_CACHE_API.md)
+- `api/cache/index.ts` / `api/cache/[name].ts` / `api/cache/strapi.ts` - Cache inventory (**GET**), single-key JSON (**GET** `/api/cache/:name`), Strapi regenerate (**POST**); see [STRAPI_CACHE_API.md](./STRAPI_CACHE_API.md)
 - `auth/` - Authentication pages
 - `auth/callback.astro` - OAuth callback
 - `auth/login.astro` - Login page

--- a/docs/STRAPI_CACHE_API.md
+++ b/docs/STRAPI_CACHE_API.md
@@ -41,6 +41,64 @@ Response is pretty-printed JSON with top-level `entries` and `bySource` (`strapi
 
 ---
 
+## Get cache entry by name
+
+### `GET /api/cache/:name`
+
+Returns the **full parsed JSON** for a single cache key (for example `strapi-authors`, `strapi-card-members`, `article-my-slug`).
+
+**Authentication:** Header `X-Webhook-Secret: <secret>` (same as other cache APIs).
+
+**Implementation:** [`src/pages/api/cache/[name].ts`](../src/pages/api/cache/[name].ts), [`src/libs/cacheViewer.ts`](../src/libs/cacheViewer.ts), [`src/libs/cacheApiAuth.ts`](../src/libs/cacheApiAuth.ts).
+
+**Query parameters:**
+
+| Parameter | Values                     | Default | Meaning                           |
+| --------- | -------------------------- | ------- | --------------------------------- |
+| `source`  | `main`, `fallback`, `auto` | `auto`  | Main `.cache/`, fallback, or both |
+
+**Examples:**
+
+```bash
+curl -sS "${ORIGIN}/api/cache/strapi-authors" \
+  -H "X-Webhook-Secret: ${STRAPI_WEBHOOK_SECRET}"
+
+curl -sS "${ORIGIN}/api/cache/article-my-post?source=fallback" \
+  -H "X-Webhook-Secret: ${STRAPI_WEBHOOK_SECRET}"
+```
+
+**Success response (200):**
+
+```json
+{
+  "success": true,
+  "key": "strapi-authors",
+  "source": "strapi",
+  "expiresAt": "May 28, 2026, 3:45 PM",
+  "expired": false,
+  "size": "12.4 KB",
+  "data": []
+}
+```
+
+**HTTP status codes:**
+
+| Status  | When                                                     |
+| ------- | -------------------------------------------------------- |
+| **200** | Entry found and JSON parsed                              |
+| **400** | Invalid cache name or invalid `source` query             |
+| **401** | Missing or wrong `X-Webhook-Secret`                      |
+| **404** | No `.json` file for that key in the searched location(s) |
+| **405** | Method other than GET                                    |
+| **500** | File exists but JSON is corrupt                          |
+
+**Notes:**
+
+- Reads **raw filesystem** files. Expired TTL entries are returned with `"expired": true` and are **not** deleted (unlike `Cache.get()` used at runtime).
+- Cache names must match safe key rules (alphanumeric start; letters, digits, `.`, `_`, `-` only; no path segments).
+
+---
+
 ## Regenerate Strapi cache (`POST /api/cache/strapi`)
 
 Rebuilds cache entries using the same Strapi GraphQL helpers as the site (`fetchStrapiArticles`, `fetchStrapiAuthors`, `getStrapiTeamMembers`, `getStrapiCardMembers`, `fetchStrapiArticleBySlug`).
@@ -274,3 +332,4 @@ If you invoke this logic from tooling or scripts **inside this codebase**:
 | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `POST /api/webhooks/strapi-content` | Strapi CMS webhook: deletes cache slices (including fallbacks where applicable) and selectively warms article-related caches |
 | `GET /api/cache`                    | Inspect cache filenames and TTL metadata                                                                                     |
+| `GET /api/cache/:name`              | Full JSON for one cache key (`source` query: main, fallback, auto)                                                           |

--- a/scripts/seo-review.mjs
+++ b/scripts/seo-review.mjs
@@ -40,6 +40,12 @@ const MAX_INPUT_CHARS = parseInt(process.env.MAX_INPUT_CHARS || '640000', 10);
 const RAW_SCAN_MODE = (process.env.SCAN_MODE || 'changed-only').toLowerCase();
 const SCAN_MODE = RAW_SCAN_MODE === 'full' ? 'full' : 'changed-only';
 const SITE_URL = process.env.SITE_URL || 'https://www.datum.net';
+let SITE_ORIGIN;
+try {
+  SITE_ORIGIN = new URL(SITE_URL).origin;
+} catch {
+  SITE_ORIGIN = 'https://www.datum.net';
+}
 const CONFIG_FILE =
   process.env.SEO_CONFIG ||
   path.join(path.dirname(new URL(import.meta.url).pathname), '/seo-review.config.json');
@@ -259,7 +265,17 @@ function extractLinksAndRefresh($, urlPath) {
     if (!href) return;
     if (/^(#|mailto:|tel:|javascript:|data:)/i.test(href)) return;
     if (href.startsWith('//')) return; // protocol-relative external
-    if (/^https?:\/\//i.test(href)) return; // absolute — treat as external, don't validate against dist
+    if (/^https?:\/\//i.test(href)) {
+      try {
+        const u = new URL(href);
+        if (u.origin === SITE_ORIGIN) {
+          refs.push(u.pathname);
+        }
+      } catch {
+        /* ignore malformed absolute URLs */
+      }
+      return;
+    }
     let pathname = null;
     if (href.startsWith('/')) {
       pathname = href.split('#')[0].split('?')[0];

--- a/src/libs/cacheApiAuth.ts
+++ b/src/libs/cacheApiAuth.ts
@@ -1,0 +1,29 @@
+// src/libs/cacheApiAuth.ts
+
+import crypto from 'node:crypto';
+
+/**
+ * Verifies X-Webhook-Secret against STRAPI_WEBHOOK_SECRET for cache API routes.
+ */
+export function verifyCacheApiSecret(request: Request): boolean {
+  const webhookSecret = process.env.STRAPI_WEBHOOK_SECRET;
+
+  if (!webhookSecret) {
+    return false;
+  }
+
+  const receivedSecret = request.headers.get('X-Webhook-Secret');
+
+  if (!receivedSecret) {
+    return false;
+  }
+
+  const expected = Buffer.from(webhookSecret);
+  const received = Buffer.from(receivedSecret);
+
+  if (expected.length !== received.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(expected, received);
+}

--- a/src/libs/cacheViewer.ts
+++ b/src/libs/cacheViewer.ts
@@ -77,6 +77,142 @@ function classifySource(key: string): CacheEntry['source'] {
   return 'other';
 }
 
+const CACHE_KEY_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+
+export type CacheSourceFilter = 'main' | 'fallback' | 'auto';
+
+export type CacheEntryByName = {
+  key: string;
+  source: CacheEntry['source'];
+  data: unknown;
+  size: number;
+  expiresAt: number | null;
+  expired: boolean;
+};
+
+export type GetCacheEntryResult =
+  | { status: 'ok'; entry: CacheEntryByName }
+  | { status: 'not_found' }
+  | { status: 'invalid_json' };
+
+/**
+ * Validates a cache key is safe for filesystem lookup (no path traversal).
+ */
+export function isSafeCacheKey(name: string): boolean {
+  const trimmed = name.trim();
+  if (!trimmed || trimmed !== name) {
+    return false;
+  }
+  if (trimmed.includes('/') || trimmed.includes('\\')) {
+    return false;
+  }
+  if (trimmed === '.' || trimmed === '..' || trimmed.includes('..')) {
+    return false;
+  }
+  return CACHE_KEY_PATTERN.test(trimmed);
+}
+
+export function formatExpiresAt(ts: number | null): string {
+  return ts === null
+    ? '—'
+    : new Date(ts).toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+export function formatSizeKb(bytes: number): string {
+  return `${Math.round((bytes / 1024) * 10) / 10} KB`;
+}
+
+function readExpiresAt(dir: string, key: string): number | null {
+  const expiresPath = path.join(dir, `${key}.expires`);
+  if (!fs.existsSync(expiresPath)) {
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(expiresPath, 'utf-8')) as number;
+  } catch {
+    return null;
+  }
+}
+
+function readCacheFile(
+  dir: string,
+  key: string,
+  source: CacheEntry['source']
+): GetCacheEntryResult {
+  const filePath = path.join(dir, `${key}.json`);
+  if (!fs.existsSync(filePath)) {
+    return { status: 'not_found' };
+  }
+
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return { status: 'not_found' };
+  }
+
+  const size = Buffer.byteLength(content, 'utf-8');
+  let data: unknown;
+  try {
+    data = JSON.parse(content) as unknown;
+  } catch {
+    return { status: 'invalid_json' };
+  }
+
+  const expiresAt = readExpiresAt(dir, key);
+
+  return {
+    status: 'ok',
+    entry: {
+      key,
+      source,
+      data,
+      size,
+      expiresAt,
+      expired: expiresAt !== null && Date.now() > expiresAt,
+    },
+  };
+}
+
+/**
+ * Reads a single cache entry from disk without mutating expired TTL files.
+ */
+export function getCacheEntryByName(
+  name: string,
+  options?: { source?: CacheSourceFilter }
+): GetCacheEntryResult {
+  const sourceFilter = options?.source ?? 'auto';
+  const CACHE_BASE = path.resolve(process.cwd(), '.cache');
+  const STRAPI_FALLBACK = path.join(CACHE_BASE, 'strapi-fallback');
+
+  const dirs: Array<{ dir: string; source: CacheEntry['source'] }> = [];
+
+  if (sourceFilter === 'main' || sourceFilter === 'auto') {
+    dirs.push({ dir: CACHE_BASE, source: classifySource(name) });
+  }
+  if (sourceFilter === 'fallback' || sourceFilter === 'auto') {
+    dirs.push({ dir: STRAPI_FALLBACK, source: 'strapi-fallback' });
+  }
+
+  let sawInvalidJson = false;
+
+  for (const { dir, source } of dirs) {
+    const result = readCacheFile(dir, name, source);
+    if (result.status === 'ok') {
+      return result;
+    }
+    if (result.status === 'invalid_json') {
+      sawInvalidJson = true;
+    }
+  }
+
+  if (sawInvalidJson) {
+    return { status: 'invalid_json' };
+  }
+
+  return { status: 'not_found' };
+}
+
 export function getCacheViewerData(): CacheViewerData {
   const CACHE_BASE = path.resolve(process.cwd(), '.cache');
   const STRAPI_FALLBACK = path.join(CACHE_BASE, 'strapi-fallback');

--- a/src/pages/api/cache/[name].ts
+++ b/src/pages/api/cache/[name].ts
@@ -1,0 +1,86 @@
+// src/pages/api/cache/[name].ts
+
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { verifyCacheApiSecret } from '@libs/cacheApiAuth';
+import {
+  formatExpiresAt,
+  formatSizeKb,
+  getCacheEntryByName,
+  isSafeCacheKey,
+  type CacheSourceFilter,
+} from '@libs/cacheViewer';
+
+const VALID_SOURCE_FILTERS = new Set<CacheSourceFilter>(['main', 'fallback', 'auto']);
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+function parseSourceFilter(url: URL): CacheSourceFilter | null {
+  const raw = url.searchParams.get('source');
+  if (raw === null) {
+    return 'auto';
+  }
+  const trimmed = raw.trim();
+  if (!VALID_SOURCE_FILTERS.has(trimmed as CacheSourceFilter)) {
+    return null;
+  }
+  return trimmed as CacheSourceFilter;
+}
+
+export const GET: APIRoute = async ({ request, params }) => {
+  if (request.method !== 'GET') {
+    return jsonResponse({ success: false, error: 'Method not allowed' }, 405);
+  }
+
+  if (!verifyCacheApiSecret(request)) {
+    return jsonResponse({ success: false, error: 'Unauthorized' }, 401);
+  }
+
+  const name = typeof params.name === 'string' ? params.name.trim() : '';
+
+  if (!isSafeCacheKey(name)) {
+    return jsonResponse({ success: false, error: 'Invalid cache name' }, 400);
+  }
+
+  const sourceFilter = parseSourceFilter(new URL(request.url));
+  if (sourceFilter === null) {
+    return jsonResponse(
+      { success: false, error: 'Invalid query: "source" must be main, fallback, or auto' },
+      400
+    );
+  }
+
+  const result = getCacheEntryByName(name, { source: sourceFilter });
+
+  if (result.status === 'not_found') {
+    return jsonResponse({ success: false, error: 'Cache entry not found', key: name }, 404);
+  }
+
+  if (result.status === 'invalid_json') {
+    return jsonResponse({ success: false, error: 'Invalid cache JSON', key: name }, 500);
+  }
+
+  const { entry } = result;
+
+  return jsonResponse(
+    {
+      success: true,
+      key: entry.key,
+      source: entry.source,
+      expiresAt: formatExpiresAt(entry.expiresAt),
+      expired: entry.expired,
+      size: formatSizeKb(entry.size),
+      data: entry.data,
+    },
+    200
+  );
+};

--- a/src/pages/api/cache/index.ts
+++ b/src/pages/api/cache/index.ts
@@ -3,14 +3,8 @@
 export const prerender = false;
 
 import type { APIRoute } from 'astro';
-import { getCacheViewerData } from '@libs/cacheViewer';
-
-function verifyWebhookSecret(request: Request): boolean {
-  const webhookSecret = process.env.STRAPI_WEBHOOK_SECRET;
-  if (!webhookSecret) return false;
-  const receivedSecret = request.headers.get('X-Webhook-Secret');
-  return receivedSecret === webhookSecret;
-}
+import { verifyCacheApiSecret } from '@libs/cacheApiAuth';
+import { formatExpiresAt, formatSizeKb, getCacheViewerData } from '@libs/cacheViewer';
 
 export const GET: APIRoute = async ({ request }) => {
   if (request.method !== 'GET') {
@@ -20,7 +14,7 @@ export const GET: APIRoute = async ({ request }) => {
     });
   }
 
-  if (!verifyWebhookSecret(request)) {
+  if (!verifyCacheApiSecret(request)) {
     return new Response(JSON.stringify({ success: false, error: 'Unauthorized' }), {
       status: 401,
       headers: { 'Content-Type': 'application/json' },
@@ -28,13 +22,6 @@ export const GET: APIRoute = async ({ request }) => {
   }
 
   const data = getCacheViewerData();
-
-  const formatExpiresAt = (ts: number | null): string =>
-    ts === null
-      ? '—'
-      : new Date(ts).toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' });
-
-  const formatSizeKb = (bytes: number): string => `${Math.round((bytes / 1024) * 10) / 10} KB`;
 
   const transformEntry = (e: (typeof data.entries)[0]) => ({
     ...e,

--- a/src/pages/api/cache/strapi.ts
+++ b/src/pages/api/cache/strapi.ts
@@ -3,35 +3,12 @@
 export const prerender = false;
 
 import type { APIRoute } from 'astro';
-import crypto from 'node:crypto';
+import { verifyCacheApiSecret } from '@libs/cacheApiAuth';
 import {
   regenerateStrapiCacheIfMissing,
   forceRegenerateStrapiCache,
   validateStrapiForceRegenerateRequest,
 } from '@libs/strapi/regenerateCache';
-
-function verifyWebhookSecret(request: Request): boolean {
-  const webhookSecret = process.env.STRAPI_WEBHOOK_SECRET;
-
-  if (!webhookSecret) {
-    return false;
-  }
-
-  const receivedSecret = request.headers.get('X-Webhook-Secret');
-
-  if (!receivedSecret) {
-    return false;
-  }
-
-  const expected = Buffer.from(webhookSecret);
-  const received = Buffer.from(receivedSecret);
-
-  if (expected.length !== received.length) {
-    return false;
-  }
-
-  return crypto.timingSafeEqual(expected, received);
-}
 
 export const POST: APIRoute = async ({ request }) => {
   if (request.method !== 'POST') {
@@ -41,7 +18,7 @@ export const POST: APIRoute = async ({ request }) => {
     });
   }
 
-  if (!verifyWebhookSecret(request)) {
+  if (!verifyCacheApiSecret(request)) {
     return new Response(JSON.stringify({ success: false, error: 'Unauthorized' }), {
       status: 401,
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
- GET /api/cache/:name with optional ?source=main|fallback|auto
- Shared verifyCacheApiSecret for all cache API routes
- seo-review: treat absolute SITE_URL links as internal for audits