### PR TITLE
fix(seo): resolve audit findings from #1361

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
+        "sharp": "^0.34.5",
         "sirv": "^3.0.2",
         "slugify": "^1.6.9",
         "tailwindcss": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
+    "sharp": "^0.34.5",
     "sirv": "^3.0.2",
     "slugify": "^1.6.9",
     "tailwindcss": "^4.3.0",

--- a/scripts/seo-review.mjs
+++ b/scripts/seo-review.mjs
@@ -95,7 +95,17 @@ function extractMeta($, urlPath) {
     .map((_, el) => $(el).text().trim())
     .get();
   const imgs = $('img').toArray();
-  const imgsMissingAlt = imgs.filter((el) => !($(el).attr('alt') || '').trim()).length;
+  // An image is "missing alt" only if it has no `alt` attribute and is not marked decorative.
+  // `alt=""` is the canonical way to mark decorative images; aria-hidden="true" and role=presentation/none
+  // also explicitly exempt an image from needing alt text.
+  const imgsMissingAlt = imgs.filter((el) => {
+    const $el = $(el);
+    if ($el.attr('alt') !== undefined) return false; // empty or non-empty alt: not missing
+    const ariaHidden = ($el.attr('aria-hidden') || '').toLowerCase() === 'true';
+    const role = ($el.attr('role') || '').toLowerCase();
+    if (ariaHidden || role === 'presentation' || role === 'none') return false;
+    return true;
+  }).length;
 
   const jsonLdNodes = $('script[type="application/ld+json"]');
   const jsonLdTypes = jsonLdNodes

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -11,12 +11,15 @@ import type { HeroProps } from '@/src/types/common';
 const {
   iconName = '',
   title = '',
+  titleTag = 'h1',
   subtitle = '',
   description = '',
   class: className,
   imagePath,
   hideContent = false,
 } = Astro.props as HeroProps;
+
+const TitleTag = titleTag;
 ---
 
 <header class:list={['hero--main', className]}>
@@ -48,7 +51,9 @@ const {
               </div>
             ) : null}
 
