### PR TITLE
fix(ci): make seo-review detect PR changes reliably

### DIFF
--- a/.github/workflows/seo-review.yml
+++ b/.github/workflows/seo-review.yml
@@ -66,9 +66,15 @@ jobs:
         run: |
           base="${{ github.event.pull_request.base.sha }}"
           head="${{ github.event.pull_request.head.sha }}"
+          # The PR merge-ref checkout does not always contain base.sha, so a bare
+          # `git diff "$base"` dies with "fatal: bad object". Fetch both commits
+          # explicitly, then diff with merge-base (three-dot) semantics. No `|| true`:
+          # a broken diff must fail the job, not silently report "no changes".
+          git fetch --no-tags --quiet origin "$base" "$head"
+          changed="$(git diff --name-only "$base...$head" -- 'src/pages/**' 'src/content/**')"
           {
             echo 'files<<EOF'
-            git diff --name-only "$base" "$head" -- 'src/pages/**' 'src/content/**' || true
+            printf '%s\n' "$changed"
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Problem
On #1364 the **SEO Review** job passed green but the bot reported `skipped-no-changes`, even though the PR changed 11 files under `src/content/**`.

Root cause (from the CI log): the "Collect changed page files" step diffed against `pull_request.base.sha`, but the PR merge-ref checkout does not always contain that commit, so `git diff` died with:
```
fatal: bad object 8a15dce5c9414fdda4be09ac408f5026eed17b35
```
The trailing `|| true` swallowed the failure → `CHANGED_FILES` empty → `skipped-no-changes`, while the job still passed.

## Fix
- Fetch `base` and `head` explicitly before diffing.
- Use merge-base (three-dot `base...head`) semantics for "changes introduced by the PR".
- Drop `|| true` so a broken diff fails the job instead of silently reporting no changes.

## Verification
- YAML validated. ✅
- Replayed the exact diff with #1364's base/head SHAs locally → returns the **11 changed files** (was 0). ✅
- Full runner-side verification (`git fetch origin <sha>`) happens when this runs in CI; github.com supports fetch-by-SHA.