### PR TITLE
fix(seo): apply 2026-06-08 audit fixes and restore MDX table rendering

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -86,6 +86,8 @@ export default defineConfig({
     mode: 'middleware',
   }),
   markdown: {
+    gfm: true,
+    smartypants: true,
     remarkPlugins: [remarkModifiedTime],
     // Astro runs Shiki before user `rehypePlugins` on MDX; that emits `astro-code` and prevents
     // expressive-code from taking over. Disable built-in highlighting so fenced blocks stay

--- a/src/content/handbook/about/purpose.md
+++ b/src/content/handbook/about/purpose.md
@@ -6,7 +6,7 @@ sidebar:
 updatedDate: Nov 13, 2025
 authors: jacob
 meta:
-  title: "Datum's Purpose - Upgrading the Internet for AI - Datum Handbook"
+  title: "Datum's Purpose - Upgrading the Internet for AI"
   description: "Why we build. Datum's mission is to democratize access to internet superpowers—like global backbones and authoritative DNS—so you can build without barriers."
   og:
     title: "Datum's purpose"

--- a/src/content/handbook/about/strategy.md
+++ b/src/content/handbook/about/strategy.md
@@ -7,7 +7,7 @@ updatedDate: Nov 13, 2025
 authors: jacob
 meta:
   title: "Datum Corporate Strategy - Open Source & Neutrality"
-  description: "Read about Datum's strategic vision. We combine a commercial open source (COSS) model with a neutral, federated architecture to empower the next generation of clouds."
+  description: "Datum's strategic vision: a commercial open source (COSS) model with neutral, federated architecture to empower the next generation of clouds."
   og:
     title: "Our strategy"
 ---

--- a/src/content/handbook/about/trends.md
+++ b/src/content/handbook/about/trends.md
@@ -7,7 +7,7 @@ updatedDate: Nov 13, 2025
 authors: jacob
 meta:
   title: "Trends in Cloud Infrastructure - Datum Handbook"
-  description: "A shift to AI native is changing infrastructure. Read about the explosion of specialized AI services and alt clouds that informs Datum's approach and founding principles"
+  description: "A shift to AI-native is changing infrastructure. Read about the explosion of specialized AI services and alt clouds that inform Datum's founding principles."
   og:
       title: Trends in Cloud Infrastructure
       description: "3 Trends that are shaping the way we work at Datum"

--- a/src/content/handbook/eos/1-year-plan.md
+++ b/src/content/handbook/eos/1-year-plan.md
@@ -7,7 +7,7 @@ updatedDate: Jan 21, 2026
 authors: jacob
 meta:
   title: "1 Year Plan - Datum Handbook"
-  description: "Learn about Datum's 1-year plan broken down by measurable revenue, organizations on the Datum Cloud platform, Builders on the Datum Cloud Platform and active ecosystem connections."
+  description: "Datum's 1-year plan: measurable revenue targets, organizations and builders on the Datum Cloud Platform, and active ecosystem connections."
   og:
     title: "1 Year Plan"
 ---

--- a/src/content/handbook/eos/quarterly-conversations.md
+++ b/src/content/handbook/eos/quarterly-conversations.md
@@ -7,7 +7,7 @@ updatedDate: Jan 23, 2026
 authors: jacob
 meta:
   title: "Quarterly Conversations - Datum Handbook"
-  description: "Datum prioritizes growth and development. This is how we guide meanintful quarterly conversations to encourage open communication and enable growth."
+  description: "Datum prioritizes growth and development. This is how we guide meaningful quarterly conversations to encourage open communication and enable growth."
   og:
     title: "Quarterly Conversations"
 ---

--- a/src/content/handbook/operate/using-github.md
+++ b/src/content/handbook/operate/using-github.md
@@ -7,7 +7,7 @@ updatedDate: Jan 21, 2026
 authors: jacob
 meta:
   title: "How we operate - Datum Handbook"
-  description: "GitHub is a critical piece of infrastructure and a daiily working environment for everyone at Datum; we organize our work in releases, ehnhancements and issues."
+  description: "GitHub is a critical piece of infrastructure and a daily working environment for everyone at Datum; we organize our work in releases, enhancements and issues."
   og:
     title: "Using GitHub"
 ---

--- a/src/content/handbook/policy/data-retention.md
+++ b/src/content/handbook/policy/data-retention.md
@@ -6,7 +6,7 @@ sidebar:
 updatedDate: Nov 13, 2025
 authors: jacob
 meta:
-  title: "Data Retention Policy - Compliance & Schedules - Datum Handbook"
+  title: "Data Retention Policy - Compliance & Schedules"
   description: "How we manage data longevity. Guidelines on the storage, archiving, and secure destruction of data throughout its lifecycle on the Datum platform."
   og:
     title: "Data retention and deletion policy"

--- a/src/content/handbook/policy/disaster-recovery.md
+++ b/src/content/handbook/policy/disaster-recovery.md
@@ -9,7 +9,7 @@ meta:
   title: "Datum Disaster Recovery RTO & RPO Standards - Datum Handbook"
   description: "Learn about Datum's DR strategies: failover testing, backup restoration, and resilience standards to maintain platform availability."
   og:
-    title: "Disaster recovery policy"
+    title: "Datum Disaster Recovery Policy — RTO, RPO & Failover Standards"
 ---
 
 Datum’s customers are dependent on our services operating as expected. Proper planning, monitoring, and recovery steps are critical to address incidents that may impact the integrity or availability of services and data is critical to the operation of Datum. Disaster Recovery is a set of processes and techniques used to help an organization like ours recover from a disaster and resume routine business operations.

--- a/src/content/legal/aup.mdx
+++ b/src/content/legal/aup.mdx
@@ -13,8 +13,6 @@ import Container from '@components/Container.astro';
 
 <Container tag="article" class="datum-prose-article max-w-4xl pb-1 flow-root *:first:mt-0">
 
-## Acceptable Use Policy
-
 <small class="mb-8 block italic">Last Updated: Mar 9, 2026</small>
 
 This Acceptable Use Policy ("AUP") describes rules that apply to any party ("you", "your", "yours", or "Customer") using any products and services provided by Datum Technology, Inc or any of its affiliates ("Services") and any user of the Services, including via any products and services provided by Customer ("End User"). Datum Technology, Inc together with its affiliates will be referred to as "Datum" in this AUP. The prohibited conduct in this AUP is not exhaustive. Customer is responsible for its End Users' compliance with this AUP. If Customer or any End User violates this AUP, Datum may suspend or terminate Customer's use of the Services. This AUP may be updated by Datum from time to time upon reasonable notice, which may be provided via Customer's account, e-mail, or by posting an updated version of this AUP at [datum.net/legal/aup](https://www.datum.net/legal/aup/).

--- a/src/content/legal/privacy.mdx
+++ b/src/content/legal/privacy.mdx
@@ -12,8 +12,6 @@ import Container from '@components/Container.astro';
 
 <Container tag="article" class="datum-prose-article max-w-4xl pb-1 flow-root *:first:mt-0">
 
-## Privacy Policy
-
 <small class="mb-8 block italic">Effective as of December 1, 2024</small>
 
 This Privacy Policy describes how Datum Technology, Inc. ("**Datum**," "**we**", "**us**" or "**our**") handles personal information that we collect through our website and other digital properties that link to this Privacy Policy (collectively, the "**Service**"), as well as through social media, our marketing activities, and other activities described in this Privacy Policy.

--- a/src/content/legal/service-country-specific-terms.mdx
+++ b/src/content/legal/service-country-specific-terms.mdx
@@ -13,8 +13,6 @@ import Container from '@components/Container.astro';
 
 <Container tag="article" class="datum-prose-article max-w-4xl pb-1 flow-root *:first:mt-0">
 
-## Service Country Specific Terms
-
 This page will contain additional requirements that apply to specific Datum services, third-party products and services made available through the Datum platform, and country-specific regulatory requirements. As Datum's platform and service offerings expand, applicable terms will be published here. For questions in the meantime, please contact [support@datum.net](mailto:support@datum.net).
 
 </Container>

--- a/src/content/legal/subprocessors.mdx
+++ b/src/content/legal/subprocessors.mdx
@@ -17,8 +17,6 @@ import Container from '@components/Container.astro';
 
 <small class="mb-8 block italic">Last Updated: April 2026</small>
 
-<div class="legal-table-wrap">
-
 | Sub-Processor | Purpose | Location |
 | :--- | :--- | :--- |
 | Anthropic | Machine learning | USA |
@@ -27,7 +25,5 @@ import Container from '@components/Container.astro';
 | Helpscout | User support | USA |
 | Loops.so | Marketing outreach | USA |
 | Resend | Automated product messaging | USA |
-
-</div>
 
 </Container>

--- a/src/content/legal/terms.mdx
+++ b/src/content/legal/terms.mdx
@@ -6,7 +6,7 @@ meta:
   title: "General Terms & Conditions - Datum User Agreement"
   description: "Read the Datum Terms of Service. The legal agreement governing your access to and use of our open network cloud, including account responsibilities and acceptable use."
   og:
-    title: "Datum Terms of Service: Network Infrastructure Services & Alternative Cloud Agreement"
+    title: "Datum Terms of Service — Network Infrastructure Agreement"
 ---
 import Container from '@components/Container.astro';
 

--- a/src/content/pages/brand/imagery.mdx
+++ b/src/content/pages/brand/imagery.mdx
@@ -2,7 +2,7 @@
 title: "The Datum illustrations"
 meta:
   title: "Datum Illustration Suite: Milo, The Team & Brand Imagery"
-  description: "Explore Datum's Illustration Suite and design guidelines for the full visual brand universe."
+  description: "Explore Datum's Illustration Suite, including Milo character art, imagery, and design guidelines that define the Datum visual brand universe."
   og:
     title: "The Datum illustrations"
     image: "../../images/og/brand.png"

--- a/src/content/pages/brand/index.mdx
+++ b/src/content/pages/brand/index.mdx
@@ -6,7 +6,7 @@ description: "Resources rooted in our brand foundation that reflect and amplify 
 slug: "brand"
 meta:
   title: "Datum Brand Assets: Logos, Guidelines & Identity"
-  description: "Explore the Datum brand design system, including design principles, typography, color palettes, logos, and illustration suite, built for a hyperscale-ready framework."
+  description: "Explore the Datum brand design system: design principles, typography, color palettes, logos, and illustration suite for a hyperscale-ready framework."
   og:
     title: Our visual identity
     description: Explore the Datum brand design system

--- a/src/content/pages/brand/typography.mdx
+++ b/src/content/pages/brand/typography.mdx
@@ -2,7 +2,7 @@
 title: "Typography"
 meta:
   title: "Datum Design: Brand Typography & Typefaces"
-  description: "Review Datum's official brand design assets, featuring our core typefaces, Canela and Alliance No.1. which reflects our unique ethos as an open, global tech company."
+  description: "Review Datum's official brand typography: core typefaces Canela and Alliance No.1, reflecting our ethos as an open, global tech company."
   og:
     title: "Datum Brand Typography"
     image: "../../images/og/brand.png"

--- a/src/content/pages/essentials.mdx
+++ b/src/content/pages/essentials.mdx
@@ -2,11 +2,11 @@
 title: Batteries included
 description: "We think core cloud features are essential, not optional."
 meta:
-  title: "Datum Essentials"
+  title: "Datum Essentials — Free Enterprise Networking Primitives"
   description: "Enterprise-grade networking primitives like Authoritative DNS, Domains, Metrics Export, RBAC, SSO and audit logs for free."
   og:
     title: "Access enterprise-grade networking foundations at zero cost"
-    description: "Enterprise-grade networking primitives."
+    description: "Enterprise-grade networking primitives like Authoritative DNS, Domains, Metrics Export, RBAC, SSO and audit logs — free to use."
 ---
 
 ## Datum is currently in a closed beta.

--- a/src/content/pages/features.mdx
+++ b/src/content/pages/features.mdx
@@ -18,7 +18,7 @@ sections:
 
 meta:
   title: "Datum Features - Critical Network Infrastructure"
-  description: "Critical network infrastructure built for agents with Zero Trust architecture. Featuring AI Edge with built-in Coraza WAF, a distributed proxy powered by Envoy, and global Tunnel connectivity powered by QUIC."
+  description: "Critical network infrastructure for agents — Zero Trust architecture, AI Edge with Coraza WAF, distributed Envoy proxy, and QUIC-powered global tunnels."
   og:
     title: "Datum Cloud Networking Features"
     description: "Secure your infrastructure and accelerate workloads - no network team required"

--- a/src/content/pages/resources/open-source.mdx
+++ b/src/content/pages/resources/open-source.mdx
@@ -5,7 +5,7 @@ iconName: code
 description: "Datum is an open source company, and we believe the best software is built in the open. In addition to the core projects that we lead and maintain, we lean into open source projects and companies wherever possible."
 slug: "open-source"
 meta:
-    title: "Building in the Open: Datum's Commitment to Open Source Projects"
+    title: "Building in the Open: Datum's Open Source Commitment"
     description: "Learn how Datum is leveraging open-source projects including Milo, HickoryDNS, and the Envoy AI Gateway, along with technologies like Crossplane and SRv6."
     og:
       title: "Our open source commitment"

--- a/src/pages/legal/[slug].astro
+++ b/src/pages/legal/[slug].astro
@@ -48,7 +48,7 @@ const sortedLegal = [...allLegal].sort((a, b) => {
   <section class="datum-container">
     <Hero
       class="light bg-glacier-mist-800 [&_.hero--main-content-title]:max-w-none"
-      title="Privacy Policies and Security Practices"
+      title={fm.title}
     />
 
     <div class="section--block section--block--small-pad bg-glacier-mist-700">

--- a/src/v1/styles/page-legal.css
+++ b/src/v1/styles/page-legal.css
@@ -54,17 +54,9 @@
 
   .legal-content {
     @apply flex-1 p-0;
-  }
-
-  .legal-on-this-page {
-    @apply w-53.25 shrink-0 self-stretch;
-  }
-
-  .legal-table-wrap {
-    @apply my-6 w-full overflow-x-auto;
 
     table {
-      @apply w-full border-separate;
+      @apply my-6 w-full border-separate;
       @apply bg-glacier-mist-900;
       border-spacing: 1px;
     }
@@ -85,5 +77,9 @@
     tbody tr:hover td {
       @apply bg-glacier-mist-800;
     }
+  }
+
+  .legal-on-this-page {
+    @apply w-53.25 shrink-0 self-stretch;
   }
 }


### PR DESCRIPTION
## Summary

Resolves the findings in the [2026-06-08 SEO audit](https://github.com/datum-cloud/datum.net/issues/1387) (score 99/100, 8 description issues + shared H1 mismatch on legal). While verifying the legal layout fix, also caught and fixed an unrelated MDX rendering bug that was silently breaking every markdown table in `.mdx` files (legal/subprocessors, the FAQ on `/essentials`).

Three semantic commits:

- **`fix(seo): apply 2026-06-08 audit fixes`** — content metadata only. Trim 4 titles >60 chars, trim 6 descriptions >160 chars, expand 2 thin descriptions, fix 3 indexed typos (`daiily`, `ehnhancements`, `meanintful`), shorten `/legal/terms` og:title (85→57), expand `/handbook/policy/disaster-recovery` og:title.
- **`fix(legal): drive H1 from per-page frontmatter`** — `src/pages/legal/[slug].astro` now reads `title={fm.title}` instead of the hardcoded `"Privacy Policies and Security Practices"`. The 4 legal pages flagged by the audit now ship the correct `<h1>` (Acceptable Use Policy / Sub-Processors / Service Country Specific Terms / Terms of Service). Drops the now-redundant in-body H2 from `aup.mdx`, `privacy.mdx`, `service-country-specific-terms.mdx`.
- **`fix(mdx): enable gfm so markdown tables render in .mdx`** — root cause: the custom `markdown` config in `astro.config.mjs` overrode Astro's defaults without setting `gfm` or `smartypants`. `@astrojs/mdx` inherits that config into its own defaults; since `gfm` was undefined, `remark-gfm` was never registered for MDX and tables rendered as one `<p>` of raw pipes. Re-asserts `gfm: true` and `smartypants: true`. Side benefit: the FAQ table on `/essentials` (and any other markdown table inside an `.mdx` file) now renders correctly too. Also drops the unnecessary `<div class="legal-table-wrap">` wrapper on subprocessors and rescopes its CSS onto `.legal-content table`.

## Verified

Built with `npm run build` and grepped the output:

- Every legal page now contains `<h1>…</h1>` matching its own subject (no more shared "Privacy Policies and Security Practices").
- All audited titles are ≤60 chars and descriptions are within 70–160 chars (`/brand`: 149, `/brand/typography`: 136, `/brand/imagery`: 146, `/features`: 152, `/essentials`: 122, `/handbook/about/purpose`: 157, `/handbook/about/strategy`: 142, `/handbook/about/trends`: 156, `/handbook/eos/1-year-plan`: 138, `/handbook/operate/using-github`: 158, `/handbook/eos/quarterly-conversations`: 148, `/handbook/policy/data-retention`: 146, `/handbook/policy/disaster-recovery`: 132, `/open-source`: 154).
- `/legal/subprocessors` now emits a proper `<table>` with `<thead>`/`<tbody>`/`<tr>`/`<th>`/`<td>` (was a single `<p>` of raw pipes).
- Indexed typos no longer present in the built HTML.

## Test plan

- [ ] `npm run build` passes (verified locally).
- [ ] Visual check `/legal/aup`, `/legal/privacy`, `/legal/subprocessors`, `/legal/terms`, `/legal/service-country-specific-terms` — each hero shows its own H1.
- [ ] Visual check `/legal/subprocessors` — table renders as a table, full width, no grey gap on the right.
- [ ] Visual check `/essentials` — FAQ "How is Datum's infrastructure structured?" table now renders.
- [ ] Visual check `/brand`, `/features`, `/handbook/about/purpose`, `/handbook/eos/quarterly-conversations`, `/handbook/operate/using-github` — content reads as expected.
- [ ] Skim Google Search Console / re-run the SEO audit to confirm the score moves above 99.