-            {title && <h1 class="hero--main-content-title" set:html={marked.parseInline(title)} />}
+            {title && (
+              <TitleTag class="hero--main-content-title" set:html={marked.parseInline(title)} />
+            )}
             {description && (
               <p
                 class="hero--main-content-description"

--- a/src/content/changelog/index.md
+++ b/src/content/changelog/index.md
@@ -5,6 +5,6 @@ meta:
   title: "Datum Changelog: Feature Releases and Product Updates"
   description: "Stay up-to-date with Datum's latest feature releases, bug fixes, and improvements for our AI-native solutions, Edge Networking platform, and open source cloud."
   og:
-    title: What we shipped
+    title: "Datum Changelog: What we shipped"
     description: Stay up to date and in the know about product improvements and launches.
 ---

--- a/src/content/handbook/about/index.md
+++ b/src/content/handbook/about/index.md
@@ -8,7 +8,7 @@ updatedDate: Nov 13, 2025
 authors: jacob
 meta:
   title: "Datum Company Overview - Our Mission & Strategy"
-  description: "Learn about Datum's purpose and strategy. We are upgrading the internet with a neutral, open source interconnection system to give every builder access to core internet capabilities."
+  description: "Datum's purpose and strategy: upgrading the internet with a neutral, open-source interconnection system to give every builder core internet capabilities."
   og:
     title: "Why Datum"
 ---

--- a/src/content/handbook/build/incidents.md
+++ b/src/content/handbook/build/incidents.md
@@ -7,7 +7,7 @@ updatedDate: Nov 13, 2025
 authors: jacob
 meta:
   title: "Incident Post-Mortems & RCAs at Datum - Datum Handbook"
-  description: "How we define incidents, respond to incidents to mitigate customer impact through following our incident reporting procedure to problem solve and prevent reoccuring incidents"
+  description: "How Datum defines and responds to incidents — from initial detection to post-mortem — to protect customers and prevent recurrence."
   og:
     title: "Incidents"
 ---

--- a/src/content/handbook/build/index.md
+++ b/src/content/handbook/build/index.md
@@ -7,7 +7,7 @@ updatedDate: Nov 13, 2025
 authors: jacob
 meta:
   title: "Engineering & Design Principles - Datum Handbook"
-  description: "How we work - As an operator-led culture, we put a lot of emphasis on our global infrastructure, open source components, and the engineering principles behind our neutral platform."
+  description: "Datum's engineering culture: global infrastructure, open-source components, and the principles behind our neutral, operator-led platform."
   og:
     title: "How we work"
 ---

--- a/src/content/handbook/eos/3-year-picture.md
+++ b/src/content/handbook/eos/3-year-picture.md
@@ -7,7 +7,7 @@ updatedDate: Jan 21, 2026
 authors: jacob
 meta:
   title: "3 Year Picture - Datum Handbook"
-  description: "Learn about Datum's 3-year vision"
+  description: "Datum's 3-year vision: where we aim to be as an open network cloud company and the milestones guiding our growth and strategy."
   og:
     title: "3 Year Picture"
 ---

--- a/src/content/handbook/eos/quarterly-rocks.md
+++ b/src/content/handbook/eos/quarterly-rocks.md
@@ -18,7 +18,7 @@ We define rocks as the critical things we prioritize (at the expense of other th
 
 A single person on the leadership team is accountable for each rock. While there is plenty of good debate about responsibility vs accountability, we prefer accountability in this context. Essentially, if you “own” a particular rock or metric, you are making a pledge to your colleagues that you will do what it takes (including asking for help, delegating key tasks, making hard trade-offs, etc) to get it done.    
 
-# Q2 2026 Rocks
+## Q2 2026 Rocks
 For this quarter we’re focused on the following major initiatives (as well as plenty of pebbles and sand). Please note, we’ve slightly sanitized these for public consumption.
 
 ## Design Win Partners Formally Engaged (Manish)
@@ -45,7 +45,7 @@ We will know this is done when the partners are secured, the program is publicly
 ## Developer Pipeline Activated (Jacob)
 We will know this is done when Datum has meaningfully grown top-of-funnel developer mindshare across key communities, measured by 500+ new users on the platform. 
 
-# Previous Rocks
+## Previous Rocks
 For context and history buffs, here are the rocks we worked on during Q1 2026:
 
 - AI CDN Started with Roadmap (Zac)

--- a/src/content/handbook/eos/vto.md
+++ b/src/content/handbook/eos/vto.md
@@ -7,10 +7,10 @@ updatedDate: Jan 21, 2026
 authors: jacob
 meta:
   title: "Vision / Traction Organizer - Datum Handbook"
-  description: "Our business values, purpose and long-term vision"
+  description: "Datum's Vision/Traction Organizer: our business values, core purpose, and long-term company vision as defined by our EOS framework."
   og:
     title: "Understanding our Vision / Traction Organizer"
-    description: "Our business values, purpose and long-term vision"
+    description: "Datum's Vision/Traction Organizer: our business values, core purpose, and long-term company vision as defined by our EOS framework."
 ---
 
 The “Vision / Traction Organizer” captures the core DNA of our business: our values, purpose, and long-term vision. As a team we review this document once per year to ensure it still fits.

--- a/src/content/handbook/eos/weekly-scorecard.md
+++ b/src/content/handbook/eos/weekly-scorecard.md
@@ -7,7 +7,7 @@ updatedDate: Jan 21, 2026
 authors: jacob
 meta:
   title: "Weekly Scorecard - Datum Handbook"
-  description: "How Datum Operates - Keeping track of our weekly metrics"
+  description: "How Datum tracks weekly metrics using our EOS scorecard — keeping the team accountable, aligned, and focused on measurable goals."
   og:
     title: "Weekly Scorecard"
 ---

--- a/src/content/handbook/operate/how-we-hire.md
+++ b/src/content/handbook/operate/how-we-hire.md
@@ -7,7 +7,7 @@ updatedDate: Feb 2, 2026
 authors: jacob
 meta:
   title: "How we hire - Datum Careers"
-  description: "Understand the interview process and how we hire for open roles"
+  description: "A guide to Datum's hiring process: from applications and interviews to offers, so you know what to expect at every stage."
   og:
       title: "How we approach hiring for open roles"
       description: "Learn about our hiring process: from applications to interviews"

--- a/src/content/handbook/operate/open-by-default.md
+++ b/src/content/handbook/operate/open-by-default.md
@@ -7,7 +7,7 @@ updatedDate: Jan 21, 2026
 authors: jacob
 meta:
   title: "Open source - Datum Handbook"
-  description: "Datum's Open Source Strategy - Our approach to building a sustainable open source company. Learn about Datum's commercial strategy, AGPLv3 licensing, and how we prioritize value for builders."
+  description: "Datum's open source strategy: AGPLv3 licensing, commercial COSS model, and how we prioritize value for builders and the community."
   og:
     title: "Open by default"
 ---

--- a/src/content/handbook/policy/disaster-recovery.md
+++ b/src/content/handbook/policy/disaster-recovery.md
@@ -7,7 +7,7 @@ updatedDate: Nov 13, 2025
 authors: jacob
 meta:
   title: "Datum Disaster Recovery Policy - RTO & RPO Standards - Datum Handbook"
-  description: "Ensuring platform availability. Learn about our disaster recovery strategies, including failover testing, backup restoration, and maintaining resilience for your workloads."
+  description: "Datum's disaster recovery strategies: failover testing, backup restoration, and resilience standards to maintain platform availability."
   og:
     title: "Disaster recovery policy"
 ---

--- a/src/content/handbook/product/index.md
+++ b/src/content/handbook/product/index.md
@@ -6,7 +6,7 @@ sidebar:
 updatedDate: Feb 15, 2026
 authors: jacob
 meta:
-  title: "Datum's Product Strategy - Vision, Values, and Rituals - Datum Handbook"
+  title: "Datum Product Strategy – Vision, Values & Rituals"
   description: "The nuts and bolts about how Datum is working to unlock internet superpowers for every agent, builder, and developer."
   og:
     title: "Product vision, values, and rituals"

--- a/src/content/legal/privacy.mdx
+++ b/src/content/legal/privacy.mdx
@@ -3,8 +3,8 @@ title: "Privacy Policy"
 slug: privacy
 description: "Learn how Datum Technology, Inc. handles the personal information that we collect through our website and other digital properties."
 meta:
-  title: "Privacy Policy - Datum Open Network Cloud - Data Protection & CCPA Rights"
-  description: "Learn how Datum protects your personal information across our open-source network cloud platform. CCPA-compliant privacy policy covering data collection, user rights, and security practices for AI-native networking services."
+  title: "Datum Privacy Policy – Data Protection & CCPA Rights"
+  description: "Learn how Datum protects your data across our open-source network cloud. CCPA-compliant policy covering data collection, user rights, and security."
   og:
     title: Privacy Policy - Datum Cloud
 ---

--- a/src/content/legal/service-country-specific-terms.mdx
+++ b/src/content/legal/service-country-specific-terms.mdx
@@ -4,7 +4,7 @@ slug: service-country-specific-terms
 description: "Additional requirements that apply to specific Datum services, third-party products and services made available through the Datum platform, and country-specific regulatory requirements."
 meta:
   title: "Service Country Specific Terms - Datum Cloud"
-  description: "Additional requirements that apply to specific Datum services, third-party products and services made available through the Datum platform, and country-specific regulatory requirements."
+  description: "Country-specific terms for Datum services, third-party products available via the Datum platform, and applicable regulatory requirements."
   og:
     title: "Datum Legal Terms"
     description: "Learn about the country specific regulatory requirements when using Datum"

--- a/src/content/pages/brand/color.mdx
+++ b/src/content/pages/brand/color.mdx
@@ -4,7 +4,7 @@ meta:
   title: "Datum Brand Colors: Official Palette & Design Codes"
   description: "Access the official color palette for Datum. Get hex codes, primary and secondary color usage for the open network cloud brand identity."
   og:
-    title: "Color"
+    title: "Datum Brand Colors"
     description: "The official color palette for Datum. Get hex codes, primary and secondary color usage for the open network cloud brand identity."
     image: "../../images/og/brand.png"
 ---

--- a/src/content/pages/brand/iconography.mdx
+++ b/src/content/pages/brand/iconography.mdx
@@ -4,7 +4,7 @@ meta:
   title: "Datum Iconography: Official Icon Set & Usage Guidelines"
   description: "Datum uses the open-source Lucide icon library to provide lightweight, scalable vector symbols with a friendly yet precise tone across all digital experiences."
   og:
-    title: "Iconography"
+    title: "Datum Iconography"
     image: "../../images/og/brand.png"
 ---
 

--- a/src/content/pages/brand/imagery.mdx
+++ b/src/content/pages/brand/imagery.mdx
@@ -2,7 +2,7 @@
 title: "The Datum illustrations"
 meta:
   title: "Datum Illustration Suite: Milo, The Team & Brand Imagery"
-  description: "Explore the cornerstone of the Datum brand identity: the Illustration Suite, featuring brand characters Milo and The Team, and guidelines for the visual brand universe."
+  description: "Explore Datum's Illustration Suite — featuring brand characters Milo and The Team, plus guidelines for the full visual brand universe."
   og:
     title: "The Datum illustrations"
     image: "../../images/og/brand.png"

--- a/src/content/pages/brand/principles.mdx
+++ b/src/content/pages/brand/principles.mdx
@@ -3,7 +3,7 @@ title: "Design Principles"
 slug: 'brand/principles'
 description: A concise encapsulation of the core personality traits of our brand and user experiences.
 meta:
-  title: "Datum Brand Principles: Grounded, Visionary, & Ethical Design"
+  title: "Datum Brand Principles: Grounded, Visionary & Ethical"
   description: "Explore Datum's core principles: Grounded and Visionary; Approachable and Expert; Proactive and Driven; and Conscientious and Ethical."
   og:
     title: "Design Principles"

--- a/src/content/pages/brand/social.mdx
+++ b/src/content/pages/brand/social.mdx
@@ -2,8 +2,8 @@
 title: "Social logos and favicons"
 description: "Download Datum's social brand assets, and icons for your projects."
 meta:
-  title: "Social Media Assets - Datum Brand Favicons, Icons & GitHub Imagery"
-  description: "Download Datum's official social brand assets including favicons, social icons, Opengraph images, and GitHub graphics for your digital, marketing, or development projects."
+  title: "Datum Social Assets: Favicons, Icons & OG Images"
+  description: "Download Datum's official social assets: favicons, social icons, OpenGraph images, and GitHub graphics for digital and marketing projects."
   og:
     title: "Social logos and favicons"
     image: "../../images/og/brand.png"

--- a/src/content/pages/brand/templates.mdx
+++ b/src/content/pages/brand/templates.mdx
@@ -2,9 +2,9 @@
 title: "Templates"
 meta:
   title: "Brand Templates - Datum Brand Assets"
-  description: "Download Datum's official templates."
+  description: "Download Datum's official presentation, document, and design templates — ready-to-use assets aligned with our brand guidelines."
   og:
-    title: "Brand templates"
+    title: "Datum Brand Templates"
     image: "../../images/og/brand.png"
 ---
 

--- a/src/content/pages/brand/typography.mdx
+++ b/src/content/pages/brand/typography.mdx
@@ -4,7 +4,7 @@ meta:
   title: "Datum Design: Brand Typography & Typefaces"
   description: "Review Datum's official brand design assets, featuring our core typefaces, Canela and Alliance No.1. which reflects our unique ethos as an open, global tech company."
   og:
-    title: "Typography"
+    title: "Datum Brand Typography"
     image: "../../images/og/brand.png"
 ---
 

--- a/src/content/pages/career.mdx
+++ b/src/content/pages/career.mdx
@@ -5,7 +5,7 @@ description: "Get to know how we work at Datum: from a people-first culture to a
 slug: career
 meta:
   title: "Work at Datum - Datum Careers"
-  description: "We're hiring! Explore open roles at Datum"
+  description: "Explore open roles at Datum. We're building the open network cloud for AI and hiring thoughtful engineers, marketers, and operators."
   og:
     title: "Join the Datum Team"
     description: "We're assembling a team of thoughtful, creative, and driven professionals who are inspired to build what's next. See our open roles."

--- a/src/content/pages/events/alt-cloud-meetups.mdx
+++ b/src/content/pages/events/alt-cloud-meetups.mdx
@@ -3,8 +3,8 @@ title: "Alt Cloud Meetups"
 slug: "alt-cloud-meetups"
 description: "Join us for an informal, geeky, growth-oriented meetup all about the Alt Clouds that build their value directly on top of infrastructure: GPU clouds, AI clouds, data clouds, developer clouds, connectivity cloud, sovereign clouds…and more!"
 meta:
-    title: "Datum Alt Cloud Meetups – Meetups, Conferences & Community Gatherings"
-    description: "Discover upcoming Datum events, conferences, and community meetups. Join us to learn about open-source network cloud, AI-native connectivity, and connect with fellow developers."
+    title: "Datum Alt Cloud Meetups – Events & Meetups"
+    description: "Join Datum's Alt Cloud Meetups to connect with open-source network cloud builders, AI-native developers, and alt-cloud providers near you."
     og:
       title: "Alt Cloud Meetups"
 ---

--- a/src/content/pages/events/community-huddles.mdx
+++ b/src/content/pages/events/community-huddles.mdx
@@ -3,8 +3,8 @@ title: "Monthly Community Huddles"
 slug: "community-huddles"
 description: "A monthly huddle that is both open and informal to discuss Datum and related technologies. Demos! Discussion! Feedback! Modest Complaining!"
 meta:
-    title: "Datum Monthly Community Huddles – Meetups, Conferences & Community Gatherings"
-    description: "Discover upcoming Datum events, conferences, and community meetups. Join us to learn about open-source network cloud, AI-native connectivity, and connect with fellow developers."
+    title: "Datum Monthly Community Huddles – Events & Meetups"
+    description: "Datum's monthly community huddles bring together builders and developers. Join us online or in person to discuss open-source cloud and AI connectivity."
     og:
       title: "Monthly Community Huddles"
 ---

--- a/src/content/pages/home.mdx
+++ b/src/content/pages/home.mdx
@@ -8,7 +8,7 @@ contents:
   - home/what-does-good-look-like
 meta:
   title: "Datum - Open Source Network Cloud for AI"
-  description: "Datum is an open, neutral, global network cloud that is built for AI and focused on giving alternative cloud providers critical network infrastructure to compete at scale, no networking team required!"
+  description: "Datum is an open, neutral, global network cloud built for AI — giving alternative cloud providers critical network infrastructure to compete at scale."
   og:
     title: "Connected infrastructure for AI – no network team required!"
     description: "Designed to power the next wave of innovation"

--- a/src/layouts/LayoutSimple.astro
+++ b/src/layouts/LayoutSimple.astro
@@ -28,10 +28,24 @@ const isProduction = import.meta.env.MODE === 'production';
 const pageUrl = Astro.site ? new URL(Astro.url.pathname, Astro.site).href : Astro.url.href;
 const imageContent = image ? image : defaultOgImage;
 
+// Resolve an image src to an absolute URL for og:image / twitter:image.
+// Facebook/LinkedIn OG scrapers require absolute URLs; relative paths get dropped.
+const siteBase = Astro.site?.href ?? 'https://www.datum.net';
+const toAbsoluteUrl = (src: string): string => {
+  if (!src || src.startsWith('http')) return src;
+  return new URL(src, siteBase).href;
+};
+
 // Overwrite with meta
 const titleValue = (meta && meta.title ? meta.title : title).replace(/<[^>]*>/g, '');
 const descriptionValue =
   meta && meta.description ? meta.description : description ? description : '';
+const twitterImage =
+  meta && meta.og && meta.og.image ? meta.og.image : defaultOgImage ? defaultOgImage : image;
+const ogImageUrl = toAbsoluteUrl(
+  meta && meta.og && meta.og.image ? meta.og.image.src : imageContent.src
+);
+const twitterImageUrl = toAbsoluteUrl(twitterImage?.src ?? imageContent.src);
 ---
 
 <!doctype html>
@@ -92,7 +106,7 @@ const descriptionValue =
         basic: {
           title: meta && meta.og && meta.og.title ? meta.og.title : title,
           type: article ? 'article' : 'website',
-          image: meta && meta.og && meta.og.image ? meta.og.image.src : imageContent.src,
+          image: ogImageUrl,
           url: meta && meta.og && meta.og.url ? meta.og.url : canonical || pageUrl,
         },
         optional: {
@@ -113,9 +127,10 @@ const descriptionValue =
         card: 'summary_large_image',
         site: config.socials.twitter.handle || '@datumcloud',
         creator: config.socials.twitter.handle || '@datumcloud',
-        title: titleValue,
-        description: descriptionValue,
-        image: imageContent.src,
+        title: meta && meta.og && meta.og.title ? meta.og.title : titleValue,
+        description:
+          meta && meta.og && meta.og.description ? meta.og.description : descriptionValue,
+        image: twitterImageUrl,
       }}
       extend={{
         meta: [

--- a/src/pages/handbook/[...slug].astro
+++ b/src/pages/handbook/[...slug].astro
@@ -94,7 +94,7 @@ const breadcrumbJsonLd = {
   jsonLd={breadcrumbJsonLd}
 >
   <section class="datum-container">
-    <Hero class="light linear-gradient-light" title="Handbook" />
+    <Hero class="light linear-gradient-light" title="Handbook" titleTag="h2" />
 
     <Article articleId={slug} />
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -43,6 +43,7 @@ export interface PaginationProps {
 export interface HeroProps {
   iconName?: string;
   title?: string;
+  titleTag?: 'h1' | 'h2';
   subtitle?: string;
   description?: string;
   class?: string;


### PR DESCRIPTION
Resolves the actionable findings from the weekly SEO audit (#1361). Mix of high-impact template fixes and copy edits.

## Code / template fixes

| Fix | File |
|---|---|
| **Duplicate H1 on all 66 handbook pages** — `Hero` now accepts a `titleTag` prop; handbook page passes `titleTag="h2"` so the article title stays the page's sole H1 | `src/components/Hero.astro`, `src/types/common.ts`, `src/pages/handbook/[...slug].astro` |
| **Brand pages emitted relative `og:image` and a stale `twitter:image`** — ported the `toAbsoluteUrl` helper from `Layout.astro` so `LayoutSimple.astro` emits absolute URLs; aligned `twitter:image`/`twitter:title`/`twitter:description` with `meta.og.*` instead of falling back to `default.png` and the page title | `src/layouts/LayoutSimple.astro` |
| **Audit false-positives on `alt=""`/`aria-hidden`/`role="presentation"`** — these are the canonical a11y patterns for decorative images; the audit now only flags genuinely missing `alt` attributes | `scripts/seo-review.mjs` |
| **`quarterly-rocks.md` was emitting 4 H1s** — demoted two stray `#` headings to `##` | `src/content/handbook/eos/quarterly-rocks.md` |

## Copy fixes (content/*)

- **Titles trimmed to ≤60 chars** on 6 pages (was up to 77): `/events/community-huddles`, `/events/alt-cloud-meetups`, `/legal/privacy`, `/handbook/product`, `/brand/social`, `/brand/principles`
- **Descriptions trimmed to ≤155 chars** on 10 pages (was up to 224): `/`, `/handbook/about`, `/handbook/build`, `/handbook/build/incidents`, `/handbook/policy/disaster-recovery`, `/handbook/operate/open-by-default`, `/legal/privacy`, `/legal/service-country-specific-terms`, `/brand/imagery`, `/events/community-huddles` (+ `/events/alt-cloud-meetups`)
- **Descriptions expanded to ≥70 chars** on 6 thin pages (was as low as 33): `/careers`, `/brand/templates`, `/handbook/eos/3-year-picture`, `/handbook/eos/vto`, `/handbook/eos/weekly-scorecard`, `/handbook/operate/how-we-hire`
- **`og:title` rebranded** on 4 brand sub-pages + changelog (e.g. `"Color"` → `"Datum Brand Colors"`, `"What we shipped"` → `"Datum Changelog: What we shipped"`) so they carry brand context when shared socially

## Verification

Ran `NODE_ENV=production npm run build` and `astro check` (0 errors, 0 warnings), then spot-checked `dist/client`:

- All 66 handbook pages: exactly 1 `<h1>` (was 2 before; 4 on \`quarterly-rocks\`)
- \`/brand/social\` \`og:image\`: \`https://www.datum.net/_astro/brand.F7NguY8x.png\` (absolute, was relative)
- \`/brand/social\` \`twitter:image\`: matches \`og:image\` (was \`default.png\`)
- \`/brand/color\` \`og:title\`: \`"Datum Brand Colors"\` (was \`"Color"\`)
- All edited titles: 42–53 chars
- All edited descriptions: 121–153 chars

## Test plan

- [ ] CI green (build, type check, SEO review on PR)
- [ ] Spot-check a handbook page in preview — one `<h1>`, "Handbook" label visually unchanged (styled by class, not tag)
- [ ] Spot-check \`/brand/social\` social preview (e.g. via opengraph.xyz) — image and title resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)