### PR TITLE
ci: skip seo-review for bot-authored PRs

### DIFF
--- a/.github/workflows/seo-review.yml
+++ b/.github/workflows/seo-review.yml
@@ -32,6 +32,9 @@ permissions:
 jobs:
   seo-review:
     name: SEO & Meta Review
+    # Skip for bot-authored PRs (renovate, dependabot, etc.); scheduled and
+    # manual runs always proceed.
+    if: github.event_name != 'pull_request' || github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     env:
       NODE_ENV: development


### PR DESCRIPTION
## Summary

Bot-authored PRs (renovate, dependabot, etc.) no longer trigger the **SEO Review** workflow. Scheduled (weekly audit) and manual (`workflow_dispatch`) runs are unaffected.

## Change

Added a job-level `if` condition to `.github/workflows/seo-review.yml`:

```yaml
if: github.event_name != 'pull_request' || github.event.pull_request.user.type != 'Bot'
```

- PR from a bot → `user.type == 'Bot'` → job skipped
- PR from a human → runs as before
- `schedule` / `workflow_dispatch` → always run

## Notes

Used `user.type != 'Bot'` rather than hardcoding `renovate`/`dependabot` logins so any GitHub App bot is covered without maintaining a name list.

## Test plan

- [ ] Open a renovate/dependabot PR → SEO Review job is skipped
- [ ] Open a human PR → SEO Review job runs
- [ ] Weekly scheduled audit still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)