### PR TITLE
fix(seo): SEO review follow-ups — descriptions, titles, og:titles, Article JSON-LD

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -141,6 +141,7 @@ const handbooks = defineCollection({
       draft: z.boolean().optional(),
       readingTime: z.string().optional(),
       lastModified: z.string().optional(),
+      updatedDate: z.string().optional(),
       authors: z.string().optional(),
       sidebar: z.object({
         label: z.string().optional(),

--- a/src/content/handbook/operate/open-by-default.md
+++ b/src/content/handbook/operate/open-by-default.md
@@ -6,7 +6,7 @@ sidebar:
 updatedDate: Jan 21, 2026
 authors: jacob
 meta:
-  title: "Open source - Datum Handbook"
+  title: "Open by Default: AGPLv3 & COSS Strategy - Datum Handbook"
   description: "Datum's open source strategy: AGPLv3 licensing, commercial COSS model, and prioritizing value for builders and the community."
   og:
     title: "Open by default"

--- a/src/content/handbook/pay-perks/benefits.md
+++ b/src/content/handbook/pay-perks/benefits.md
@@ -6,10 +6,10 @@ sidebar:
 updatedDate: May 11, 2026
 authors: jacob
 meta:
-  title: "Benefits - Datum Handbook"
+  title: "Employee Benefits: Health, Equipment & PTO - Datum Handbook"
   description: "Explore the benefits at Datum beyond equity: time off, equipment budgets, health care, retirement, and country-specific programs."
   og:
-    title: "Benefits at Datum"
+    title: "Employee Benefits at Datum"
     description: "What Datum offers beyond salary and equity."
 ---
 

--- a/src/content/handbook/pay-perks/compensation.md
+++ b/src/content/handbook/pay-perks/compensation.md
@@ -6,7 +6,7 @@ sidebar:
 updatedDate: May 11, 2026
 authors: jacob
 meta:
-  title: "Compensation - Datum Handbook"
+  title: "Salary, Levels & Pay Reviews - Datum Handbook"
   description: "Explore how Datum structures salary, levels, steps, benchmarking, and pay reviews as part of our commitment to transparency."
   og:
     title: "Compensation at Datum"

--- a/src/content/handbook/policy/incident-disclosure.md
+++ b/src/content/handbook/policy/incident-disclosure.md
@@ -7,7 +7,7 @@ updatedDate: Nov 13, 2025
 authors: jacob
 meta:
   title: "Datum Incident Disclosure Policy - Datum Handbook"
-  description: "We believe in radical transparency. Explore Datum's policy on disclosing security incidents and vulnerabilities to customers, partners, and the open source community."
+  description: "Datum's radical-transparency incident disclosure policy: how we notify customers, partners, and the open source community of security vulnerabilities."
   og:
     title: "Incident disclosure policy"
 ---

--- a/src/content/handbook/product/customers.md
+++ b/src/content/handbook/product/customers.md
@@ -7,7 +7,7 @@ updatedDate: Nov 13, 2025
 authors: jacob
 meta:
   title: "Customer Segments & Market Focus at Datum - Datum Handbook"
-  description: "Empowering the builders. Read about the user personas that drive our product decisions, from network architects to developers needing programmable infrastructure."
+  description: "Empowering the builders. Read about the user personas driving our product decisions — from network architects to developers needing programmable infrastructure."
   og:
     title: "Who we are building for"
 ---

--- a/src/content/handbook/product/fit.md
+++ b/src/content/handbook/product/fit.md
@@ -7,7 +7,7 @@ updatedDate: Nov 13, 2025
 authors: jacob
 meta:
   title: "Datum Product to Market Fit Philosophy - Datum Handbook"
-  description: "Where Datum fits in the cloud ecosystem. Our perspective on Product-Market Fit (PMF), distinguishing our open network cloud from hyperscalers and traditional ISPs."
+  description: "Where Datum fits in the cloud ecosystem: our take on PMF and how our open network cloud differs from hyperscalers and traditional ISPs."
   og:
     title: "How we fit"
 ---

--- a/src/content/handbook/product/milo.md
+++ b/src/content/handbook/product/milo.md
@@ -7,9 +7,9 @@ updatedDate: Nov 13, 2025
 authors: jacob
 meta:
   title: "Milo - Datum's Open Source Business Operating System"
-  description: "Automate your operations. A technical guide to Milo, the open source backend that unifies identity, metering, and policy management for modern service providers."
+  description: "A technical guide to Milo, the open source backend unifying identity, metering, and policy management for modern service providers. Automate your operations."
   og:
-    title: "Milo"
+    title: "Milo — Datum's Open Source Business Operating System"
 ---
 
 [Milo is an open source](https://www.milo-os.com/) ‘system of action’ for product-led, B2B companies. Think of it as a business control plane designed specifically for cloud service providers, helping them innovate faster and scale better with less toil.

--- a/src/content/handbook/product/pricing.md
+++ b/src/content/handbook/product/pricing.md
@@ -7,9 +7,9 @@ updatedDate: Nov 13, 2025
 authors: jacob
 meta:
   title: "Pricing Tiers & Models - Datum Product Strategy"
-  description: "Understanding our billing model. A guide to Datum's pricing tiers, from the free Builder plan to Enterprise interconnection, and the logic behind our rate limits."
+  description: "A guide to Datum's pricing tiers — from the free Builder plan to Enterprise interconnection — and the logic behind our rate limits."
   og:
-    title: "Pricing"
+    title: "Datum Pricing Tiers & Models"
 ---
 
 We currently have outlined three tiers of service. Only time in the market will tell us if we’re correct, and where we need to evolve. Since this entry is likely to get out of date from time to time, please check our [pricing page](/pricing) for the latest official details. 

--- a/src/content/handbook/product/roadmap.md
+++ b/src/content/handbook/product/roadmap.md
@@ -9,7 +9,7 @@ meta:
   title: "Datum Product Roadmap - Future Releases & Strategy"
   description: "What's next for Datum? Read our roadmap to see planned updates for the AI Gateway, Adaptive Proxy, and global interconnection services."
   og:
-    title: "Roadmap"
+    title: "Datum Product Roadmap"
 ---
 
 Working in the open is a core construct at Datum, but the area of transparency that we put the most effort into is communicating our roadmap as well as our backlog for consideration.

--- a/src/pages/handbook/[...slug].astro
+++ b/src/pages/handbook/[...slug].astro
@@ -7,6 +7,10 @@ import Article from '@components/handbook/Article.astro';
 import defaultOgImage from '@content/images/og/handbook.png';
 
 import { getCollection, render } from 'astro:content';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+
+dayjs.extend(customParseFormat);
 
 // const currentPostIndex = handbooks.findIndex((post) => post.id == Astro.params.slug);
 export async function getStaticPaths() {
@@ -46,7 +50,7 @@ export async function getStaticPaths() {
 
 const { slug } = Astro.params;
 const { entry } = Astro.props;
-const { title, description, meta } = entry.data;
+const { title, description, meta, updatedDate, authors } = entry.data;
 
 // Set default handbook OG image if not specified in frontmatter
 const handbookMeta = {
@@ -79,10 +83,38 @@ breadcrumbItems.push({
   item: `https://www.datum.net/handbook/${slug}/`,
 });
 
-const breadcrumbJsonLd = {
+// Article JSON-LD — `updatedDate` is authored as a human-readable string ("Nov 13, 2025");
+// fall back to undefined when missing so we don't emit invalid dates.
+const parsedUpdated = updatedDate ? dayjs(updatedDate, 'MMM D, YYYY') : null;
+const updatedIso = parsedUpdated && parsedUpdated.isValid() ? parsedUpdated.toISOString() : null;
+const pageUrl = `https://www.datum.net/handbook/${slug}`;
+
+const articleDescription = description || meta?.description;
+
+const articleJsonLd: Record<string, unknown> = {
+  '@type': 'TechArticle',
+  headline: title,
+  ...(articleDescription ? { description: articleDescription } : {}),
+  url: pageUrl,
+  mainEntityOfPage: pageUrl,
+  inLanguage: 'en',
+  isPartOf: { '@type': 'WebSite', name: 'Datum Handbook', url: 'https://www.datum.net/handbook/' },
+  publisher: {
+    '@type': 'Organization',
+    name: 'Datum',
+    url: 'https://www.datum.net/',
+    logo: {
+      '@type': 'ImageObject',
+      url: 'https://www.datum.net/images/logo-datum.png',
+    },
+  },
+  ...(updatedIso ? { datePublished: updatedIso, dateModified: updatedIso } : {}),
+  ...(authors ? { author: { '@type': 'Person', name: authors } } : {}),
+};
+
+const handbookJsonLd = {
   '@context': 'https://schema.org',
-  '@type': 'BreadcrumbList',
-  itemListElement: breadcrumbItems,
+  '@graph': [{ '@type': 'BreadcrumbList', itemListElement: breadcrumbItems }, articleJsonLd],
 };
 ---
 
@@ -91,7 +123,7 @@ const breadcrumbJsonLd = {
   description={description}
   bodyClass={`page-handbook page-handbook--${slug}`}
   meta={handbookMeta}
-  jsonLd={breadcrumbJsonLd}
+  jsonLd={handbookJsonLd}
 >
   <section class="datum-container">
     <Hero class="light linear-gradient-light" title="Handbook" titleTag="h2" />


### PR DESCRIPTION
Follow-up to #1364, closing the remaining items from the [SEO review on that PR](https://github.com/datum-cloud/datum.net/pull/1364#issuecomment-4599079271). Most are copy tweaks; the one structural change is adding `TechArticle` JSON-LD to handbook pages.

## Content (10 files)

### 5 descriptions trimmed to ≤160 chars

| Page | Was | Now |
|---|---|---|
| `/handbook/policy/incident-disclosure` | 166 | 150 |
| `/handbook/product/customers` | 162 | 160 |
| `/handbook/product/fit` | 163 | 135 |
| `/handbook/product/milo` | 161 | 157 |
| `/handbook/product/pricing` | 162 | 131 |

### 3 thin titles expanded (use more of the keyword budget)

| Page | New title | Chars |
|---|---|---|
| `/handbook/operate/open-by-default` | "Open by Default: AGPLv3 & COSS Strategy - Datum Handbook" | 56 |
| `/handbook/pay-perks/benefits` | "Employee Benefits: Health, Equipment & PTO - Datum Handbook" | 59 |
| `/handbook/pay-perks/compensation` | "Salary, Levels & Pay Reviews - Datum Handbook" | 45 |

### 4 generic og:titles rebranded

| Page | Was | Now |
|---|---|---|
| `/handbook/product/milo` | "Milo" | "Milo — Datum's Open Source Business Operating System" |
| `/handbook/product/pricing` | "Pricing" | "Datum Pricing Tiers & Models" |
| `/handbook/product/roadmap` | "Roadmap" | "Datum Product Roadmap" |
| `/handbook/pay-perks/benefits` | "Benefits at Datum" | "Employee Benefits at Datum" |

## TechArticle JSON-LD on handbook pages (2 code files)

Handbook pages previously only emitted Organization + WebSite + BreadcrumbList structured data — no Article schema. Now emit a `TechArticle` alongside the BreadcrumbList via a single `@graph`, with `headline`, `description`, `url`, `mainEntityOfPage`, `inLanguage`, `isPartOf`, `publisher`, `datePublished`, `dateModified`, and `author`. This unlocks rich results for handbook content and strengthens E-E-A-T signals.

- **`src/content.config.ts`**: add `updatedDate` to the handbook schema. It was already authored in frontmatter and used by `Article.astro` via the remark plugin, but wasn't validated — so accessing `entry.data.updatedDate` was previously untyped.
- **`src/pages/handbook/[...slug].astro`**: parse `updatedDate` (e.g. "Nov 13, 2025") with dayjs into ISO 8601, build `TechArticle`, combine with `BreadcrumbList` under `@graph`. Falls back to `meta.description` when no top-level `description` is set (the standard pattern for handbook frontmatter).

Sample output from `/handbook/product/milo`:

```json
{
  "@context": "https://schema.org",
  "@graph": [
    { "@type": "BreadcrumbList", "itemListElement": [...] },
    {
      "@type": "TechArticle",
      "headline": "Milo",
      "description": "A technical guide to Milo, the open source backend...",
      "url": "https://www.datum.net/handbook/product/milo",
      "mainEntityOfPage": "https://www.datum.net/handbook/product/milo",
      "inLanguage": "en",
      "isPartOf": { "@type": "WebSite", "name": "Datum Handbook", "url": "https://www.datum.net/handbook/" },
      "publisher": { "@type": "Organization", "name": "Datum", "url": "https://www.datum.net/", "logo": { "@type": "ImageObject", "url": "https://www.datum.net/images/logo-datum.png" } },
      "datePublished": "2025-11-12T17:00:00.000Z",
      "dateModified": "2025-11-12T17:00:00.000Z",
      "author": { "@type": "Person", "name": "jacob" }
    }
  ]
}
```

## Verification

- `astro check`: 0 errors / 0 warnings
- `NODE_ENV=production npm run build` succeeds
- All 66 handbook pages still emit exactly 1 `<h1>`
- All edited descriptions render at 131–160 chars; edited titles at 45–59 chars
- Sample handbook page `@graph` validates against Schema.org

## Test plan

- [ ] CI green (build, type check, SEO review on PR)
- [ ] Run a couple of handbook URLs through [Google's Rich Results Test](https://search.google.com/test/rich-results) once deployed to preview — `TechArticle` should be detected with no warnings
- [ ] Eyeball one of the rebranded social previews (e.g. `/handbook/product/milo`) via opengraph.xyz

🤖 Generated with [Claude Code](https://claude.com/claude-code)
