### PR TITLE
fix(seo): resolve audit findings from #1339

### DIFF
--- a/.github/workflows/seo-review.yml
+++ b/.github/workflows/seo-review.yml
@@ -53,6 +53,11 @@ jobs:
         run: npm ci
 
       - name: Build site
+        # Audit the production output: NODE_ENV=production matches the deploy
+        # build (Dockerfile) so indexability/analytics reflect the live site
+        # instead of being forced to noindex by the dev-mode default.
+        env:
+          NODE_ENV: production
         run: npm run build
 
       - name: Collect changed page files (PR only)

--- a/src/content/changelog/index.md
+++ b/src/content/changelog/index.md
@@ -5,6 +5,6 @@ meta:
   title: "Datum Changelog: Feature Releases and Product Updates"
   description: "Stay up-to-date with Datum's latest feature releases, bug fixes, and improvements for our AI-native solutions, Edge Networking platform, and open source cloud."
   og:
-    title: What we shippped
+    title: What we shipped
     description: Stay up to date and in the know about product improvements and launches.
 ---

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -113,7 +113,12 @@ const twitterImageUrl = toAbsoluteUrl(twitterImage?.src ?? imageContent.src);
           url: meta && meta.og && meta.og.url ? meta.og.url : canonical || pageUrl,
         },
         optional: {
-          description: meta && meta.og && meta.og.description ? meta.og.description : description,
+          description:
+            meta && meta.og && meta.og.description
+              ? meta.og.description
+              : meta && meta.description
+                ? meta.description
+                : description,
           siteName: 'Datum',
           locale: 'en_US',
         },

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -26,7 +26,7 @@ const { Content } = await render(page);
       <div class="max-width max-w-(--breakpoint---internal)">
         <div class="grid grid-cols-6 gap-8 md:gap-15 lg:gap-25 xl:gap-28">
           <div class="col-span-6 md:col-span-3">
-            <h2 class="datum-text-8xl mb-5 lg:mb-8">{fm.title}</h2>
+            <h1 class="datum-text-8xl mb-5 lg:mb-8">{fm.title}</h1>
             <div class="datum-prose-lg">
               <Content />
             </div>


### PR DESCRIPTION
Resolves the actionable bugs from the weekly SEO audit (#1339). Scope: high-confidence bug fixes + the root cause behind the false-positive `noindex` flags. Marketing-copy rewrites (description length) and the low-severity duplicate-H1 items are intentionally left for a follow-up.

## Changes

| Fix | File |
|---|---|
| **noindex root cause** — build the audit in `NODE_ENV=production` (scoped to the build step so `npm ci` still installs devDeps) so audits reflect the live, indexable site instead of the dev-mode `noindex` default | `.github/workflows/seo-review.yml` |
| **changelog og:title typo** — `What we shippped` → `What we shipped` | `src/content/changelog/index.md` |
| **contact missing H1** — page title rendered as `<h2>` (Hero was `hideContent`), now `<h1>` | `src/pages/contact.astro` |
| **handbook og:description `null` ×7** — og:description now falls back to `meta.description`; fixes all handbook pages with one change | `src/layouts/Layout.astro` |

## Important: the "16 noindex pages" was a false positive
The audit workflow built with `NODE_ENV: development`, and `Layout.astro` gates indexability on `noindex={!isProduction}` — so every page in that build was `noindex,nofollow`. The actual deploy (`Dockerfile` → `NODE_ENV=production`) ships those pages as indexable. Verified: the production `dist/client` output emits no `robots` meta tag. **No live page was ever de-indexed.** This PR makes the audit build match production so the false alarm stops.

## Verification
Ran a full `NODE_ENV=production npm run build` and confirmed in `dist/client`:
- `changelog` → `og:title` = `What we shipped`
- `contact` → exactly 1 `<h1>`
- `handbook/about` → `og:description` populated (was null)
- no `robots` meta on changelog/contact (indexable)

## Not in this PR (flagged for follow-up)
- Meta description trims (>160) on brand/social, imagery, typography, events ×2, features; expansions (<70) on careers, brand/templates — marketing copy
- Duplicate H1 ×8 on handbook pages (`Hero` "Handbook" + Article title) — low severity, needs shared `Hero` change
- Missing alt text ×2 (community-huddles, features)
- Twitter/OG image mismatch — appears already resolved in current `Layout.astro`; likely a stale finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)