### PR TITLE
feat(changelog): render GitHub asset videos in a video player

### DIFF
--- a/src/components/changelog/Card.astro
+++ b/src/components/changelog/Card.astro
@@ -6,6 +6,18 @@ import Icon from '@components/Icon.astro';
 import { changelogs, type ChangelogProps } from '@/src/libs/datum';
 
 const entries = await changelogs();
+
+// GitHub renders bare media URLs (uploaded via the issue/discussion editor) as
+// inline video players. `marked` only autolinks them, so we convert those
+// anchors into <video> players. Images stay as <img> tags and are untouched,
+// since only bare URLs — not the `![alt](...)`/`<img>` syntax — match here.
+function embedGithubVideos(html: string): string {
+  return html.replace(
+    /<a href="(https:\/\/github\.com\/user-attachments\/assets\/[a-f0-9-]+|https?:\/\/[^"]+\.(?:mp4|mov|webm|ogv|ogg))"[^>]*>[^<]*<\/a>/gi,
+    (_match, url: string) =>
+      `<video class="changelog-entry-card-video" controls preload="metadata" playsinline src="${url}"></video>`
+  );
+}
 ---
 
 <div class="changelog-list">
@@ -45,7 +57,10 @@ const entries = await changelogs();
         </div>
 
         <article class="changelog-entry-card">
-          <div class="changelog-entry-card-body" set:html={marked.parse(entry.body)} />
+          <div
+            class="changelog-entry-card-body"
+            set:html={embedGithubVideos(marked.parse(entry.body) as string)}
+          />
 
           {entry.labels && entry.labels.nodes.length > 0 && (
             <div class="changelog-entry-card-tags">

--- a/src/v1/styles/components-changelog.css
+++ b/src/v1/styles/components-changelog.css
@@ -93,6 +93,10 @@
       @apply border-app---dark---utility-4 mb-3 max-w-full border shadow-sm;
     }
 
+    video {
+      @apply border-app---dark---utility-4 mb-3 h-auto max-h-[500px] w-full max-w-full border shadow-sm;
+    }
+
     pre {
       @apply bg-glacier-mist-700 border-glacier-mist-900 mb-5 max-w-full overflow-auto rounded-lg border p-4;
 


### PR DESCRIPTION
## Summary

The changelog page (`changelog.astro` → `Card.astro`) renders GitHub discussion bodies with `marked`. GitHub auto-embeds bare media URLs as inline video players, but `marked` only autolinks them — so uploaded screen recordings appeared as clickable URLs instead of playable videos.

This converts those autolinked GitHub-asset URLs (and any `.mp4/.mov/.webm/.ogv/.ogg` link) into native `<video>` players. Image tags (`<img>`) are left untouched, since only bare URLs — not `![alt](...)`/`<img>` syntax — are matched.

## Changes

- **`Card.astro`**: added `embedGithubVideos()` post-processing on the rendered markdown body, emitting `<video controls preload="metadata" playsinline>`.
- **`components-changelog.css`**: added a `video` style mirroring the existing `img` rule, capped at `max-h-[500px]`.

## Notes

- A bare `user-attachments/assets` link is treated as a video. In a changelog these are always screen recordings; GitHub serves images via `<img>` and labeled file links keep their text, so neither is matched.

## Test plan

- [x] `npm run build` (astro check + build) passes
- [x] Verified against cached discussion bodies: 4 bare-link videos → `<video>`, 19 `<img>` screenshots untouched, 0 leftover asset anchors
- [ ] Visual check on the deployed changelog page that players render and respect the 500px cap