### PR TITLE
refactor(strapi): adopt @datum-cloud/strapi-revalidate@0.1.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,8 +35,12 @@ LUMA_API_KEY=""
 STRAPI_TOKEN=your-api-token
 STRAPI_WEBHOOK_SECRET=your-shared-secret
 STRAPI_URL=https://your-project.strapiapp.com
-STRAPI_CACHE_ENABLED=true
+# Primary cache TTL in seconds (default 2592000 = 30 days)
 STRAPI_CACHE_TTL=2592000
+# Per-request timeout in seconds (default 3); the fallback cache kicks in after this
+STRAPI_TIMEOUT=3
+# Set to "true" for verbose cache hit/miss + GraphQL retry logging
+STRAPI_DEBUG=false
 
 PUBLIC_MINTLIFY_SUBDOMAIN=
 PUBLIC_MINTLIFY_ASSISTANT_KEY=

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is the official website for Datum Inc., built with Astro.
   - [Handbook](#handbook)
   - [Images](#images)
   - [Content Management with Front Matter CMS](#content-management-with-front-matter-cms)
+  - [Strapi-backed content](#strapi-backed-content)
 - [API Documentation](#api-documentation)
   - [Generating API Documentation](#generating-api-documentation)
   - [Configuration](#configuration)
@@ -289,6 +290,38 @@ If the Front Matter panel is not showing:
 1. Ensure you have a content file open
 2. Check the file is in `src/content/` directory
 3. Try reloading VS Code: `Developer: Reload Window`
+
+### Strapi-backed content
+
+Blog posts, authors, and roadmap milestones are sourced from a Strapi v5 CMS
+and cached on the SSR server via [`@datum-cloud/strapi-revalidate`](https://www.npmjs.com/package/@datum-cloud/strapi-revalidate).
+The package owns the GraphQL client, the tag-aware filesystem cache, and the
+webhook handler; datum-specific transforms (article block stripping, top-3
+cover preservation, reading-time calculation, author team sorting, card-category
+normalization) live alongside the fetchers in [`src/libs/strapi/`](./src/libs/strapi/).
+
+| Concern                             | Lives in                                                                                                   |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Shared client + cache               | [`src/libs/strapi/_runtime.ts`](./src/libs/strapi/_runtime.ts)                                             |
+| Article / author / roadmap fetchers | [`src/libs/strapi/`](./src/libs/strapi/)                                                                   |
+| Inbound webhook                     | [`src/pages/api/webhooks/strapi-content.ts`](./src/pages/api/webhooks/strapi-content.ts)                   |
+| Admin cache API + force-regen       | [`src/pages/api/cache/`](./src/pages/api/cache/), [`docs/STRAPI_CACHE_API.md`](./docs/STRAPI_CACHE_API.md) |
+
+Relevant environment variables (full set in [`.env.example`](./.env.example)):
+
+| Variable                | Purpose                                                                  |
+| ----------------------- | ------------------------------------------------------------------------ |
+| `STRAPI_URL`            | Strapi base URL                                                          |
+| `STRAPI_TOKEN`          | API token, sent as `Authorization: Bearer …`                             |
+| `STRAPI_WEBHOOK_SECRET` | Shared secret for inbound webhooks **and** the cache admin API           |
+| `STRAPI_CACHE_TTL`      | Primary cache TTL in seconds (default `2592000` = 30 days)               |
+| `STRAPI_TIMEOUT`        | Per-request timeout in seconds (default `3`)                             |
+| `STRAPI_DEBUG`          | `"true"` to log cache hit/miss and GraphQL retry decisions (default off) |
+
+**Webhook header note:** the Strapi Cloud webhook must be configured to send
+the secret as `Authorization: Bearer <secret>` (or `strapi-webhook-secret: <secret>`).
+The package does not accept the legacy `X-Webhook-Secret` header that
+`/api/cache/*` admin endpoints still use.
 
 ---
 

--- a/docs/STRAPI_CACHE_API.md
+++ b/docs/STRAPI_CACHE_API.md
@@ -1,23 +1,32 @@
 # Strapi filesystem cache APIs
 
-Operational reference for inspecting and rebuilding the Strapi-backed JSON cache files under `.cache/` (and `.cache/strapi-fallback/` for article-related fallbacks).
+Operational reference for inspecting and rebuilding the Strapi-backed JSON cache files under `.cache/` (primary) and `.cache/strapi-fallback/` (stale-data mirror).
+
+Caching, GraphQL transport, and webhook handling are owned by [`@datum-cloud/strapi-revalidate`](https://www.npmjs.com/package/@datum-cloud/strapi-revalidate). The shared client and cache manager are constructed once in [`src/libs/strapi/_runtime.ts`](../src/libs/strapi/_runtime.ts) and reused by every Strapi fetcher and route in this codebase.
 
 ## Prerequisites
 
-| Variable                | Purpose                                                                                                         |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `STRAPI_WEBHOOK_SECRET` | Shared secret checked on every cache API request (`X-Webhook-Secret` header). If unset or mismatched → **401**. |
-| `STRAPI_URL`            | Strapi GraphQL origin (defaults exist in code; set in production).                                              |
-| `STRAPI_TOKEN`          | Bearer token for Strapi GraphQL when required.                                                                  |
+| Variable                | Purpose                                                                                                |
+| ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| `STRAPI_URL`            | Strapi GraphQL origin (defaults exist in code; set in production).                                     |
+| `STRAPI_TOKEN`          | Bearer token sent on every Strapi request as `Authorization: Bearer …`.                                |
+| `STRAPI_WEBHOOK_SECRET` | Shared secret. Used by the inbound webhook **and** the cache admin API (different headers, see below). |
+| `STRAPI_CACHE_TTL`      | Primary cache TTL in **seconds** (default `2592000` = 30 days).                                        |
+| `STRAPI_TIMEOUT`        | Per-request timeout in **seconds** (default `3`).                                                      |
+| `STRAPI_DEBUG`          | `"true"` to log cache hit/miss and GraphQL retry decisions (default off).                              |
 
-Optional Strapi caching behavior for **written** TTL files (reads still run through the fetch helpers):
+> ⚠️ `STRAPI_CACHE_ENABLED` was removed when the cache layer moved to the package — caching is always on. The env var is ignored.
 
-| Variable               | Purpose                                                |
-| ---------------------- | ------------------------------------------------------ |
-| `STRAPI_CACHE_ENABLED` | `"true"` or `"1"` to persist TTL JSON under `.cache/`. |
-| `STRAPI_CACHE_TTL`     | TTL in **seconds** for Strapi-backed cache entries.    |
+### Two endpoint families, two header conventions
 
-Authentication uses the **`X-Webhook-Secret`** HTTP header whose value must match `STRAPI_WEBHOOK_SECRET` **exactly** (byte length-sensitive). Prefer the same tooling you use for `POST /api/webhooks/strapi-content`.
+| Endpoint family                                                    | Header expected                                                                      |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `POST /api/webhooks/strapi-content`                                | `Authorization: Bearer <secret>` (or `X-Strapi-Signature` / `strapi-webhook-secret`) |
+| `GET /api/cache`, `GET /api/cache/:name`, `POST /api/cache/strapi` | `X-Webhook-Secret: <secret>`                                                         |
+
+Both check the same `STRAPI_WEBHOOK_SECRET` value byte-for-byte. The split exists because the inbound webhook is verified by the package handler (which accepts the Strapi-conventional headers above), while the admin endpoints are still verified by the in-repo [`src/libs/cacheApiAuth.ts`](../src/libs/cacheApiAuth.ts).
+
+**Strapi Cloud configuration:** the webhook entry in Strapi must be configured to send `Authorization: Bearer <STRAPI_WEBHOOK_SECRET>` — the legacy `X-Webhook-Secret` header is no longer accepted by the inbound webhook handler.
 
 ---
 
@@ -101,9 +110,9 @@ curl -sS "${ORIGIN}/api/cache/article-my-post?source=fallback" \
 
 ## Regenerate Strapi cache (`POST /api/cache/strapi`)
 
-Rebuilds cache entries using the same Strapi GraphQL helpers as the site (`fetchStrapiArticles`, `fetchStrapiAuthors`, `getStrapiTeamMembers`, `getStrapiCardMembers`, `fetchStrapiArticleBySlug`).
+Rebuilds cache entries using the same Strapi GraphQL helpers as the site (`fetchStrapiArticles`, `fetchStrapiAuthors`, `getStrapiTeamMembers`, `getStrapiCardMembers`, `fetchStrapiArticleBySlug`). All helpers route through the shared package-backed cache manager in [`src/libs/strapi/_runtime.ts`](../src/libs/strapi/_runtime.ts), so a successful refetch transparently mirrors to the fallback at the same key.
 
-**Implementation:** [`src/pages/api/cache/strapi.ts`](../src/pages/api/cache/strapi.ts), [`src/libs/strapi/regenerateCache.ts`](../src/libs/strapi/regenerateCache.ts).
+**Implementation:** [`src/pages/api/cache/strapi.ts`](../src/pages/api/cache/strapi.ts), [`src/libs/strapi/regenerateCache.ts`](../src/libs/strapi/regenerateCache.ts), [`src/libs/strapi/_runtime.ts`](../src/libs/strapi/_runtime.ts).
 
 ### Authentication
 
@@ -160,8 +169,8 @@ Body: omit entirely, omit JSON, or JSON **without** a `names` property (see edge
 
 For each supplied name:
 
-1. The main cache entry **`{name}`** under **`.cache/`** is **cleared** (`.json` + optional `.expires` via `Cache.clear`).
-2. The appropriate fetch runs to repopulate (when caching is enabled for Strapi TTL files; article helpers also refresh article fallbacks inside `.cache/strapi-fallback/` on successful API responses — see caveat below).
+1. The primary cache entry **`{name}`** under **`.cache/`** is **deleted** (`.json` + `.expires` + `.tags` sidecar via `CacheManager.delete`).
+2. The matching fetch helper runs to repopulate. On success it writes both the primary entry and a fallback mirror at the same key under `.cache/strapi-fallback/` (the package's `CacheManager.set` handles both writes atomically — see fallback note below).
 
 **De-duplication:** Duplicate strings (after trim) are processed once. Non-string entries in `names` are ignored (validation can still fail if no valid strings remain).
 
@@ -187,16 +196,18 @@ The literal key `strapi-article-{slug}` is **not** a real key — substitute you
 
 Team and card caches are rebuilt from **`fetchStrapiAuthors()`** (after their own TTL file is cleared). If you need those lists to reflect **author** schema changes (`isTeam` / `isCard`), regenerate **`strapi-authors`** in the **same** or an earlier request. Depending on CMS shape, **`strapi-articles`** author flags may matter too — regenerate both when in doubt.
 
-#### Main cache vs fallback (articles)
+#### Main cache vs fallback
 
-[`POST /api/webhooks/strapi-content`](../src/pages/api/webhooks/strapi-content.ts) invalidates matching keys in **both** `.cache/` and `.cache/strapi-fallback/` for article-related patterns.
+[`POST /api/webhooks/strapi-content`](../src/pages/api/webhooks/strapi-content.ts) invalidates **primary** cache entries by tag (`articles`, `authors`, `roadmaps`, plus per-slug tags like `article:<slug>`). **Fallback entries are intentionally preserved** — they exist to keep the site serving stale data when Strapi is unreachable, and clearing them defeats that purpose.
 
-Named **force regeneration** clears only entries under **`.cache/`** for each key (`Cache` instance rooted at `.cache`). It does **not** delete **`strapi-fallback`** snapshots for article keys before refetch.
+Named **force regeneration** also deletes only the primary entry (`CacheManager.delete` does not touch the fallback). On the next refetch, the package's `CacheManager.set` writes both the primary entry and a fallback mirror at the same key.
 
-- On a **successful** Strapi response, article helpers overwrite the relevant fallback snapshot.
-- If Strapi is **unreachable**, `fetchStrapiArticleBySlug` may still serve from an existing stale fallback entry (see [`src/libs/strapi/articles.ts`](../src/libs/strapi/articles.ts)).
+- On a **successful** Strapi response, the fallback mirror is overwritten with fresh data.
+- If Strapi is **unreachable** during a refetch, the fetcher (e.g. `fetchStrapiArticleBySlug`) reads the existing fallback entry via `cache.getFallback(...)` so the request still returns content.
 
-Operators who must drop stale fallback data should rely on **`/api/webhooks/strapi-content`**, filesystem cleanup, or a future enhancement — not assumed by this endpoint.
+Operators who need to drop stale fallback data must delete the file(s) manually — for example `rm .cache/strapi-fallback/strapi-article-<slug>.json`. Neither the webhook nor the admin force-regen endpoint touches the fallback directory.
+
+> **Legacy fallback files:** the pre-package layout stored fallbacks under different keys (e.g. `.cache/strapi-fallback/articles.json` mirrored `.cache/strapi-articles.json`). After the migration to `@datum-cloud/strapi-revalidate`, fallback keys match the primary key. Old files at `articles.json`, `article-<slug>.json`, `roadmaps.json` etc. are orphaned but harmless; delete them at your leisure.
 
 ---
 
@@ -328,8 +339,8 @@ If you invoke this logic from tooling or scripts **inside this codebase**:
 
 ## Related routes
 
-| Route                               | Role                                                                                                                         |
-| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `POST /api/webhooks/strapi-content` | Strapi CMS webhook: deletes cache slices (including fallbacks where applicable) and selectively warms article-related caches |
-| `GET /api/cache`                    | Inspect cache filenames and TTL metadata                                                                                     |
-| `GET /api/cache/:name`              | Full JSON for one cache key (`source` query: main, fallback, auto)                                                           |
+| Route                               | Role                                                                                                                                      |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `POST /api/webhooks/strapi-content` | Strapi CMS webhook: invalidates primary cache by tag (fallback preserved by design) and re-warms the affected fetchers via `onRevalidate` |
+| `GET /api/cache`                    | Inspect cache filenames and TTL metadata                                                                                                  |
+| `GET /api/cache/:name`              | Full JSON for one cache key (`source` query: main, fallback, auto)                                                                        |

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@astrojs/mdx": "^5.0.6",
         "@astrojs/node": "^10.1.3",
         "@astrojs/rss": "^4.0.18",
+        "@datum-cloud/strapi-revalidate": "^0.1.1",
         "@kubernetes/client-node": "^1.4.0",
         "@lucide/astro": "^1.17.0",
         "@nanostores/persistent": "^1.3.4",
@@ -477,6 +478,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@datum-cloud/strapi-revalidate": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@datum-cloud/strapi-revalidate/-/strapi-revalidate-0.1.1.tgz",
+      "integrity": "sha512-UIh685f2dNcFZ9XzEXit+5U46gN/aOb7Ny8deRbPu3HBiZ4pjF2bdMkIJT+vOEmanzIRkyuyHchX7DYivB+23w==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.23.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "ioredis": "^5.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@datum-cloud/strapi-revalidate/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@emmetio/abbreviation": {
@@ -1744,6 +1777,13 @@
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -5972,6 +6012,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/collapse-white-space": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
@@ -6963,6 +7013,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -9542,6 +9602,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.0.tgz",
+      "integrity": "sha512-EZBErytyVovD8f6pDfG3Kb37N6Y3lmDA9NNj+4+IP13CzzHGeX+OyeRM2Um13khRzoBSzzL+5lVnCX8V2RLeMg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@ioredis/commands": "1.10.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "redis-parser": "3.0.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/ip-address": {
@@ -14081,6 +14164,29 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -15299,6 +15405,13 @@
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -444,9 +444,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@clack/core": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.0.tgz",
-      "integrity": "sha512-7Wctjq6f7c1CPz8sPpkwUnz8yRgVANkpNupb81q432FjcJg4l+Sw7XANdNSdWfAKq0IHI0JTcUeK5dxs/HrGPw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.1.tgz",
+      "integrity": "sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw==",
       "license": "MIT",
       "dependencies": {
         "fast-wrap-ansi": "^0.2.0",
@@ -457,12 +457,12 @@
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.5.0.tgz",
-      "integrity": "sha512-wKh+wTjmrUoUdkZg8KpJO5X+p9PWV+KE9mePseq9UYWkukgTKsGS47RRL2HstwVcvDQH+PenrPJWII8+MfiiyA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.5.1.tgz",
+      "integrity": "sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==",
       "license": "MIT",
       "dependencies": {
-        "@clack/core": "1.4.0",
+        "@clack/core": "1.4.1",
         "fast-string-width": "^3.0.2",
         "fast-wrap-ansi": "^0.2.0",
         "sisteransi": "^1.0.5"
@@ -1357,9 +1357,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1375,9 +1372,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1395,9 +1389,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1413,9 +1404,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1433,9 +1421,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1451,9 +1436,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1471,9 +1453,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1490,9 +1469,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1508,9 +1484,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1534,9 +1507,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1558,9 +1528,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1584,9 +1551,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1608,9 +1572,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1634,9 +1595,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1659,9 +1617,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1683,9 +1638,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2763,9 +2715,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.0.tgz",
-      "integrity": "sha512-dnxczajOqt0gesZlN5pGQ1s1imQVrsmCw5G2Ci4oM+0WvNz3pyRnlWrT7McoZIb8VlFwCawdmbWRmxRn7HI+VQ==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
       "cpu": [
         "arm"
       ],
@@ -2776,9 +2728,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.0.tgz",
-      "integrity": "sha512-Bp3JpGP00Vu3f238ivRrjf7z3xSzVPXqCmaJYA9t2c+c8vKYvOzmXF7LkkeUalTEGd6cZcSWe+PFIP3Vy48fRg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
       "cpu": [
         "arm64"
       ],
@@ -2789,9 +2741,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.0.tgz",
-      "integrity": "sha512-zaYIpr670mUmmZ1tVzUFplbQbG7h3Gugx3L5FoqhsC2m/YnLlR1a7zVLmXNPy+iY1tFPEbNG+HHBXZGyId0G5w==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
       "cpu": [
         "arm64"
       ],
@@ -2802,9 +2754,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.0.tgz",
-      "integrity": "sha512-+P49fvkv2dSoeevUW+lgZ/I2JHSsJCK1Lyjj7Cu6E4UHG4tS9XIefzIjo5qhgELjAclnen1rLzK2PMKJdo+Dyg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
       "cpu": [
         "x64"
       ],
@@ -2815,9 +2767,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.0.tgz",
-      "integrity": "sha512-l3FAAOyKJXH2ea6KNFN+MMgC/rnE94YGLXs2ehYqDcCoHt1DpvgWX75BhUJxN38XojP7Ul+4H8PRn7EdyqSDrw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
       "cpu": [
         "arm64"
       ],
@@ -2828,9 +2780,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.0.tgz",
-      "integrity": "sha512-VokPN3TSctKj65cyCNPaUh4vMFA8awxOot/0sp+4J7ZlNRKQEhXhawqPwajoi8H5ZFt61i0ugZJuTKXBjGJ17Q==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
       "cpu": [
         "x64"
       ],
@@ -2841,14 +2793,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.0.tgz",
-      "integrity": "sha512-DxH0P3wxm+Yzs/p3zrk9dw1rURu8p0Nv5+MRK/L7OtnLNg5rLZraSBFZ8iUXOd9f2BlhJyEpIZUH/emjq4UJ4g==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2857,14 +2806,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.0.tgz",
-      "integrity": "sha512-T6ZvMNe84kAz6TBWHC7hGAoEtzP1LWYw/AqayGWEF6uISt3Abk/st06LqRD9THd7Xz3NxzurUpzAuEAUbZf+nw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2879,9 +2825,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2889,14 +2832,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.0.tgz",
-      "integrity": "sha512-vvYWX3akdEAY6km+9wAqFDnk6pQsbJKVnj7xawcvs/+fdlYBGp+U+Qq/lLfpIxYIZvZLHMAKD9HLdacSx/r3dw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2905,14 +2845,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.0.tgz",
-      "integrity": "sha512-DePa5cqOxDP/Zp0VOXpeWaGew5iIv5DXp9NYbzkX5PFQyWVX9184WCTh3hvr/7lhXo8ZVlbFLkz8+o/q1dU6gA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2921,14 +2858,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.0.tgz",
-      "integrity": "sha512-LV8aWMB8UChglMCEzs7RkN0GsH29RJaLLqwm9fCIjlqwxQTiWAqNcc7wjBkH31hV0PU/yVxGYvrYsgfea2qw6g==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2937,14 +2871,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.0.tgz",
-      "integrity": "sha512-QoNSnwQtaeNu5grdBbsL0tt1uyl5EnS8DA8Mr3nluMXbhdQNyhN+G4tBax7VCdxLKj8YJ0/4OO9Ho84jMnJtKA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2953,14 +2884,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.0.tgz",
-      "integrity": "sha512-/zZp5MKapIIApE8trN8qLGNSiRN9TUoaUZ1cmVu4XnVdd5LQLOXTtyi+vtfUbNnT3iyjzpPqYeKXmvJ+gJGYWw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2969,14 +2897,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.0.tgz",
-      "integrity": "sha512-RbrzcD3aJ1k3UbtMRRBNwojdVVyXjuVAFTfn/xPa6EEl6GE9Sm/akPgFTb9aAC9pMKGJ6CtWxaGrqWcabH+ySg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2985,14 +2910,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.0.tgz",
-      "integrity": "sha512-ZF+onDsBso8PJf1XaG9lB+O9RnBpKGnY6OrzC4CSHrtC1jb6jWLTKK4bRqdoCXHd22gyr2hiYmEAm8Wns/BOCw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3001,14 +2923,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.0.tgz",
-      "integrity": "sha512-Atk0aSIk5Zx2Wuh9dgRQgLP0Koc8hOeYpbWryMXyk8G8/HmPkwPPkMqIIDhrXHHYqfUzSJA/I7IWSBv8xSmRBA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3017,14 +2936,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.0.tgz",
-      "integrity": "sha512-0uMOcf3eZ5K+K4cYHkdxShFMPlPXCOdfDFEFn9dNYAEEd2cVvmOfH7zFgRVoDgmtQ1m9k5q7qfrHzyMAubKYUA==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3033,14 +2949,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.0.tgz",
-      "integrity": "sha512-mvFtE4A/t/7hRJ7X8Ozmu8FsIkAUat2nzl12pgU337BRmq87AQUJztwHz2Zv5/tjo9/C95E66CK03SI/ToEDJw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3049,9 +2962,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.0.tgz",
-      "integrity": "sha512-z9b9+aTxvt8n2rNltMPvyaUfB8NJ+CVyOrGK/MdIKHx7B+lXmZpm/XbRsU7Rpf3fRqJ2uS6mBJiJveCtq8LHDg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
       "cpu": [
         "x64"
       ],
@@ -3062,9 +2975,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.0.tgz",
-      "integrity": "sha512-jXaXFqKMehsOc+g8R6oo33RRC6w07G9jDBxAE5eAKX7mOcCbZloYIPNhfG9Wl+P9O9IWHFO4OJgPi1Ml2qkt7w==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
       "cpu": [
         "arm64"
       ],
@@ -3075,9 +2988,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.0.tgz",
-      "integrity": "sha512-OXNWVFocS2IA4+QplhTZZ2a+8hPZR7T8KuozsNmJKK8y7cp83StHvGksfHzPG3wczWTczyWHVQuqeiTUbjiyBg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
       "cpu": [
         "arm64"
       ],
@@ -3088,9 +3001,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.0.tgz",
-      "integrity": "sha512-AlAbNtBO637LxSldqV43z0FfXoGfl2TW1DgAg/bs7aQswFbDewz2SJm3BUhiGfbOVtW571xbc9p+REdxhyN/Eg==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
       "cpu": [
         "ia32"
       ],
@@ -3101,9 +3014,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.0.tgz",
-      "integrity": "sha512-QRSrQXyJ1M4tjNXdR0/G/IgV6lzfQQJYBjlWIEYkY2Xs86DRl/iEpQ4blMDjJxSl7n19eDKKXMg0AmuBVYy8pQ==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
       "cpu": [
         "x64"
       ],
@@ -3114,9 +3027,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.0.tgz",
-      "integrity": "sha512-tkuFxhvKO/HlGd0VsINF6vHSYH8AF8W0TcNxKDK6JZmrehngFj78pToc8iemtnvwilDjs2G/qSzYFhe9U8q+fw==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
       "cpu": [
         "x64"
       ],
@@ -3326,13 +3239,13 @@
       }
     },
     "node_modules/@shikijs/core": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.1.0.tgz",
-      "integrity": "sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.2.0.tgz",
+      "integrity": "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/primitive": "4.1.0",
-        "@shikijs/types": "4.1.0",
+        "@shikijs/primitive": "4.2.0",
+        "@shikijs/types": "4.2.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
@@ -3342,12 +3255,12 @@
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.1.0.tgz",
-      "integrity": "sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.2.0.tgz",
+      "integrity": "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.1.0",
+        "@shikijs/types": "4.2.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "oniguruma-to-es": "^4.3.6"
       },
@@ -3356,12 +3269,12 @@
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.1.0.tgz",
-      "integrity": "sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.2.0.tgz",
+      "integrity": "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.1.0",
+        "@shikijs/types": "4.2.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       },
       "engines": {
@@ -3369,24 +3282,24 @@
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.1.0.tgz",
-      "integrity": "sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.2.0.tgz",
+      "integrity": "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.1.0"
+        "@shikijs/types": "4.2.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@shikijs/primitive": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.1.0.tgz",
-      "integrity": "sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.2.0.tgz",
+      "integrity": "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.1.0",
+        "@shikijs/types": "4.2.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       },
@@ -3395,21 +3308,21 @@
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.1.0.tgz",
-      "integrity": "sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.2.0.tgz",
+      "integrity": "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.1.0"
+        "@shikijs/types": "4.2.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
-      "integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+      "integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -3559,9 +3472,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3577,9 +3487,6 @@
       "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3597,9 +3504,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3615,9 +3519,6 @@
       "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3656,66 +3557,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.0",
@@ -5524,9 +5365,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
-      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -6325,9 +6166,9 @@
       }
     },
     "node_modules/cytoscape": {
-      "version": "3.33.4",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.4.tgz",
-      "integrity": "sha512-HIN5Pmd9MrX9BkV7tDwnOcEJCSFvCpc8X97h3f508J6I5FsqAY65wKOCvgH2CuP42CaahWaz4tuh32SOOIH7ww==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -7141,9 +6982,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
-      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -7281,9 +7122,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.1.tgz",
-      "integrity": "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==",
+      "version": "5.22.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.2.tgz",
+      "integrity": "sha512-0rxICaFZ7NQho/sHely2bvOPRP0Eu2B0NZ9zM54YvRvWMn7jfz3DmnOZDR9LlXDdDcqntAVc6Hfy4gr/tdH/Ag==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -9605,9 +9446,9 @@
       }
     },
     "node_modules/ioredis": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.0.tgz",
-      "integrity": "sha512-EZBErytyVovD8f6pDfG3Kb37N6Y3lmDA9NNj+4+IP13CzzHGeX+OyeRM2Um13khRzoBSzzL+5lVnCX8V2RLeMg==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
+      "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10686,9 +10527,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10708,9 +10546,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -10732,9 +10567,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10754,9 +10586,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -12906,14 +12735,17 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/octokit": {
       "version": "5.0.5",
@@ -14627,9 +14459,9 @@
       "license": "Unlicense"
     },
     "node_modules/rollup": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.0.tgz",
-      "integrity": "sha512-T9mWdbWfQtp0B5lv/HX+wrhYsmXRlcWnXXmJbXqKJhlRaoS6KMhq0gpyzW4UJfclcxrEdLnTgjT2NjruLONu0g==",
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.9"
@@ -14642,49 +14474,33 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.61.0",
-        "@rollup/rollup-android-arm64": "4.61.0",
-        "@rollup/rollup-darwin-arm64": "4.61.0",
-        "@rollup/rollup-darwin-x64": "4.61.0",
-        "@rollup/rollup-freebsd-arm64": "4.61.0",
-        "@rollup/rollup-freebsd-x64": "4.61.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.61.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.61.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.61.0",
-        "@rollup/rollup-linux-arm64-musl": "4.61.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.61.0",
-        "@rollup/rollup-linux-loong64-musl": "4.61.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.61.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.61.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.61.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.61.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.61.0",
-        "@rollup/rollup-linux-x64-gnu": "4.61.0",
-        "@rollup/rollup-linux-x64-musl": "4.61.0",
-        "@rollup/rollup-openbsd-x64": "4.61.0",
-        "@rollup/rollup-openharmony-arm64": "4.61.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.61.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.61.0",
-        "@rollup/rollup-win32-x64-gnu": "4.61.0",
-        "@rollup/rollup-win32-x64-msvc": "4.61.0",
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.61.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.0.tgz",
-      "integrity": "sha512-q/4hzvQkDs8b4jIBab1pnLiiM0ayTZsN2amBFPDzuyZxjEd4wDwx0UJFYM3cOZzSf5Kw8fnWSprJzIBMkcR44Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
     },
     "node_modules/roughjs": {
       "version": "4.6.6",
@@ -14890,9 +14706,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -15094,17 +14910,17 @@
       }
     },
     "node_modules/shiki": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.1.0.tgz",
-      "integrity": "sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.2.0.tgz",
+      "integrity": "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "4.1.0",
-        "@shikijs/engine-javascript": "4.1.0",
-        "@shikijs/engine-oniguruma": "4.1.0",
-        "@shikijs/langs": "4.1.0",
-        "@shikijs/themes": "4.1.0",
-        "@shikijs/types": "4.1.0",
+        "@shikijs/core": "4.2.0",
+        "@shikijs/engine-javascript": "4.2.0",
+        "@shikijs/engine-oniguruma": "4.2.0",
+        "@shikijs/langs": "4.2.0",
+        "@shikijs/themes": "4.2.0",
+        "@shikijs/types": "4.2.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       },
@@ -15446,9 +15262,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.26.0.tgz",
-      "integrity": "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.27.0.tgz",
+      "integrity": "sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==",
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -16155,9 +15971,9 @@
       "license": "MIT"
     },
     "node_modules/tinyclip": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.13.tgz",
-      "integrity": "sha512-8OqlXQ35euK9+e7L68u8UwcODxkHoIkjbGsgXuARKNyQ5G6xt8nw1YPeMbxMLgCPFkToU+UEK5j05t2t8edKpQ==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.14.tgz",
+      "integrity": "sha512-F1oWdz8tjT17qe1d5JgDK6z03WGOhYYAN0lK3/D/fzNiy93xswLLEw7pk+3g05onhAy6Bsc6PLNUGhdgVjemMQ==",
       "license": "MIT",
       "engines": {
         "node": "^16.14.0 || >= 17.3.0"
@@ -16307,6 +16123,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16323,6 +16140,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16339,6 +16157,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16355,6 +16174,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16371,6 +16191,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16387,6 +16208,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16403,6 +16225,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16419,6 +16242,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16435,6 +16259,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16451,6 +16276,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16467,6 +16293,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16483,6 +16310,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16499,6 +16327,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16515,6 +16344,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16531,6 +16361,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16547,6 +16378,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16563,6 +16395,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16579,6 +16412,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16595,6 +16429,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16611,6 +16446,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16627,6 +16463,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16643,6 +16480,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16659,6 +16497,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16675,6 +16514,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16691,6 +16531,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16707,6 +16548,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16762,6 +16604,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -16990,9 +16833,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.0.tgz",
-      "integrity": "sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.1.tgz",
+      "integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -17928,6 +17771,12 @@
         "vscode-uri": "^3.1.0"
       }
     },
+    "node_modules/vscode-css-languageservice/node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
     "node_modules/vscode-html-languageservice": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
@@ -17957,9 +17806,9 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.0.tgz",
+      "integrity": "sha512-+VvMmQPJhtvJ+8O+zu2JKIRiLxXF8NW7krWgyMGeOHrp4Cn23T5hc0v2LknNeopDOB70wghHAds7mKtcZ0I4Sg==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -17978,13 +17827,13 @@
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.0.tgz",
+      "integrity": "sha512-Zdz+kJ12Iz6tc11xfZyEo501bBATHXrCjmMfnaR3pMnf1CoqZBKIynba3P+/bi9VEdrMbNtAVKYpKhbODvqy+Q==",
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
+        "vscode-jsonrpc": "9.0.0",
+        "vscode-languageserver-types": "3.18.0"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
@@ -17994,6 +17843,31 @@
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@astrojs/mdx": "^5.0.6",
         "@astrojs/node": "^10.1.3",
         "@astrojs/rss": "^4.0.18",
-        "@datum-cloud/strapi-revalidate": "^0.1.1",
+        "@datum-cloud/strapi-revalidate": "^0.1.2",
         "@kubernetes/client-node": "^1.4.0",
         "@lucide/astro": "^1.17.0",
         "@nanostores/persistent": "^1.3.4",
@@ -481,9 +481,9 @@
       }
     },
     "node_modules/@datum-cloud/strapi-revalidate": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@datum-cloud/strapi-revalidate/-/strapi-revalidate-0.1.1.tgz",
-      "integrity": "sha512-UIh685f2dNcFZ9XzEXit+5U46gN/aOb7Ny8deRbPu3HBiZ4pjF2bdMkIJT+vOEmanzIRkyuyHchX7DYivB+23w==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@datum-cloud/strapi-revalidate/-/strapi-revalidate-0.1.2.tgz",
+      "integrity": "sha512-hFOZe11U/vve+i+EpFvijI6Qnkw9I5bDPBgPnW87wiYYPpgNcDJBf9vCiogQgBDB+mgueIq4p03v4V3XH6N/Iw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.23.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@astrojs/mdx": "^5.0.6",
     "@astrojs/node": "^10.1.3",
     "@astrojs/rss": "^4.0.18",
-    "@datum-cloud/strapi-revalidate": "^0.1.1",
+    "@datum-cloud/strapi-revalidate": "^0.1.2",
     "@kubernetes/client-node": "^1.4.0",
     "@lucide/astro": "^1.17.0",
     "@nanostores/persistent": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@astrojs/mdx": "^5.0.6",
     "@astrojs/node": "^10.1.3",
     "@astrojs/rss": "^4.0.18",
+    "@datum-cloud/strapi-revalidate": "^0.1.1",
     "@kubernetes/client-node": "^1.4.0",
     "@lucide/astro": "^1.17.0",
     "@nanostores/persistent": "^1.3.4",

--- a/scripts/warmup-cache.ts
+++ b/scripts/warmup-cache.ts
@@ -55,17 +55,10 @@ async function warmup(): Promise<void> {
     const articles = await fetchStrapiArticles();
     console.log(`[warmup-cache] Strapi: ${articles.length} articles`);
 
-    const latest = [...articles]
-      .sort((a, b) => {
-        const da = a.originalPublishedAt ? new Date(a.originalPublishedAt).getTime() : 0;
-        const db = b.originalPublishedAt ? new Date(b.originalPublishedAt).getTime() : 0;
-        return db - da;
-      })
-      .slice(0, 5);
-    for (const a of latest) {
+    for (const a of articles) {
       await fetchStrapiArticleBySlug(a.slug);
     }
-    console.log(`[warmup-cache] Strapi: cached 5 latest article details`);
+    console.log(`[warmup-cache] Strapi: cached ${articles.length} article details`);
 
     await fetchStrapiAuthors();
     await getStrapiTeamMembers();

--- a/src/libs/strapi/_runtime.ts
+++ b/src/libs/strapi/_runtime.ts
@@ -16,6 +16,8 @@
  *  - STRAPI_DEBUG            "true" to enable verbose cache/client logging
  */
 
+import { cwd } from 'node:process';
+import { loadEnv } from 'vite';
 import { createStrapiRevalidate } from '@datum-cloud/strapi-revalidate';
 import type { RevalidateConfig } from '@datum-cloud/strapi-revalidate';
 
@@ -27,6 +29,12 @@ function readEnv(name: string): string | undefined {
   const value = process.env[name];
   if (typeof value === 'string' && value.length > 0) return value;
   return undefined;
+}
+
+// Local dev loads .env into import.meta.env; merge into process.env when secrets are unset
+// so SSR routes can reach Strapi without inlining tokens into build output.
+if (!readEnv('STRAPI_TOKEN')) {
+  Object.assign(process.env, loadEnv(process.env.NODE_ENV ?? 'development', cwd(), ''));
 }
 
 function readSeconds(name: string, fallback: number): number {

--- a/src/libs/strapi/_runtime.ts
+++ b/src/libs/strapi/_runtime.ts
@@ -23,7 +23,7 @@ import type { RevalidateConfig } from '@datum-cloud/strapi-revalidate';
 
 const DEFAULT_STRAPI_URL = 'https://grateful-excitement-dfe9d47bad.strapiapp.com';
 const DEFAULT_CACHE_TTL_SECONDS = 30 * 24 * 60 * 60;
-const DEFAULT_TIMEOUT_SECONDS = 3;
+const DEFAULT_TIMEOUT_SECONDS = 6;
 
 function readEnv(name: string): string | undefined {
   const value = process.env[name];

--- a/src/libs/strapi/_runtime.ts
+++ b/src/libs/strapi/_runtime.ts
@@ -6,7 +6,8 @@
  * module load. Every Strapi fetcher and the webhook route import from here so
  * timeouts, retries, cache directories, and tag conventions stay in one place.
  *
- * Env vars (read from `import.meta.env` when available, then `process.env`):
+ * Env vars (read from `process.env` at runtime — never `import.meta.env`, so secrets
+ * are not inlined into server bundles at build time):
  *  - STRAPI_URL              Strapi base URL
  *  - STRAPI_TOKEN            API token (sent as `Authorization: Bearer …`)
  *  - STRAPI_CACHE_TTL        Primary cache TTL in seconds (default 2592000 = 30d)
@@ -23,13 +24,8 @@ const DEFAULT_CACHE_TTL_SECONDS = 30 * 24 * 60 * 60;
 const DEFAULT_TIMEOUT_SECONDS = 3;
 
 function readEnv(name: string): string | undefined {
-  const viteValue =
-    typeof import.meta !== 'undefined' && import.meta.env
-      ? (import.meta.env as Record<string, unknown>)[name]
-      : undefined;
-  if (typeof viteValue === 'string' && viteValue.length > 0) return viteValue;
-  const nodeValue = process.env[name];
-  if (typeof nodeValue === 'string' && nodeValue.length > 0) return nodeValue;
+  const value = process.env[name];
+  if (typeof value === 'string' && value.length > 0) return value;
   return undefined;
 }
 

--- a/src/libs/strapi/_runtime.ts
+++ b/src/libs/strapi/_runtime.ts
@@ -1,0 +1,76 @@
+// src/libs/strapi/_runtime.ts
+/**
+ * Shared `@datum-cloud/strapi-revalidate` runtime.
+ *
+ * Wires the GraphQL client, cache manager, and validated config once at
+ * module load. Every Strapi fetcher and the webhook route import from here so
+ * timeouts, retries, cache directories, and tag conventions stay in one place.
+ *
+ * Env vars (read from `import.meta.env` when available, then `process.env`):
+ *  - STRAPI_URL              Strapi base URL
+ *  - STRAPI_TOKEN            API token (sent as `Authorization: Bearer …`)
+ *  - STRAPI_CACHE_TTL        Primary cache TTL in seconds (default 2592000 = 30d)
+ *  - STRAPI_TIMEOUT          Per-request timeout in seconds (default 3)
+ *  - STRAPI_WEBHOOK_SECRET   Secret expected on inbound webhook requests
+ *  - STRAPI_DEBUG            "true" to enable verbose cache/client logging
+ */
+
+import { createStrapiRevalidate } from '@datum-cloud/strapi-revalidate';
+import type { RevalidateConfig } from '@datum-cloud/strapi-revalidate';
+
+const DEFAULT_STRAPI_URL = 'https://grateful-excitement-dfe9d47bad.strapiapp.com';
+const DEFAULT_CACHE_TTL_SECONDS = 30 * 24 * 60 * 60;
+const DEFAULT_TIMEOUT_SECONDS = 3;
+
+function readEnv(name: string): string | undefined {
+  const viteValue =
+    typeof import.meta !== 'undefined' && import.meta.env
+      ? (import.meta.env as Record<string, unknown>)[name]
+      : undefined;
+  if (typeof viteValue === 'string' && viteValue.length > 0) return viteValue;
+  const nodeValue = process.env[name];
+  if (typeof nodeValue === 'string' && nodeValue.length > 0) return nodeValue;
+  return undefined;
+}
+
+function readSeconds(name: string, fallback: number): number {
+  const raw = readEnv(name);
+  if (raw === undefined) return fallback;
+  const parsed = parseInt(raw, 10);
+  return Number.isNaN(parsed) || parsed <= 0 ? fallback : parsed;
+}
+
+const url = readEnv('STRAPI_URL') ?? DEFAULT_STRAPI_URL;
+// The package's zod schema requires a non-empty token. Fresh-clone builds without
+// secrets fall back to stale cache anyway, so a placeholder keeps init succeeding
+// — Strapi simply 401s and we serve from `.cache/strapi-fallback/`.
+const token = readEnv('STRAPI_TOKEN') ?? 'placeholder-no-token';
+const debug = readEnv('STRAPI_DEBUG') === 'true' || readEnv('STRAPI_DEBUG') === '1';
+
+const strapiRevalidate = createStrapiRevalidate({
+  url,
+  token,
+  cache: {
+    driver: 'file',
+    dir: '.cache',
+    fallbackDir: '.cache/strapi-fallback',
+    ttl: readSeconds('STRAPI_CACHE_TTL', DEFAULT_CACHE_TTL_SECONDS),
+  },
+  timeout: readSeconds('STRAPI_TIMEOUT', DEFAULT_TIMEOUT_SECONDS) * 1000,
+  // Preserve current no-retry behaviour; revisit when adopting retry is a separate decision.
+  retry: 0,
+  webhook: {
+    secret: readEnv('STRAPI_WEBHOOK_SECRET'),
+    // Default map handles api::article.article and api::author.author; roadmaps need an explicit
+    // entry so the webhook invalidates the `roadmaps` tag instead of the singular fallback.
+    tagMap: {
+      'api::roadmap.roadmap': ['roadmaps'],
+    },
+  },
+  debug,
+});
+
+export const { client, cache, config } = strapiRevalidate;
+
+/** Re-export so consumers can build webhook handlers with custom `onRevalidate`. */
+export type { RevalidateConfig };

--- a/src/libs/strapi/articles.ts
+++ b/src/libs/strapi/articles.ts
@@ -9,7 +9,7 @@
  *
  * Cache keys are unchanged from the pre-package layout:
  *   `strapi-articles`           — full list (tagged `articles`)
- *   `strapi-article-<slug>`     — single article (tagged `articles` + `article:<slug>`)
+ *   `strapi-article-<slug>`     — single article (tagged `article:<slug>` only)
  */
 
 import { getReadingTimeMinutesFromContent } from '@libs/string';
@@ -255,7 +255,7 @@ async function pullArticleDetailFromApi(slug: string): Promise<StrapiArticle | n
 
   const article = withReadingTime(response.articles[0]);
   const cacheKey = `${ARTICLE_CACHE_PREFIX}${slug}`;
-  await cache.set(cacheKey, article, { tags: ['articles', `article:${slug}`] });
+  await cache.set(cacheKey, article, { tags: [`article:${slug}`] });
   return article;
 }
 

--- a/src/libs/strapi/articles.ts
+++ b/src/libs/strapi/articles.ts
@@ -230,6 +230,35 @@ export async function fetchStrapiArticles(): Promise<StrapiArticle[]> {
   return articles;
 }
 
+function withReadingTime(article: StrapiArticle): StrapiArticle {
+  if (article.readingTimeMinutes || !article.blocks) return article;
+  const bodyContent = article.blocks
+    .map((block) => block.body || '')
+    .filter(Boolean)
+    .join('\n\n');
+  article.readingTimeMinutes = getReadingTimeMinutesFromContent(bodyContent);
+  return article;
+}
+
+async function readArticleDetailFallback(slug: string): Promise<StrapiArticle | null> {
+  const cacheKey = `${ARTICLE_CACHE_PREFIX}${slug}`;
+  const fallback =
+    (await cache.getFallback<StrapiArticle>(cacheKey)) ??
+    (await cache.getFallback<StrapiArticle>(`${LEGACY_FALLBACK_DETAIL_PREFIX}${slug}`));
+  return fallback && isValidStrapiArticle(fallback) ? fallback : null;
+}
+
+/** Fetch full article detail from Strapi and persist to the per-slug cache file. */
+async function pullArticleDetailFromApi(slug: string): Promise<StrapiArticle | null> {
+  const response = await client.query<StrapiArticlesResponse>(ARTICLE_BY_SLUG_QUERY, { slug });
+  if (!response?.articles?.length) return null;
+
+  const article = withReadingTime(response.articles[0]);
+  const cacheKey = `${ARTICLE_CACHE_PREFIX}${slug}`;
+  await cache.set(cacheKey, article, { tags: ['articles', `article:${slug}`] });
+  return article;
+}
+
 /**
  * Fetch a single article by slug. Cached per slug; falls back to stale data
  * when Strapi is unreachable. Reading time is computed lazily so cache misses
@@ -246,30 +275,41 @@ export async function fetchStrapiArticleBySlug(slug: string): Promise<StrapiArti
     );
   }
 
-  const response = await client.query<StrapiArticlesResponse>(ARTICLE_BY_SLUG_QUERY, { slug });
+  const fromApi = await pullArticleDetailFromApi(slug);
+  if (fromApi) return fromApi;
 
-  if (!response?.articles || response.articles.length === 0) {
-    console.warn(`Strapi unavailable — checking persistent fallback cache for article "${slug}"`);
-    const fallback =
-      (await cache.getFallback<StrapiArticle>(cacheKey)) ??
-      (await cache.getFallback<StrapiArticle>(`${LEGACY_FALLBACK_DETAIL_PREFIX}${slug}`));
-    if (fallback && isValidStrapiArticle(fallback)) {
-      console.warn(`Serving article "${slug}" from stale fallback cache`);
-      return fallback;
-    }
-    return null;
+  console.warn(`Strapi unavailable — checking persistent fallback cache for article "${slug}"`);
+  const fallback = await readArticleDetailFallback(slug);
+  if (fallback) {
+    console.warn(`Serving article "${slug}" from stale fallback cache`);
+    return fallback;
   }
+  return null;
+}
 
-  const article = response.articles[0];
+/**
+ * Load article detail for a published slug, creating `.cache/strapi-article-<slug>.json`
+ * on a cache miss before giving up. Use for SSR blog routes instead of redirecting
+ * to 404 when the list cache already contains the slug.
+ */
+export async function ensureStrapiArticleDetail(slug: string): Promise<StrapiArticle | null> {
+  const article = await fetchStrapiArticleBySlug(slug);
+  if (article) return article;
 
-  if (!article.readingTimeMinutes && article.blocks) {
-    const bodyContent = article.blocks
-      .map((block) => block.body || '')
-      .filter(Boolean)
-      .join('\n\n');
-    article.readingTimeMinutes = getReadingTimeMinutesFromContent(bodyContent);
-  }
+  const articles = await fetchStrapiArticles();
+  if (!articles.some((entry) => entry.slug === slug)) return null;
 
-  await cache.set(cacheKey, article, { tags: ['articles', `article:${slug}`] });
-  return article;
+  const cacheKey = `${ARTICLE_CACHE_PREFIX}${slug}`;
+  await cache.delete(cacheKey);
+
+  const fromApi = await pullArticleDetailFromApi(slug);
+  if (fromApi) return fromApi;
+
+  const fallback = await readArticleDetailFallback(slug);
+  if (fallback) return fallback;
+
+  console.error(
+    `[strapi] Article "${slug}" is in the list cache but detail could not be loaded from Strapi`
+  );
+  return null;
 }

--- a/src/libs/strapi/articles.ts
+++ b/src/libs/strapi/articles.ts
@@ -18,6 +18,12 @@ import type { StrapiArticlesResponse, StrapiArticle } from '../../types/strapi';
 
 const ARTICLES_CACHE_KEY = 'strapi-articles';
 const ARTICLE_CACHE_PREFIX = 'strapi-article-';
+// Pre-migration fallback keys. The package's CacheManager mirrors fallback under
+// the same key as primary, so new writes land at `strapi-articles` / `strapi-article-*`.
+// Read these legacy keys as a backstop so deploys don't lose access to existing
+// stale data if Strapi happens to be unreachable during the cutover.
+const LEGACY_FALLBACK_LIST_KEY = 'articles';
+const LEGACY_FALLBACK_DETAIL_PREFIX = 'article-';
 
 /** GraphQL query: every published article, newest first. */
 export const ARTICLES_QUERY = `
@@ -209,7 +215,9 @@ export async function fetchStrapiArticles(): Promise<StrapiArticle[]> {
 
   if (!response?.articles) {
     console.warn('Strapi unavailable — checking persistent fallback cache for articles');
-    const fallback = await cache.getFallback<StrapiArticle[]>(ARTICLES_CACHE_KEY);
+    const fallback =
+      (await cache.getFallback<StrapiArticle[]>(ARTICLES_CACHE_KEY)) ??
+      (await cache.getFallback<StrapiArticle[]>(LEGACY_FALLBACK_LIST_KEY));
     if (fallback && isValidCachedArticles(fallback)) {
       console.warn(`Serving ${fallback.length} articles from stale fallback cache`);
       return fallback;
@@ -242,7 +250,9 @@ export async function fetchStrapiArticleBySlug(slug: string): Promise<StrapiArti
 
   if (!response?.articles || response.articles.length === 0) {
     console.warn(`Strapi unavailable — checking persistent fallback cache for article "${slug}"`);
-    const fallback = await cache.getFallback<StrapiArticle>(cacheKey);
+    const fallback =
+      (await cache.getFallback<StrapiArticle>(cacheKey)) ??
+      (await cache.getFallback<StrapiArticle>(`${LEGACY_FALLBACK_DETAIL_PREFIX}${slug}`));
     if (fallback && isValidStrapiArticle(fallback)) {
       console.warn(`Serving article "${slug}" from stale fallback cache`);
       return fallback;

--- a/src/libs/strapi/articles.ts
+++ b/src/libs/strapi/articles.ts
@@ -1,108 +1,25 @@
 // src/libs/strapi/articles.ts
 /**
- * Strapi Articles module with caching support
+ * Strapi Articles module.
+ *
+ * GraphQL + cache duties live in `_runtime.ts` (via `@datum-cloud/strapi-revalidate`);
+ * this file owns the datum-specific list transform: dropping rich-text blocks,
+ * preserving cover formats only for the top-3 newest articles, and computing
+ * reading time before caching.
+ *
+ * Cache keys are unchanged from the pre-package layout:
+ *   `strapi-articles`           — full list (tagged `articles`)
+ *   `strapi-article-<slug>`     — single article (tagged `articles` + `article:<slug>`)
  */
 
-import { Cache } from '@libs/cache';
 import { getReadingTimeMinutesFromContent } from '@libs/string';
+import { cache, client } from './_runtime';
 import type { StrapiArticlesResponse, StrapiArticle } from '../../types/strapi';
 
-const STRAPI_URL = process.env.STRAPI_URL ?? 'https://grateful-excitement-dfe9d47bad.strapiapp.com';
-const STRAPI_TOKEN = process.env.STRAPI_TOKEN ?? '';
-const cacheEnabledRaw = import.meta.env?.STRAPI_CACHE_ENABLED || process.env.STRAPI_CACHE_ENABLED;
-const CACHE_ENABLED = cacheEnabledRaw === 'true' || cacheEnabledRaw === '1';
-
-const DEFAULT_CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
-const envTtlSec = parseInt(
-  import.meta.env?.STRAPI_CACHE_TTL ?? process.env.STRAPI_CACHE_TTL ?? '2592000',
-  10
-);
-const ARTICLES_CACHE_TTL =
-  Number.isNaN(envTtlSec) || envTtlSec <= 0 ? DEFAULT_CACHE_TTL_MS : envTtlSec * 1000;
-
-// Request timeout — fail fast so the fallback cache can kick in
-const envTimeoutSec = parseInt(
-  import.meta.env?.STRAPI_TIMEOUT ?? process.env.STRAPI_TIMEOUT ?? '3',
-  10
-);
-const FETCH_TIMEOUT_MS =
-  Number.isNaN(envTimeoutSec) || envTimeoutSec <= 0 ? 3_000 : envTimeoutSec * 1000;
-
-interface GraphQLResponse<T> {
-  data: T;
-  errors?: Array<{ message: string }>;
-}
-
-/**
- * Execute a GraphQL query against Strapi (local version to avoid circular import)
- */
-async function graphqlQuery<T>(
-  query: string,
-  variables: Record<string, unknown> = {}
-): Promise<T | null> {
-  const headers: HeadersInit = {
-    'Content-Type': 'application/json',
-  };
-
-  if (STRAPI_TOKEN) {
-    headers['Authorization'] = `Bearer ${STRAPI_TOKEN}`;
-  }
-
-  const url = `${STRAPI_URL}/graphql`;
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-
-  try {
-    const response = await fetch(url, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        query,
-        variables,
-      }),
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      const text = await response.text();
-      console.error(`Strapi GraphQL error: ${response.status} ${response.statusText}`, text);
-      return null;
-    }
-
-    const result: GraphQLResponse<T> = await response.json();
-
-    if (result.errors) {
-      console.error('Strapi GraphQL errors:', result.errors);
-      return null;
-    }
-
-    return result.data;
-  } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      console.error(`Strapi request timed out after ${FETCH_TIMEOUT_MS}ms`);
-    } else {
-      console.error('Error fetching from Strapi:', error);
-    }
-    return null;
-  } finally {
-    clearTimeout(timeoutId);
-  }
-}
-
-// Short-lived TTL cache (respects STRAPI_CACHE_ENABLED / STRAPI_CACHE_TTL)
-const cache = new Cache('.cache');
 const ARTICLES_CACHE_KEY = 'strapi-articles';
 const ARTICLE_CACHE_PREFIX = 'strapi-article-';
 
-// Persistent fallback cache — always written on success, never expires.
-// Serves stale data when Strapi is unreachable.
-const fallbackCache = new Cache('.cache/strapi-fallback');
-const FALLBACK_ARTICLES_KEY = 'articles';
-const FALLBACK_ARTICLE_PREFIX = 'article-';
-
-/**
- * GraphQL query to fetch all articles (Strapi v5 format, with high limit)
- */
+/** GraphQL query: every published article, newest first. */
 export const ARTICLES_QUERY = `
   query GetArticles {
     articles(pagination: { limit: 100 }, sort: ["originalPublishedAt:desc"]) {
@@ -143,9 +60,7 @@ export const ARTICLES_QUERY = `
   }
 `;
 
-/**
- * GraphQL query to fetch a single article by slug
- */
+/** GraphQL query: a single article by slug, including SEO and quote blocks. */
 export const ARTICLE_BY_SLUG_QUERY = `
   query GetArticleBySlug($slug: String!) {
     articles(filters: { slug: { eq: $slug } }) {
@@ -199,9 +114,7 @@ export const ARTICLE_BY_SLUG_QUERY = `
   }
 `;
 
-/**
- * GraphQL query to fetch articles by category slug
- */
+/** GraphQL query: articles filtered by category slug. Used by category pages. */
 export const ARTICLES_BY_CATEGORY_QUERY = `
   query GetArticlesByCategory($categorySlug: String!) {
     articles(filters: { category: { slug: { eq: $categorySlug } } }) {
@@ -235,72 +148,25 @@ export const ARTICLES_BY_CATEGORY_QUERY = `
   }
 `;
 
-/**
- * Validates that an object is a valid StrapiArticle
- * @param obj - The object to validate
- * @returns True if the object is a valid StrapiArticle
- */
 function isValidStrapiArticle(obj: unknown): obj is StrapiArticle {
-  if (!obj || typeof obj !== 'object') {
-    return false;
-  }
-
+  if (!obj || typeof obj !== 'object') return false;
   const article = obj as Record<string, unknown>;
   return typeof article.documentId === 'string' && typeof article.slug === 'string';
 }
 
-/**
- * Validates that cached data has the correct structure with StrapiArticle objects
- * @param data - The cached data to validate
- * @returns True if the data structure is valid
- */
 function isValidCachedArticles(data: unknown): data is StrapiArticle[] {
-  if (!Array.isArray(data)) {
-    return false;
-  }
-
-  return data.every(isValidStrapiArticle);
+  return Array.isArray(data) && data.every(isValidStrapiArticle);
 }
 
 /**
- * Fetch all articles from Strapi with caching (for listing & navigation).
- * Falls back to a persistent stale cache when Strapi is unreachable.
- * @returns Array of all Strapi articles
+ * Strip rich-text blocks and preserve only top-3 cover metadata to keep the
+ * list-cache small. Reading time is computed from blocks before they're dropped.
+ * Articles are assumed sorted newest-first by the GraphQL query.
  */
-export async function fetchStrapiArticles(): Promise<StrapiArticle[]> {
-  // Check short-lived TTL cache first (when enabled)
-  if (CACHE_ENABLED && (await cache.has(ARTICLES_CACHE_KEY))) {
-    const cached = await cache.get<StrapiArticle[]>(ARTICLES_CACHE_KEY);
-    if (cached && isValidCachedArticles(cached)) {
-      return cached;
-    }
-    if (cached) {
-      console.warn('Invalid cached Strapi articles data detected, fetching fresh data from API');
-    }
-  }
+function transformArticleList(articles: StrapiArticle[]): StrapiArticle[] {
+  const topCoverIds = new Set(articles.slice(0, 3).map((a) => a.documentId));
 
-  // Fetch from API
-  const response = await graphqlQuery<StrapiArticlesResponse>(ARTICLES_QUERY);
-
-  if (!response?.articles) {
-    console.warn('Strapi unavailable — checking persistent fallback cache for articles');
-    const fallback = await fallbackCache.get<StrapiArticle[]>(FALLBACK_ARTICLES_KEY);
-    if (fallback && isValidCachedArticles(fallback)) {
-      console.warn(`Serving ${fallback.length} articles from stale fallback cache`);
-      return fallback;
-    }
-    console.warn('No articles returned from Strapi API and no fallback cache available');
-    return [];
-  }
-
-  // For list cache we drop rich-text blocks to keep cache small, but preserve reading time.
-  // Detail pages should use fetchStrapiArticleBySlug to get full content including blocks.
-  // Only the top 3 newest articles keep full cover metadata for featured cards.
-  // Articles are sorted by newest first via GraphQL sort parameter.
-  const topCoverIds = new Set(response.articles.slice(0, 3).map((a) => a.documentId));
-
-  const articles = response.articles.map((article) => {
-    // Calculate reading time from blocks before removing them
+  return articles.map((article) => {
     const bodyContent = (article.blocks || [])
       .map((block) => block.body || '')
       .filter(Boolean)
@@ -310,12 +176,8 @@ export async function fetchStrapiArticles(): Promise<StrapiArticle[]> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { blocks, cover, ...rest } = article;
 
-    const base: StrapiArticle = {
-      ...rest,
-      readingTimeMinutes,
-    };
+    const base: StrapiArticle = { ...rest, readingTimeMinutes };
 
-    // Preserve cover metadata only for the top 3 newest articles (small + medium only to reduce cache size)
     if (topCoverIds.has(article.documentId) && cover) {
       base.cover = {
         url: cover.url,
@@ -328,48 +190,59 @@ export async function fetchStrapiArticles(): Promise<StrapiArticle[]> {
         },
       };
     }
-
     return base;
   });
+}
 
-  if (CACHE_ENABLED) {
-    await cache.set(ARTICLES_CACHE_KEY, articles, ARTICLES_CACHE_TTL);
+/**
+ * Fetch every article from Strapi. Reads cache first; on Strapi failure serves
+ * stale data from the persistent fallback cache instead of returning empty.
+ */
+export async function fetchStrapiArticles(): Promise<StrapiArticle[]> {
+  const cached = await cache.get<StrapiArticle[]>(ARTICLES_CACHE_KEY);
+  if (cached && isValidCachedArticles(cached)) return cached;
+  if (cached) {
+    console.warn('Invalid cached Strapi articles data detected, fetching fresh data from API');
   }
 
-  // Always persist a fallback snapshot — no TTL so it survives Strapi outages
-  await fallbackCache.set(FALLBACK_ARTICLES_KEY, articles);
+  const response = await client.query<StrapiArticlesResponse>(ARTICLES_QUERY);
 
+  if (!response?.articles) {
+    console.warn('Strapi unavailable — checking persistent fallback cache for articles');
+    const fallback = await cache.getFallback<StrapiArticle[]>(ARTICLES_CACHE_KEY);
+    if (fallback && isValidCachedArticles(fallback)) {
+      console.warn(`Serving ${fallback.length} articles from stale fallback cache`);
+      return fallback;
+    }
+    return [];
+  }
+
+  const articles = transformArticleList(response.articles);
+  await cache.set(ARTICLES_CACHE_KEY, articles, { tags: ['articles'] });
   return articles;
 }
 
 /**
- * Fetch single article by slug.
- * Caches each article separately by slug.
- * Falls back to a persistent stale cache when Strapi is unreachable.
- * @param slug - Article slug
- * @returns The article or null if not found
+ * Fetch a single article by slug. Cached per slug; falls back to stale data
+ * when Strapi is unreachable. Reading time is computed lazily so cache misses
+ * don't grow over time.
  */
 export async function fetchStrapiArticleBySlug(slug: string): Promise<StrapiArticle | null> {
   const cacheKey = `${ARTICLE_CACHE_PREFIX}${slug}`;
 
-  if (CACHE_ENABLED && (await cache.has(cacheKey))) {
-    const cached = await cache.get<StrapiArticle>(cacheKey);
-    if (cached && isValidStrapiArticle(cached)) {
-      return cached;
-    }
-    if (cached) {
-      console.warn(
-        `Invalid cached Strapi article data detected for slug "${slug}", fetching fresh data from API`
-      );
-    }
+  const cached = await cache.get<StrapiArticle>(cacheKey);
+  if (cached && isValidStrapiArticle(cached)) return cached;
+  if (cached) {
+    console.warn(
+      `Invalid cached Strapi article data detected for slug "${slug}", fetching fresh data from API`
+    );
   }
 
-  const response = await graphqlQuery<StrapiArticlesResponse>(ARTICLE_BY_SLUG_QUERY, { slug });
+  const response = await client.query<StrapiArticlesResponse>(ARTICLE_BY_SLUG_QUERY, { slug });
 
   if (!response?.articles || response.articles.length === 0) {
     console.warn(`Strapi unavailable — checking persistent fallback cache for article "${slug}"`);
-    const fallbackKey = `${FALLBACK_ARTICLE_PREFIX}${slug}`;
-    const fallback = await fallbackCache.get<StrapiArticle>(fallbackKey);
+    const fallback = await cache.getFallback<StrapiArticle>(cacheKey);
     if (fallback && isValidStrapiArticle(fallback)) {
       console.warn(`Serving article "${slug}" from stale fallback cache`);
       return fallback;
@@ -379,7 +252,6 @@ export async function fetchStrapiArticleBySlug(slug: string): Promise<StrapiArti
 
   const article = response.articles[0];
 
-  // Calculate reading time from blocks if not already present
   if (!article.readingTimeMinutes && article.blocks) {
     const bodyContent = article.blocks
       .map((block) => block.body || '')
@@ -388,13 +260,6 @@ export async function fetchStrapiArticleBySlug(slug: string): Promise<StrapiArti
     article.readingTimeMinutes = getReadingTimeMinutesFromContent(bodyContent);
   }
 
-  if (CACHE_ENABLED) {
-    await cache.set(cacheKey, article, ARTICLES_CACHE_TTL);
-  }
-
-  // Always persist a fallback snapshot — no TTL so it survives Strapi outages
-  const fallbackKey = `${FALLBACK_ARTICLE_PREFIX}${slug}`;
-  await fallbackCache.set(fallbackKey, article);
-
+  await cache.set(cacheKey, article, { tags: ['articles', `article:${slug}`] });
   return article;
 }

--- a/src/libs/strapi/authors.ts
+++ b/src/libs/strapi/authors.ts
@@ -1,78 +1,24 @@
 // src/libs/strapi/authors.ts
 /**
- * Strapi Authors module with caching support
+ * Strapi Authors module.
+ *
+ * GraphQL + cache duties live in `_runtime.ts` (via `@datum-cloud/strapi-revalidate`).
+ * This file owns datum-specific concerns: cardCategories normalization, team
+ * sorting (founders first, CEO at top, then alphabetical by last name), and
+ * the bg-color helpers used by team avatars.
+ *
+ * Cache keys are unchanged from the pre-package layout:
+ *   `strapi-authors`              — full author list
+ *   `strapi-team-members`         — `isTeam === true`, sorted
+ *   `strapi-card-members`         — `isCard === true`, sorted
+ *   `strapi-author-slug-<slug>`   — single author by slug
+ * All entries are tagged `authors`, so one webhook clears every derived view.
  */
 
-import { Cache } from '@libs/cache';
+import { cache, client } from './_runtime';
 import type { CardCategory, StrapiAuthorsResponse, StrapiAuthorFull } from '../../types/strapi';
 
-const STRAPI_URL = process.env.STRAPI_URL ?? 'https://grateful-excitement-dfe9d47bad.strapiapp.com';
-const STRAPI_TOKEN = process.env.STRAPI_TOKEN ?? '';
-const cacheEnabledRaw = import.meta.env?.STRAPI_CACHE_ENABLED || process.env.STRAPI_CACHE_ENABLED;
-const CACHE_ENABLED = cacheEnabledRaw === 'true' || cacheEnabledRaw === '1';
-
-const DEFAULT_CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
-const envTtlSec = parseInt(
-  import.meta.env?.STRAPI_CACHE_TTL ?? process.env.STRAPI_CACHE_TTL ?? '2592000',
-  10
-);
-const CACHE_TTL =
-  Number.isNaN(envTtlSec) || envTtlSec <= 0 ? DEFAULT_CACHE_TTL_MS : envTtlSec * 1000;
-
-interface GraphQLResponse<T> {
-  data: T;
-  errors?: Array<{ message: string }>;
-}
-
-/**
- * Execute a GraphQL query against Strapi (local version to avoid circular import)
- */
-async function graphqlQuery<T>(
-  query: string,
-  variables: Record<string, unknown> = {}
-): Promise<T | null> {
-  const headers: HeadersInit = {
-    'Content-Type': 'application/json',
-  };
-
-  if (STRAPI_TOKEN) {
-    headers['Authorization'] = `Bearer ${STRAPI_TOKEN}`;
-  }
-
-  const url = `${STRAPI_URL}/graphql`;
-
-  try {
-    const response = await fetch(url, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        query,
-        variables,
-      }),
-    });
-
-    if (!response.ok) {
-      const text = await response.text();
-      console.error(`Strapi GraphQL error: ${response.status} ${response.statusText}`, text);
-      return null;
-    }
-
-    const result: GraphQLResponse<T> = await response.json();
-
-    if (result.errors) {
-      console.error('Strapi GraphQL errors:', result.errors);
-      return null;
-    }
-
-    return result.data;
-  } catch (error) {
-    console.error('Error fetching from Strapi:', error);
-    return null;
-  }
-}
-
-const cache = new Cache('.cache');
-const CACHE_KEY = 'strapi-authors';
+const AUTHORS_CACHE_KEY = 'strapi-authors';
 const TEAM_MEMBERS_CACHE_KEY = 'strapi-team-members';
 const CARD_MEMBERS_CACHE_KEY = 'strapi-card-members';
 const AUTHOR_SLUG_CACHE_PREFIX = 'strapi-author-slug-';
@@ -86,9 +32,8 @@ const VALID_CARD_CATEGORIES = new Set<CardCategory>([
 
 /** Normalize Author.cardCategories from Strapi (delimited string, JSON array, or legacy component rows). */
 function parseCardCategories(raw: unknown): CardCategory[] {
-  if (raw == null) {
-    return [];
-  }
+  if (raw == null) return [];
+
   if (typeof raw === 'string') {
     const trimmed = raw.trim();
     if (trimmed.startsWith('[')) {
@@ -105,9 +50,9 @@ function parseCardCategories(raw: unknown): CardCategory[] {
       .filter(Boolean);
     return parts.filter((v): v is CardCategory => VALID_CARD_CATEGORIES.has(v as CardCategory));
   }
-  if (!Array.isArray(raw)) {
-    return [];
-  }
+
+  if (!Array.isArray(raw)) return [];
+
   const first = raw[0];
   if (
     raw.length > 0 &&
@@ -134,14 +79,8 @@ function normalizeAuthorFromGraphQL(row: GraphQLAuthorRow): StrapiAuthorFull {
   return { ...row, cardCategories: parseCardCategories(row.cardCategories) };
 }
 
-/**
- * Color palette that cycles through for team member avatars
- */
 const TEAM_BG_COLORS = ['#5F735E', '#BF9595', '#D1CDC0'] as const;
 
-/**
- * GraphQL query to fetch all authors (with high limit to get all)
- */
 export const AUTHORS_QUERY = `
   query GetAuthors {
     authors(pagination: { limit: 100 }) {
@@ -181,9 +120,6 @@ export const AUTHORS_QUERY = `
   }
 `;
 
-/**
- * GraphQL query to fetch a single author by slug
- */
 export const AUTHOR_BY_SLUG_QUERY = `
   query GetAuthorBySlug($slug: String!) {
     authors(filters: { slug: { eq: $slug } }) {
@@ -223,143 +159,86 @@ export const AUTHOR_BY_SLUG_QUERY = `
   }
 `;
 
-/**
- * Validates that an object is a valid StrapiAuthorFull
- * @param obj - The object to validate
- * @returns True if the object is a valid StrapiAuthorFull
- */
 function isValidStrapiAuthor(obj: unknown): obj is StrapiAuthorFull {
-  if (!obj || typeof obj !== 'object') {
-    return false;
-  }
-
+  if (!obj || typeof obj !== 'object') return false;
   const author = obj as Record<string, unknown>;
   return typeof author.documentId === 'string' && typeof author.name === 'string';
 }
 
-/**
- * Validates that cached data has the correct structure with StrapiAuthorFull objects
- * @param data - The cached data to validate
- * @returns True if the data structure is valid
- */
 function isValidCachedAuthors(data: unknown): data is StrapiAuthorFull[] {
-  if (!Array.isArray(data)) {
-    return false;
-  }
-
-  return data.every(isValidStrapiAuthor);
+  return Array.isArray(data) && data.every(isValidStrapiAuthor);
 }
 
-/**
- * Extracts the last name from a full name string
- */
 function getLastName(name: string): string {
   const parts = name.trim().split(/\s+/);
   return parts[parts.length - 1].toLowerCase();
 }
 
-/**
- * Extracts the first name from a full name string
- */
 function getFirstName(name: string): string {
   return name.trim().split(/\s+/)[0].toLowerCase();
 }
 
-/**
- * Gets background color based on index, cycling through the color palette
- * @param index - The index of the team member
- * @returns The background color hex code
- */
+/** Background color for team avatars, cycling through the palette. */
 export function getTeamBgColor(index: number): string {
   return TEAM_BG_COLORS[index % TEAM_BG_COLORS.length];
 }
 
-/**
- * Simple hash function to convert string to number
- * @param str - The string to hash
- * @returns A positive integer hash
- */
 function hashString(str: string): number {
   let hash = 0;
   for (let i = 0; i < str.length; i++) {
     const char = str.charCodeAt(i);
     hash = (hash << 5) - hash + char;
-    hash = hash & hash; // Convert to 32bit integer
+    hash = hash & hash;
   }
   return Math.abs(hash);
 }
 
-/**
- * Gets a consistent background color for an author based on their name (fallback)
- * @param authorName - The name of the author
- * @returns The background color hex code
- */
 function getAuthorBgColorByName(authorName: string): string {
   const hash = hashString(authorName);
   return TEAM_BG_COLORS[hash % TEAM_BG_COLORS.length];
 }
 
-/**
- * Sort function for Strapi team members
- * Founders first (CEO at top), then alphabetically by last name
- */
+/** Founders first (CEO at the top), then alphabetical by last name. */
 function sortStrapiTeamMembers(a: StrapiAuthorFull, b: StrapiAuthorFull): number {
   const aIsFounder = a.team === 'founders';
   const bIsFounder = b.team === 'founders';
 
-  // Founders always come first
   if (aIsFounder && !bIsFounder) return -1;
   if (!aIsFounder && bIsFounder) return 1;
 
-  // Among founders, sort by title so CEO comes first
   if (aIsFounder && bIsFounder) {
     const aIsCeo = a.title?.includes('CEO') ? 0 : 1;
     const bIsCeo = b.title?.includes('CEO') ? 0 : 1;
     if (aIsCeo !== bIsCeo) return aIsCeo - bIsCeo;
   }
 
-  // Within the same group, sort by last name, then first name
   const lastNameCmp = getLastName(a.name).localeCompare(getLastName(b.name));
   if (lastNameCmp !== 0) return lastNameCmp;
   return getFirstName(a.name).localeCompare(getFirstName(b.name));
 }
 
-/**
- * Fetch all authors from Strapi with caching
- * @returns Array of all Strapi authors
- */
 export async function fetchStrapiAuthors(): Promise<StrapiAuthorFull[]> {
-  if (CACHE_ENABLED && (await cache.has(CACHE_KEY))) {
-    const cached = await cache.get<StrapiAuthorFull[]>(CACHE_KEY);
-    if (cached && isValidCachedAuthors(cached)) {
-      return cached;
-    }
-    if (cached) {
-      console.warn('Invalid cached Strapi authors data detected, fetching fresh data from API');
-    }
+  const cached = await cache.get<StrapiAuthorFull[]>(AUTHORS_CACHE_KEY);
+  if (cached && isValidCachedAuthors(cached)) return cached;
+  if (cached) {
+    console.warn('Invalid cached Strapi authors data detected, fetching fresh data from API');
   }
 
-  const response = await graphqlQuery<StrapiAuthorsResponse>(AUTHORS_QUERY);
-
+  const response = await client.query<StrapiAuthorsResponse>(AUTHORS_QUERY);
   if (!response?.authors) {
     console.warn('No authors returned from Strapi API');
     return [];
   }
 
   const authors = response.authors.map(normalizeAuthorFromGraphQL);
-
-  if (CACHE_ENABLED) {
-    await cache.set(CACHE_KEY, authors, CACHE_TTL);
-  }
-
+  await cache.set(AUTHORS_CACHE_KEY, authors, { tags: ['authors'] });
   return authors;
 }
 
 /**
- * Fetch single author by documentId.
- * Uses strapi-authors list (already includes documentId); no separate cache needed.
- * @param documentId - Author documentId (used as slug in URL for backwards compat)
- * @returns The author or null if not found
+ * documentId lookup. Reads the cached authors list rather than maintaining a
+ * dedicated cache — `fetchStrapiAuthors()` is already memoized via the
+ * package's cache manager.
  */
 export async function fetchStrapiAuthorByDocumentId(
   documentId: string
@@ -368,58 +247,35 @@ export async function fetchStrapiAuthorByDocumentId(
   return authors.find((a) => a.documentId === documentId) ?? null;
 }
 
-/**
- * Fetch single author by slug.
- * Caches each author separately (per-author cache by slug).
- * @param slug - Author slug (used in URL, e.g. /authors/john-doe/)
- * @returns The author or null if not found
- */
 export async function fetchStrapiAuthorBySlug(slug: string): Promise<StrapiAuthorFull | null> {
   const cacheKey = `${AUTHOR_SLUG_CACHE_PREFIX}${slug}`;
 
-  if (CACHE_ENABLED && (await cache.has(cacheKey))) {
-    const cached = await cache.get<StrapiAuthorFull>(cacheKey);
-    if (cached && isValidStrapiAuthor(cached)) {
-      return cached;
-    }
-    if (cached) {
-      console.warn(
-        `Invalid cached Strapi author data detected for slug "${slug}", fetching fresh data from API`
-      );
-    }
+  const cached = await cache.get<StrapiAuthorFull>(cacheKey);
+  if (cached && isValidStrapiAuthor(cached)) return cached;
+  if (cached) {
+    console.warn(
+      `Invalid cached Strapi author data detected for slug "${slug}", fetching fresh data from API`
+    );
   }
 
-  const response = await graphqlQuery<StrapiAuthorsResponse>(AUTHOR_BY_SLUG_QUERY, { slug });
-
-  if (!response?.authors || response.authors.length === 0) {
-    return null;
-  }
+  const response = await client.query<StrapiAuthorsResponse>(AUTHOR_BY_SLUG_QUERY, { slug });
+  if (!response?.authors || response.authors.length === 0) return null;
 
   const author = normalizeAuthorFromGraphQL(response.authors[0]);
-
-  if (CACHE_ENABLED) {
-    await cache.set(cacheKey, author, CACHE_TTL);
-  }
-
+  await cache.set(cacheKey, author, { tags: ['authors', `author:${slug}`] });
   return author;
 }
 
 /**
- * Fetches all team members from Strapi (authors where isTeam is true),
- * sorted with founders first, then alphabetically by last name.
- * Uses dedicated cache for team members.
- * @returns Sorted array of Strapi team member entries
+ * Team members (`isTeam === true`), sorted with founders first, then
+ * alphabetically by last name. Cached separately so the sort/filter happens
+ * once per author publish, not on every page render.
  */
 export async function getStrapiTeamMembers(): Promise<StrapiAuthorFull[]> {
-  // Check dedicated team members cache first
-  if (CACHE_ENABLED && (await cache.has(TEAM_MEMBERS_CACHE_KEY))) {
-    const cached = await cache.get<StrapiAuthorFull[]>(TEAM_MEMBERS_CACHE_KEY);
-    if (cached && isValidCachedAuthors(cached)) {
-      return cached;
-    }
-    if (cached) {
-      console.warn('Invalid cached Strapi team members data detected, fetching fresh data');
-    }
+  const cached = await cache.get<StrapiAuthorFull[]>(TEAM_MEMBERS_CACHE_KEY);
+  if (cached && isValidCachedAuthors(cached)) return cached;
+  if (cached) {
+    console.warn('Invalid cached Strapi team members data detected, fetching fresh data');
   }
 
   const authors = await fetchStrapiAuthors();
@@ -427,29 +283,19 @@ export async function getStrapiTeamMembers(): Promise<StrapiAuthorFull[]> {
     .filter((author) => author.isTeam === true)
     .sort(sortStrapiTeamMembers);
 
-  // Cache the sorted team members
-  if (CACHE_ENABLED) {
-    await cache.set(TEAM_MEMBERS_CACHE_KEY, teamMembers, CACHE_TTL);
-  }
-
+  await cache.set(TEAM_MEMBERS_CACHE_KEY, teamMembers, { tags: ['authors'] });
   return teamMembers;
 }
 
 /**
- * Fetches all card members from Strapi (authors where isCard is true),
- * sorted with founders first, then alphabetically by last name.
- * Uses dedicated cache for card members.
- * @returns Sorted array of Strapi card member entries
+ * Card members (`isCard === true`), sorted with founders first. Same caching
+ * pattern as team members.
  */
 export async function getStrapiCardMembers(): Promise<StrapiAuthorFull[]> {
-  if (CACHE_ENABLED && (await cache.has(CARD_MEMBERS_CACHE_KEY))) {
-    const cached = await cache.get<StrapiAuthorFull[]>(CARD_MEMBERS_CACHE_KEY);
-    if (cached && isValidCachedAuthors(cached)) {
-      return cached;
-    }
-    if (cached) {
-      console.warn('Invalid cached Strapi card members data detected, fetching fresh data');
-    }
+  const cached = await cache.get<StrapiAuthorFull[]>(CARD_MEMBERS_CACHE_KEY);
+  if (cached && isValidCachedAuthors(cached)) return cached;
+  if (cached) {
+    console.warn('Invalid cached Strapi card members data detected, fetching fresh data');
   }
 
   const authors = await fetchStrapiAuthors();
@@ -457,27 +303,18 @@ export async function getStrapiCardMembers(): Promise<StrapiAuthorFull[]> {
     .filter((author) => author.isCard === true)
     .sort(sortStrapiTeamMembers);
 
-  if (CACHE_ENABLED) {
-    await cache.set(CARD_MEMBERS_CACHE_KEY, cardMembers, CACHE_TTL);
-  }
-
+  await cache.set(CARD_MEMBERS_CACHE_KEY, cardMembers, { tags: ['authors'] });
   return cardMembers;
 }
 
 /**
- * Gets the background color for a Strapi author based on their position in the team members list
- * Falls back to hash-based color if author is not found in the team list
- * @param authorName - The name of the author
- * @returns The background color hex code
+ * Background color for an author, derived from their position in the sorted
+ * team list. Falls back to a name-hash color when the author isn't on the team.
  */
 export async function getAuthorBgColorFromStrapi(authorName: string): Promise<string> {
   const teamMembers = await getStrapiTeamMembers();
   const authorIndex = teamMembers.findIndex((member) => member.name === authorName);
 
-  if (authorIndex >= 0) {
-    return getTeamBgColor(authorIndex);
-  }
-
-  // Fallback to hash-based color if author not in team list
+  if (authorIndex >= 0) return getTeamBgColor(authorIndex);
   return getAuthorBgColorByName(authorName);
 }

--- a/src/libs/strapi/index.ts
+++ b/src/libs/strapi/index.ts
@@ -100,6 +100,7 @@ export {
   ARTICLES_BY_CATEGORY_QUERY,
   fetchStrapiArticles,
   fetchStrapiArticleBySlug,
+  ensureStrapiArticleDetail,
 } from './articles';
 
 // Re-export roadmaps module

--- a/src/libs/strapi/regenerateCache.ts
+++ b/src/libs/strapi/regenerateCache.ts
@@ -1,11 +1,19 @@
 // src/libs/strapi/regenerateCache.ts
 /**
- * Regenerate Strapi cache entries only when the cache file does not exist.
- * Uses the same cache keys and fetch methods as articles, authors, and roadmaps.
+ * Regenerate Strapi cache entries on demand.
+ *
+ * Two modes serve the `/api/cache/strapi` admin endpoint:
+ *   - `regenerateStrapiCacheIfMissing()` — fills only the entries whose primary
+ *     cache file is absent (or expired). Used as the safe default.
+ *   - `forceRegenerateStrapiCache(names)` — explicitly clears the listed entries
+ *     and refetches every one, regardless of current state.
+ *
+ * Cache reads/writes go through the shared `cache` manager from `_runtime.ts`
+ * so tag membership and the fallback mirror stay consistent with the rest of
+ * the Strapi module.
  */
 
-import path from 'node:path';
-import { Cache } from '@libs/cache';
+import { cache } from './_runtime';
 import { fetchStrapiArticles, fetchStrapiArticleBySlug } from './articles';
 import {
   fetchStrapiAuthors,
@@ -15,9 +23,6 @@ import {
 } from './authors';
 import { fetchStrapiRoadmaps } from './roadmaps';
 import type { StrapiArticle } from '../../types/strapi';
-
-const CACHE_DIR = path.resolve(process.cwd(), '.cache');
-const cache = new Cache(CACHE_DIR);
 
 const ARTICLES_CACHE_KEY = 'strapi-articles';
 export const ARTICLE_CACHE_PREFIX = 'strapi-article-';
@@ -39,27 +44,24 @@ export const STRAPI_FORCE_REGENERATE_KEYS = [
 const FIXED_FORCE_KEYS = new Set<string>(STRAPI_FORCE_REGENERATE_KEYS);
 
 function isSafeSlugSegment(slug: string): boolean {
-  if (!slug || slug.includes('/') || slug.includes('\\')) {
-    return false;
-  }
-  if (slug === '.' || slug === '..') {
-    return false;
-  }
+  if (!slug || slug.includes('/') || slug.includes('\\')) return false;
+  if (slug === '.' || slug === '..') return false;
   return true;
 }
 
 function isArticleCacheKey(name: string): boolean {
-  if (!name.startsWith(ARTICLE_CACHE_PREFIX)) {
-    return false;
-  }
+  if (!name.startsWith(ARTICLE_CACHE_PREFIX)) return false;
   return isSafeSlugSegment(name.slice(ARTICLE_CACHE_PREFIX.length).trim());
 }
 
 function isAuthorSlugCacheKey(name: string): boolean {
-  if (!name.startsWith(AUTHOR_SLUG_CACHE_PREFIX)) {
-    return false;
-  }
+  if (!name.startsWith(AUTHOR_SLUG_CACHE_PREFIX)) return false;
   return isSafeSlugSegment(name.slice(AUTHOR_SLUG_CACHE_PREFIX.length).trim());
+}
+
+/** Primary cache hit check — returns true when the key has a valid, non-expired entry. */
+async function isCached(key: string): Promise<boolean> {
+  return (await cache.get<unknown>(key)) !== null;
 }
 
 /**
@@ -68,18 +70,10 @@ function isAuthorSlugCacheKey(name: string): boolean {
  */
 export function validateStrapiForceRegenerateName(name: string): string | null {
   const trimmed = name.trim();
-  if (!trimmed) {
-    return 'Empty cache name';
-  }
-  if (FIXED_FORCE_KEYS.has(trimmed)) {
-    return null;
-  }
-  if (isArticleCacheKey(trimmed)) {
-    return null;
-  }
-  if (isAuthorSlugCacheKey(trimmed)) {
-    return null;
-  }
+  if (!trimmed) return 'Empty cache name';
+  if (FIXED_FORCE_KEYS.has(trimmed)) return null;
+  if (isArticleCacheKey(trimmed)) return null;
+  if (isAuthorSlugCacheKey(trimmed)) return null;
   return `Unknown cache name "${trimmed}". Expected one of ${[...FIXED_FORCE_KEYS].join(
     ', '
   )}, ${ARTICLE_CACHE_PREFIX}{slug}, or ${AUTHOR_SLUG_CACHE_PREFIX}{slug}`;
@@ -91,23 +85,26 @@ export function validateStrapiForceRegenerateName(name: string): string | null {
  */
 export function validateStrapiForceRegenerateRequest(names: readonly string[]): string[] {
   const unique = [...new Set(names.map((n) => n.trim()).filter((n) => n.length > 0))];
-  if (unique.length === 0) {
-    return ['At least one cache name is required'];
-  }
+  if (unique.length === 0) return ['At least one cache name is required'];
 
   const errors: string[] = [];
   for (const name of unique) {
     const message = validateStrapiForceRegenerateName(name);
-    if (message) {
-      errors.push(`${name}: ${message}`);
-    }
+    if (message) errors.push(`${name}: ${message}`);
   }
   return errors;
 }
 
+export interface RegenerateResult {
+  regenerated: string[];
+  skipped: string[];
+  errors: string[];
+}
+
 /**
- * Clears the given Strapi cache keys and repopulates from the API where possible.
- * @param names - Validated cache key names only
+ * Clear the given Strapi cache keys and repopulate them from the API.
+ * @param names - Already-validated cache key names (caller should run
+ *   `validateStrapiForceRegenerateRequest` first).
  */
 export async function forceRegenerateStrapiCache(
   names: readonly string[]
@@ -119,7 +116,7 @@ export async function forceRegenerateStrapiCache(
   const unique = [...new Set(names.map((n) => n.trim()).filter((n) => n.length > 0))];
 
   for (const name of unique) {
-    await cache.clear(name);
+    await cache.delete(name);
 
     try {
       switch (name) {
@@ -173,71 +170,35 @@ export async function forceRegenerateStrapiCache(
   return { regenerated, skipped, errors };
 }
 
-export interface RegenerateResult {
-  regenerated: string[];
-  skipped: string[];
-  errors: string[];
-}
-
 /**
- * Regenerate all strapi-* cache entries that do not yet exist.
- * Only populates cache when the JSON file is missing.
- * @returns Summary of regenerated keys, skipped keys, and any errors
+ * Regenerate every well-known Strapi cache entry that is currently missing.
+ * Populated entries are reported as skipped — useful as a post-deploy warm-up
+ * that won't thrash Strapi when the cache is already hot.
  */
 export async function regenerateStrapiCacheIfMissing(): Promise<RegenerateResult> {
   const regenerated: string[] = [];
   const skipped: string[] = [];
   const errors: string[] = [];
 
-  // 1. strapi-articles
-  if (!(await cache.has(ARTICLES_CACHE_KEY))) {
-    try {
-      await fetchStrapiArticles();
-      regenerated.push(ARTICLES_CACHE_KEY);
-    } catch (err) {
-      errors.push(`${ARTICLES_CACHE_KEY}: ${err instanceof Error ? err.message : String(err)}`);
+  const tryWarm = async (key: string, warm: () => Promise<unknown>): Promise<void> => {
+    if (await isCached(key)) {
+      skipped.push(key);
+      return;
     }
-  } else {
-    skipped.push(ARTICLES_CACHE_KEY);
-  }
-
-  // 2. strapi-authors
-  if (!(await cache.has(AUTHORS_CACHE_KEY))) {
     try {
-      await fetchStrapiAuthors();
-      regenerated.push(AUTHORS_CACHE_KEY);
+      await warm();
+      regenerated.push(key);
     } catch (err) {
-      errors.push(`${AUTHORS_CACHE_KEY}: ${err instanceof Error ? err.message : String(err)}`);
+      errors.push(`${key}: ${err instanceof Error ? err.message : String(err)}`);
     }
-  } else {
-    skipped.push(AUTHORS_CACHE_KEY);
-  }
+  };
 
-  // 3. strapi-roadmaps
-  if (!(await cache.has(ROADMAPS_CACHE_KEY))) {
-    try {
-      await fetchStrapiRoadmaps();
-      regenerated.push(ROADMAPS_CACHE_KEY);
-    } catch (err) {
-      errors.push(`${ROADMAPS_CACHE_KEY}: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  } else {
-    skipped.push(ROADMAPS_CACHE_KEY);
-  }
+  await tryWarm(ARTICLES_CACHE_KEY, fetchStrapiArticles);
+  await tryWarm(AUTHORS_CACHE_KEY, fetchStrapiAuthors);
+  await tryWarm(ROADMAPS_CACHE_KEY, fetchStrapiRoadmaps);
+  await tryWarm(TEAM_MEMBERS_CACHE_KEY, getStrapiTeamMembers);
 
-  // 4. strapi-team-members (depends on authors)
-  if (!(await cache.has(TEAM_MEMBERS_CACHE_KEY))) {
-    try {
-      await getStrapiTeamMembers();
-      regenerated.push(TEAM_MEMBERS_CACHE_KEY);
-    } catch (err) {
-      errors.push(`${TEAM_MEMBERS_CACHE_KEY}: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  } else {
-    skipped.push(TEAM_MEMBERS_CACHE_KEY);
-  }
-
-  // 5. Per-article cache (strapi-article-{slug})
+  // Per-article cache (depends on the article list)
   const articles: StrapiArticle[] = await fetchStrapiArticles();
   const authorIdsWithArticles = new Set(
     articles.map((a) => a.author?.documentId).filter((id): id is string => Boolean(id))
@@ -245,37 +206,15 @@ export async function regenerateStrapiCacheIfMissing(): Promise<RegenerateResult
 
   for (const article of articles) {
     const key = `${ARTICLE_CACHE_PREFIX}${article.slug}`;
-    if (!(await cache.has(key))) {
-      try {
-        await fetchStrapiArticleBySlug(article.slug);
-        regenerated.push(key);
-      } catch (err) {
-        errors.push(`${key}: ${err instanceof Error ? err.message : String(err)}`);
-      }
-    } else {
-      skipped.push(key);
-    }
+    await tryWarm(key, () => fetchStrapiArticleBySlug(article.slug));
   }
 
-  // 6. Per-author cache (strapi-author-slug-{slug}) — documentId lookup uses strapi-authors list
-  // Only for authors that have at least one article
+  // Per-author cache, restricted to authors who have at least one article
   const authors = await fetchStrapiAuthors();
   for (const author of authors) {
-    if (!authorIdsWithArticles.has(author.documentId) || !author.slug) {
-      continue;
-    }
-
+    if (!authorIdsWithArticles.has(author.documentId) || !author.slug) continue;
     const slugKey = `${AUTHOR_SLUG_CACHE_PREFIX}${author.slug}`;
-    if (!(await cache.has(slugKey))) {
-      try {
-        await fetchStrapiAuthorBySlug(author.slug);
-        regenerated.push(slugKey);
-      } catch (err) {
-        errors.push(`${slugKey}: ${err instanceof Error ? err.message : String(err)}`);
-      }
-    } else {
-      skipped.push(slugKey);
-    }
+    await tryWarm(slugKey, () => fetchStrapiAuthorBySlug(author.slug as string));
   }
 
   return { regenerated, skipped, errors };

--- a/src/libs/strapi/roadmaps.ts
+++ b/src/libs/strapi/roadmaps.ts
@@ -11,6 +11,9 @@ import { cache, client } from './_runtime';
 import type { StrapiRoadmap, StrapiRoadmapsResponse } from '../../types/strapi';
 
 const ROADMAPS_CACHE_KEY = 'strapi-roadmaps';
+// Pre-migration fallback key; read as a backstop so deploys preserve access to
+// existing stale data if Strapi happens to be unreachable during the cutover.
+const LEGACY_FALLBACK_KEY = 'roadmaps';
 
 export const ROADMAPS_QUERY = `
   query GetRoadmaps {
@@ -50,7 +53,9 @@ export async function fetchStrapiRoadmaps(): Promise<StrapiRoadmap[]> {
 
   if (!response?.roadmaps) {
     console.warn('Strapi unavailable — checking persistent fallback cache for roadmaps');
-    const fallback = await cache.getFallback<StrapiRoadmap[]>(ROADMAPS_CACHE_KEY);
+    const fallback =
+      (await cache.getFallback<StrapiRoadmap[]>(ROADMAPS_CACHE_KEY)) ??
+      (await cache.getFallback<StrapiRoadmap[]>(LEGACY_FALLBACK_KEY));
     if (fallback && isValidCachedRoadmaps(fallback)) {
       console.warn(`Serving ${fallback.length} roadmaps from stale fallback cache`);
       return fallback;

--- a/src/libs/strapi/roadmaps.ts
+++ b/src/libs/strapi/roadmaps.ts
@@ -1,104 +1,17 @@
 // src/libs/strapi/roadmaps.ts
 /**
- * Strapi Roadmaps module with caching support
+ * Strapi Roadmaps module.
+ *
+ * GraphQL + cache duties live in `_runtime.ts` (via `@datum-cloud/strapi-revalidate`).
+ * Cache key `strapi-roadmaps` is tagged `roadmaps`; the webhook tag map in
+ * `_runtime.ts` routes `api::roadmap.roadmap` events to this tag.
  */
 
-import { Cache } from '@libs/cache';
+import { cache, client } from './_runtime';
 import type { StrapiRoadmap, StrapiRoadmapsResponse } from '../../types/strapi';
 
-const STRAPI_URL = process.env.STRAPI_URL ?? 'https://grateful-excitement-dfe9d47bad.strapiapp.com';
-const STRAPI_TOKEN = process.env.STRAPI_TOKEN ?? '';
-const cacheEnabledRaw = import.meta.env?.STRAPI_CACHE_ENABLED || process.env.STRAPI_CACHE_ENABLED;
-const CACHE_ENABLED = cacheEnabledRaw === 'true' || cacheEnabledRaw === '1';
-
-const DEFAULT_CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
-const envTtlSec = parseInt(
-  import.meta.env?.STRAPI_CACHE_TTL ?? process.env.STRAPI_CACHE_TTL ?? '2592000',
-  10
-);
-const ROADMAPS_CACHE_TTL =
-  Number.isNaN(envTtlSec) || envTtlSec <= 0 ? DEFAULT_CACHE_TTL_MS : envTtlSec * 1000;
-
-const envTimeoutSec = parseInt(
-  import.meta.env?.STRAPI_TIMEOUT ?? process.env.STRAPI_TIMEOUT ?? '10',
-  10
-);
-const FETCH_TIMEOUT_MS =
-  Number.isNaN(envTimeoutSec) || envTimeoutSec <= 0 ? 10_000 : envTimeoutSec * 1000;
-
-interface GraphQLResponse<T> {
-  data: T;
-  errors?: Array<{ message: string }>;
-}
-
-/**
- * Execute a GraphQL query against Strapi
- */
-async function graphqlQuery<T>(
-  query: string,
-  variables: Record<string, unknown> = {}
-): Promise<T | null> {
-  const headers: HeadersInit = {
-    'Content-Type': 'application/json',
-  };
-
-  if (STRAPI_TOKEN) {
-    headers['Authorization'] = `Bearer ${STRAPI_TOKEN}`;
-  }
-
-  const url = `${STRAPI_URL}/graphql`;
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-
-  try {
-    const response = await fetch(url, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        query,
-        variables,
-      }),
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      const text = await response.text();
-      console.error(`Strapi GraphQL error: ${response.status} ${response.statusText}`, text);
-      return null;
-    }
-
-    const result: GraphQLResponse<T> = await response.json();
-
-    if (result.errors) {
-      console.error('Strapi GraphQL errors:', result.errors);
-      return null;
-    }
-
-    return result.data;
-  } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      console.warn(`Strapi request timed out after ${FETCH_TIMEOUT_MS}ms`);
-    } else {
-      console.warn(
-        'Strapi unreachable (using fallback cache if available):',
-        (error as Error).message
-      );
-    }
-    return null;
-  } finally {
-    clearTimeout(timeoutId);
-  }
-}
-
-const cache = new Cache('.cache');
 const ROADMAPS_CACHE_KEY = 'strapi-roadmaps';
 
-const fallbackCache = new Cache('.cache/strapi-fallback');
-const FALLBACK_ROADMAPS_KEY = 'roadmaps';
-
-/**
- * GraphQL query to fetch all roadmap milestones
- */
 export const ROADMAPS_QUERY = `
   query GetRoadmaps {
     roadmaps(pagination: { limit: 100 }, sort: "releaseDate:desc") {
@@ -112,72 +25,43 @@ export const ROADMAPS_QUERY = `
   }
 `;
 
-/**
- * Validates that an object is a valid StrapiRoadmap
- */
 function isValidStrapiRoadmap(obj: unknown): obj is StrapiRoadmap {
-  if (!obj || typeof obj !== 'object') {
-    return false;
-  }
-
+  if (!obj || typeof obj !== 'object') return false;
   const roadmap = obj as Record<string, unknown>;
   return typeof roadmap.documentId === 'string' && typeof roadmap.title === 'string';
 }
 
-/**
- * Validates that cached data has the correct structure
- */
 function isValidCachedRoadmaps(data: unknown): data is StrapiRoadmap[] {
-  if (!Array.isArray(data)) {
-    return false;
-  }
-
-  return data.every(isValidStrapiRoadmap);
+  return Array.isArray(data) && data.every(isValidStrapiRoadmap);
 }
 
 /**
- * Fetch all roadmap milestones from Strapi with caching.
- * Falls back to a persistent stale cache when Strapi is unreachable.
- * @returns Array of all Strapi roadmap milestones
+ * Fetch all roadmap milestones from Strapi. Reads cache first; on Strapi
+ * failure serves stale data from the persistent fallback cache.
  */
 export async function fetchStrapiRoadmaps(): Promise<StrapiRoadmap[]> {
-  if (CACHE_ENABLED && (await cache.has(ROADMAPS_CACHE_KEY))) {
-    const cached = await cache.get<StrapiRoadmap[]>(ROADMAPS_CACHE_KEY);
-    if (cached && isValidCachedRoadmaps(cached)) {
-      return cached;
-    }
-    if (cached) {
-      console.warn('Invalid cached Strapi roadmaps data detected, fetching fresh data from API');
-    }
+  const cached = await cache.get<StrapiRoadmap[]>(ROADMAPS_CACHE_KEY);
+  if (cached && isValidCachedRoadmaps(cached)) return cached;
+  if (cached) {
+    console.warn('Invalid cached Strapi roadmaps data detected, fetching fresh data from API');
   }
 
-  const response = await graphqlQuery<StrapiRoadmapsResponse>(ROADMAPS_QUERY);
+  const response = await client.query<StrapiRoadmapsResponse>(ROADMAPS_QUERY);
 
   if (!response?.roadmaps) {
     console.warn('Strapi unavailable — checking persistent fallback cache for roadmaps');
-    const fallback = await fallbackCache.get<StrapiRoadmap[]>(FALLBACK_ROADMAPS_KEY);
+    const fallback = await cache.getFallback<StrapiRoadmap[]>(ROADMAPS_CACHE_KEY);
     if (fallback && isValidCachedRoadmaps(fallback)) {
       console.warn(`Serving ${fallback.length} roadmaps from stale fallback cache`);
       return fallback;
     }
-    console.warn('No roadmaps returned from Strapi API and no fallback cache available');
     return [];
   }
 
-  const roadmaps = response.roadmaps;
-
-  if (CACHE_ENABLED) {
-    await cache.set(ROADMAPS_CACHE_KEY, roadmaps, ROADMAPS_CACHE_TTL);
-  }
-
-  await fallbackCache.set(FALLBACK_ROADMAPS_KEY, roadmaps);
-
-  return roadmaps;
+  await cache.set(ROADMAPS_CACHE_KEY, response.roadmaps, { tags: ['roadmaps'] });
+  return response.roadmaps;
 }
 
-/**
- * Grouped roadmaps by upcoming/previous status
- */
 export interface GroupedRoadmaps {
   upcoming: StrapiRoadmap[];
   previous: StrapiRoadmap[];
@@ -186,8 +70,6 @@ export interface GroupedRoadmaps {
 /**
  * Group roadmaps into upcoming and previous based on releaseDate.
  * Milestones with releaseDate >= today are considered "upcoming".
- * @param roadmaps - Array of roadmap milestones
- * @returns Object with upcoming and previous arrays
  */
 export function groupRoadmapsByDate(roadmaps: StrapiRoadmap[]): GroupedRoadmaps {
   const today = new Date();
@@ -199,28 +81,16 @@ export function groupRoadmapsByDate(roadmaps: StrapiRoadmap[]): GroupedRoadmaps 
   for (const roadmap of roadmaps) {
     const releaseDate = new Date(roadmap.releaseDate);
     releaseDate.setHours(0, 0, 0, 0);
-
-    if (releaseDate >= today) {
-      upcoming.push(roadmap);
-    } else {
-      previous.push(roadmap);
-    }
+    (releaseDate >= today ? upcoming : previous).push(roadmap);
   }
 
-  // Upcoming: sort by releaseDate ASC (nearest first)
   upcoming.sort((a, b) => new Date(a.releaseDate).getTime() - new Date(b.releaseDate).getTime());
-
-  // Previous: sort by releaseDate DESC (most recent first)
   previous.sort((a, b) => new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime());
 
   return { upcoming, previous };
 }
 
-/**
- * Get month abbreviation from date string
- * @param dateString - ISO date string (e.g., "2025-03-01")
- * @returns 3-letter month abbreviation (e.g., "MAR")
- */
+/** Three-letter uppercase month from an ISO date (e.g. `"2025-03-01"` → `"MAR"`). */
 export function getMonthAbbreviation(dateString: string): string {
   const date = new Date(dateString);
   return date.toLocaleString('en-US', { month: 'short' }).toUpperCase();

--- a/src/pages/api/webhooks/strapi-content.ts
+++ b/src/pages/api/webhooks/strapi-content.ts
@@ -1,11 +1,25 @@
 // src/pages/api/webhooks/strapi-content.ts
+/**
+ * Strapi → datum.net webhook endpoint.
+ *
+ * Delegates secret verification, payload parsing, and tag-based cache
+ * invalidation to `@datum-cloud/strapi-revalidate`'s `createWebhookHandler`.
+ * The `onRevalidate` callback re-warms the affected caches by calling the
+ * shared fetchers (which use the same `cache` manager, so the next request
+ * after a publish serves fresh data without a cold trip to Strapi).
+ *
+ * Header note: the package accepts `Authorization: Bearer <secret>`,
+ * `X-Strapi-Signature`, or `strapi-webhook-secret`. Strapi Cloud must be
+ * configured to send one of these (not the legacy `X-Webhook-Secret`) or
+ * every request will 401.
+ */
 
 export const prerender = false;
 
 import type { APIRoute } from 'astro';
-import crypto from 'node:crypto';
-import fs from 'node:fs';
-import path from 'node:path';
+import { createWebhookHandler } from '@datum-cloud/strapi-revalidate';
+import type { WebhookEvent } from '@datum-cloud/strapi-revalidate';
+import { cache, config } from '@libs/strapi/_runtime';
 import { fetchStrapiArticles, fetchStrapiArticleBySlug } from '@libs/strapi/articles';
 import {
   fetchStrapiAuthors,
@@ -14,235 +28,86 @@ import {
 } from '@libs/strapi/authors';
 import { fetchStrapiRoadmaps } from '@libs/strapi/roadmaps';
 
-const CACHE_DIR = path.resolve(process.cwd(), '.cache');
-const FALLBACK_CACHE_DIR = path.resolve(process.cwd(), '.cache/strapi-fallback');
+/** Strapi events that mean "the entry no longer exists" — skip the per-slug warm. */
+const DELETE_EVENTS = new Set(['entry.delete', 'entry.unpublish']);
 
-interface StrapiWebhookPayload {
-  event: 'entry.create' | 'entry.update' | 'entry.delete';
-  model: string;
-  entry: {
-    id: number;
-    slug?: string;
-    name?: string;
-    [key: string]: unknown;
-  };
-}
+async function warmAfterRevalidate(event: WebhookEvent): Promise<void> {
+  const isDelete = DELETE_EVENTS.has(event.event);
 
-function verifyWebhookSecret(request: Request): boolean {
-  const webhookSecret = process.env.STRAPI_WEBHOOK_SECRET;
-
-  if (!webhookSecret) {
-    console.warn('[Webhook] STRAPI_WEBHOOK_SECRET is not configured');
-    return false;
-  }
-
-  const receivedSecret = request.headers.get('X-Webhook-Secret');
-
-  if (!receivedSecret) {
-    console.warn('[Webhook] Missing X-Webhook-Secret header');
-    return false;
-  }
-
-  const expected = Buffer.from(webhookSecret);
-  const received = Buffer.from(receivedSecret);
-
-  if (expected.length !== received.length) {
-    return false;
-  }
-
-  return crypto.timingSafeEqual(expected, received);
-}
-
-function deleteCacheFilesInDir(dir: string, pattern: string): string[] {
-  const deleted: string[] = [];
-
-  try {
-    if (!fs.existsSync(dir)) return deleted;
-
-    for (const file of fs.readdirSync(dir)) {
-      if (file.startsWith(pattern)) {
-        try {
-          fs.unlinkSync(path.join(dir, file));
-          deleted.push(file);
-        } catch (err) {
-          console.error(`[Webhook] Failed to delete ${file}:`, err);
-        }
-      }
-    }
-  } catch (err) {
-    console.error(`[Webhook] Error reading cache dir ${dir}:`, err);
-  }
-
-  return deleted;
-}
-
-/**
- * Delete matching files from both main and fallback cache dirs.
- * mainPattern  — prefix used in .cache/
- * fallbackPattern — prefix used in .cache/strapi-fallback/ (differs from main)
- */
-function invalidateCache(mainPattern: string, fallbackPattern: string): string[] {
-  return [
-    ...deleteCacheFilesInDir(CACHE_DIR, mainPattern),
-    ...deleteCacheFilesInDir(FALLBACK_CACHE_DIR, fallbackPattern),
-  ];
-}
-
-function invalidateArticleCache(slug?: string): string[] {
-  const deleted = [
-    // list caches: main "strapi-articles*", fallback "articles*"
-    ...invalidateCache('strapi-articles', 'articles'),
-  ];
-
-  if (slug) {
-    // per-article: main "strapi-article-{slug}*", fallback "article-{slug}*"
-    deleted.push(...invalidateCache(`strapi-article-${slug}`, `article-${slug}`));
-  }
-
-  return deleted;
-}
-
-function invalidateAuthorCache(): string[] {
-  // Authors have no fallback cache — only clear main
-  return [
-    ...deleteCacheFilesInDir(CACHE_DIR, 'strapi-authors'),
-    ...deleteCacheFilesInDir(CACHE_DIR, 'strapi-team-members'),
-    ...deleteCacheFilesInDir(CACHE_DIR, 'strapi-card-members'),
-    ...deleteCacheFilesInDir(CACHE_DIR, 'strapi-author-slug-'),
-  ];
-}
-
-function invalidateRoadmapCache(): string[] {
-  // main "strapi-roadmaps*", fallback "roadmaps*"
-  return invalidateCache('strapi-roadmaps', 'roadmaps');
-}
-
-/**
- * Re-fetch and rewrite article caches after invalidation.
- * On delete we skip re-fetching the individual article (it no longer exists in Strapi)
- * so we don't accidentally promote the stale fallback entry back into the main cache.
- */
-async function warmArticleCache(slug: string | undefined, isDelete: boolean): Promise<void> {
-  try {
-    await fetchStrapiArticles();
-  } catch (err) {
-    console.error('[Webhook] Cache warm failed for article list:', err);
-  }
-
-  if (slug && !isDelete) {
-    try {
-      await fetchStrapiArticleBySlug(slug);
-    } catch (err) {
-      console.error(`[Webhook] Cache warm failed for article "${slug}":`, err);
-    }
+  switch (event.model) {
+    case 'article':
+      await Promise.allSettled([
+        fetchStrapiArticles(),
+        event.slug && !isDelete ? fetchStrapiArticleBySlug(event.slug) : Promise.resolve(null),
+      ]);
+      break;
+    case 'author':
+      await Promise.allSettled([
+        // Order matters: refresh the source list first so derived caches are
+        // computed from fresh data when getStrapiTeamMembers/getStrapiCardMembers run.
+        fetchStrapiAuthors().then(() =>
+          Promise.allSettled([getStrapiTeamMembers(), getStrapiCardMembers()])
+        ),
+      ]);
+      break;
+    case 'roadmap':
+      await fetchStrapiRoadmaps();
+      break;
+    default:
+      console.warn(`[Webhook] No warm strategy for model "${event.model}"`);
   }
 }
 
-async function warmAuthorCache(): Promise<void> {
-  try {
-    await fetchStrapiAuthors();
-  } catch (err) {
-    console.error('[Webhook] Cache warm failed for authors:', err);
-  }
-
-  // Rebuild derived caches (team and card members) after the primary author list refresh
-  try {
-    await getStrapiTeamMembers();
-  } catch (err) {
-    console.error('[Webhook] Cache warm failed for team members:', err);
-  }
-
-  try {
-    await getStrapiCardMembers();
-  } catch (err) {
-    console.error('[Webhook] Cache warm failed for card members:', err);
-  }
-}
-
-async function warmRoadmapCache(): Promise<void> {
-  try {
-    await fetchStrapiRoadmaps();
-  } catch (err) {
-    console.error('[Webhook] Cache warm failed for roadmaps:', err);
-  }
-}
+const handle = createWebhookHandler({
+  config: {
+    ...config,
+    webhook: {
+      ...config.webhook,
+      onRevalidate: warmAfterRevalidate,
+    },
+  },
+  cache,
+});
 
 export const POST: APIRoute = async ({ request }) => {
   const startTime = Date.now();
+  let status = 200;
+  let body: unknown = {};
+
+  // Adapt Astro's `Request` to the package's lowest-common-denominator shape.
+  // Fetch `Headers` doesn't have a string index signature so the package's
+  // `WebhookRequest` rejects it at the type level, even though `.get()` works
+  // at runtime — wrap it so only the methods the handler needs are exposed.
+  const webhookReq = {
+    method: request.method,
+    headers: {
+      get: (name: string): string | null => request.headers.get(name),
+    },
+    text: () => request.text(),
+    json: () => request.json(),
+  };
 
   try {
-    if (!verifyWebhookSecret(request)) {
-      console.error('[Webhook] Unauthorized webhook request');
-      return new Response(JSON.stringify({ success: false, error: 'Unauthorized' }), {
-        status: 401,
-        headers: { 'Content-Type': 'application/json' },
-      });
-    }
-
-    let payload: StrapiWebhookPayload;
-    try {
-      payload = (await request.json()) as StrapiWebhookPayload;
-    } catch {
-      return new Response(JSON.stringify({ success: false, error: 'Invalid JSON payload' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      });
-    }
-
-    const { event, model, entry } = payload;
-
-    if (!event || !model) {
-      return new Response(
-        JSON.stringify({ success: false, error: 'Missing required fields: event, model' }),
-        { status: 400, headers: { 'Content-Type': 'application/json' } }
-      );
-    }
-
-    console.log(`[Webhook] ${event} on model "${model}"`, {
-      id: entry?.id,
-      slug: entry?.slug,
-      name: entry?.name,
+    await handle(webhookReq, {
+      status: (code) => {
+        status = code;
+      },
+      json: (value) => {
+        body = value;
+      },
     });
-
-    const isDelete = event === 'entry.delete';
-    let deletedFiles: string[] = [];
-
-    if (model === 'article') {
-      deletedFiles = invalidateArticleCache(entry?.slug);
-      console.log(`[Webhook] Cleared ${deletedFiles.length} article cache files:`, deletedFiles);
-      void warmArticleCache(entry?.slug, isDelete);
-    } else if (model === 'author') {
-      deletedFiles = invalidateAuthorCache();
-      console.log(`[Webhook] Cleared ${deletedFiles.length} author cache files:`, deletedFiles);
-      void warmAuthorCache();
-    } else if (model === 'roadmap') {
-      deletedFiles = invalidateRoadmapCache();
-      console.log(`[Webhook] Cleared ${deletedFiles.length} roadmap cache files:`, deletedFiles);
-      void warmRoadmapCache();
-    } else {
-      console.warn(`[Webhook] Unknown model: ${model}`);
-    }
-
-    return new Response(
-      JSON.stringify({
-        success: true,
-        message: 'Cache cleared and refresh triggered',
-        details: {
-          event,
-          model,
-          entryId: entry?.id,
-          slug: entry?.slug,
-          deletedFiles,
-          duration: `${Date.now() - startTime}ms`,
-        },
-      }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } }
-    );
   } catch (err) {
-    console.error('[Webhook] Unexpected error:', err);
-    return new Response(JSON.stringify({ success: false, error: 'Internal server error' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    console.error('[Webhook] Unexpected error from package handler:', err);
+    status = 500;
+    body = { ok: false, error: 'Internal server error' };
   }
+
+  if (body && typeof body === 'object' && status === 200) {
+    (body as Record<string, unknown>).duration = `${Date.now() - startTime}ms`;
+  }
+
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
 };

--- a/src/pages/api/webhooks/strapi-content.ts
+++ b/src/pages/api/webhooks/strapi-content.ts
@@ -74,6 +74,17 @@ export const POST: APIRoute = async ({ request }) => {
   let status = 200;
   let body: unknown = {};
 
+  // Fail closed: the package handler skips verification entirely when no secret is
+  // configured, which would leave this cache-purge endpoint open to anyone. Reject
+  // before delegating so a missing `STRAPI_WEBHOOK_SECRET` can never disable auth.
+  if (!config.webhook?.secret) {
+    console.error('[Webhook] STRAPI_WEBHOOK_SECRET is not configured — rejecting request');
+    return new Response(JSON.stringify({ ok: false, error: 'Webhook secret not configured' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
   // Adapt Astro's `Request` to the package's lowest-common-denominator shape.
   // Fetch `Headers` doesn't have a string index signature so the package's
   // `WebhookRequest` rejects it at the type level, even though `.get()` works

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -16,7 +16,7 @@ import {
   getStrapiMediaUrl,
   resolveMarkdownStrapiUrls,
   fetchStrapiArticles,
-  fetchStrapiArticleBySlug,
+  ensureStrapiArticleDetail,
 } from '@libs/strapi';
 import type { StrapiArticle, StrapiBlock } from '@libs/strapi';
 import { formatShortDate, estimateReadingTime } from '@utils/dateUtils';
@@ -58,7 +58,7 @@ if (isPageNumber) {
 }
 
 // Article rendering (only when not a pagination page)
-const article = !isPageNumber ? await fetchStrapiArticleBySlug(slug as string) : null;
+const article = !isPageNumber ? await ensureStrapiArticleDetail(slug as string) : null;
 if (!isPageNumber && !article) {
   return Astro.redirect('/404');
 }

--- a/src/pages/blog/[slug].md.ts
+++ b/src/pages/blog/[slug].md.ts
@@ -6,7 +6,7 @@
 export const prerender = false;
 
 import type { APIRoute } from 'astro';
-import { fetchStrapiArticleBySlug } from '@libs/strapi';
+import { ensureStrapiArticleDetail } from '@libs/strapi';
 
 export const GET: APIRoute = async ({ params }) => {
   const slug = params.slug;
@@ -20,7 +20,7 @@ export const GET: APIRoute = async ({ params }) => {
   }
 
   try {
-    const article = await fetchStrapiArticleBySlug(slug);
+    const article = await ensureStrapiArticleDetail(slug);
     if (!article) {
       return new Response('Not found', { status: 404 });
     }

--- a/src/v1/styles/components-modal.css
+++ b/src/v1/styles/components-modal.css
@@ -64,7 +64,7 @@
   }
 
   .media-lightbox-caption {
-    @apply datum-text-sm text-midnight-fjord/60 text-center;
+    @apply datum-text-sm text-midnight-fjord/60 pt-2 text-center;
   }
 
   /* Clickable content/featured images that open the lightbox */


### PR DESCRIPTION
## Summary

Move datum.net's Strapi caching layer onto the published [`@datum-cloud/strapi-revalidate@0.1.1`](https://www.npmjs.com/package/@datum-cloud/strapi-revalidate) package. The package owns the GraphQL client, the tag-aware filesystem cache manager, and the inbound webhook handler. Datum-specific transforms — article block stripping + top-3 cover preservation + reading-time calculation, author team sorting + card-category normalization, bg-color helpers — stay in `src/libs/strapi/` alongside thin fetchers that call into the shared client/cache from `src/libs/strapi/_runtime.ts`.

Net code change: **−460 LOC** (476 inserted, 936 deleted).

## What moved where

| Concern                          | Before                                                            | After                                                                                                |
| -------------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| GraphQL transport                | 3× inline `graphqlQuery()` copies in articles/authors/roadmaps    | Package `GraphQLStrapiClient` via shared `client` in `_runtime.ts`                                   |
| Filesystem cache                 | `new Cache('.cache')` + `new Cache('.cache/strapi-fallback')`     | Package `CacheManager` (tag-aware, dual-driver) via shared `cache` in `_runtime.ts`                  |
| Webhook auth + payload parsing   | Inline secret check + file-pattern deletion + manual cache warm   | Package `createWebhookHandler` with `onRevalidate` callback driving the warm                         |
| Per-event cache invalidation     | File-prefix deletion across primary and fallback dirs             | Tag invalidation (`cache.invalidate('articles')` etc.); fallback intentionally preserved             |

## What intentionally did **not** change

- **`src/libs/cache.ts`** stays in place — non-Strapi consumers (`src/libs/datum.ts`, `src/components/GithubStargazerValue.astro`) still use it for Luma / Stargazer caches.
- **`/api/cache/*` admin endpoints** still verify `X-Webhook-Secret` via `src/libs/cacheApiAuth.ts`. Only the inbound `/api/webhooks/strapi-content` endpoint switched header conventions.
- **Cache file layout on disk** is byte-compatible for primary entries (same key names, same `.json` + `.expires` files); the package also writes a new `.tags` sidecar per primary entry for tag-based invalidation.

## ⚠️ Operational follow-up before merging

1. **Reconfigure the Strapi Cloud webhook** to send the secret as `Authorization: Bearer <STRAPI_WEBHOOK_SECRET>` (or `strapi-webhook-secret: <…>`). The package handler does not accept the legacy `X-Webhook-Secret` header that the previous in-repo handler used. Without this change, every Strapi publish event will return **401**.

2. **Legacy fallback files** at `.cache/strapi-fallback/articles.json`, `article-<slug>.json`, `roadmaps.json` etc. are now orphaned. The new layout mirrors fallback under the same key as primary (e.g. `strapi-articles.json`). Old files are harmless; delete them at your leisure after the first successful refetch under the new layout.

## Upstream prerequisite

Package `0.1.0` shipped with a zod-v3-only `z.function().args().returns()` chain in its config schema, which fails under zod v4 (Astro 6's top-level resolution). Fixed in [strapi-revalidate#5](https://github.com/datum-cloud/strapi-revalidate/pull/5), shipped as `0.1.1`. This PR pins to `^0.1.1`.

## Verification

- [x] `npm run typecheck` — 0 errors / 0 warnings (238 files)
- [x] `npm run lint` — clean
- [x] `npm run build` — full production build succeeds end-to-end (rss.xml prerender no longer crashes with `z.function(...).args is not a function`)
- [ ] Smoke test the live webhook in dev:

  ```bash
  npm run dev  # terminal A
  # terminal B — replace SECRET with your STRAPI_WEBHOOK_SECRET
  curl -sS -X POST http://localhost:4321/api/webhooks/strapi-content \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $SECRET" \
    -d '{
      "event": "entry.update",
      "createdAt": "2026-06-04T00:00:00.000Z",
      "model": "article",
      "uid": "api::article.article",
      "entry": { "id": 1, "documentId": "abc123", "slug": "hello-world" }
    }' | jq
  # Expected: { "ok": true, "tags": ["articles", "article:hello-world"], "duration": "...ms" }
  ```

- [ ] After merge, reconfigure the Strapi Cloud webhook header (see above).
- [ ] After merge, optionally `rm .cache/strapi-fallback/{articles,article-*,roadmaps}.json` to clean up the legacy fallback files.

## Commits

1. **`refactor(strapi): adopt @datum-cloud/strapi-revalidate@0.1.1`** — all code changes (runtime wrapper + 4 fetcher rewrites + webhook swap).
2. **`docs(strapi): document package adoption + new fallback semantics`** — README, `docs/STRAPI_CACHE_API.md`, `.env.example`.
