### PR TITLE
chore(strapi): bump strapi-revalidate to 0.2.0 and remove workarounds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@astrojs/mdx": "^5.0.6",
         "@astrojs/node": "^10.1.3",
         "@astrojs/rss": "^4.0.18",
-        "@datum-cloud/strapi-revalidate": "^0.1.2",
+        "@datum-cloud/strapi-revalidate": "^0.2.0",
         "@kubernetes/client-node": "^1.4.0",
         "@lucide/astro": "^1.17.0",
         "@nanostores/persistent": "^1.3.4",
@@ -481,9 +481,9 @@
       }
     },
     "node_modules/@datum-cloud/strapi-revalidate": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@datum-cloud/strapi-revalidate/-/strapi-revalidate-0.1.2.tgz",
-      "integrity": "sha512-hFOZe11U/vve+i+EpFvijI6Qnkw9I5bDPBgPnW87wiYYPpgNcDJBf9vCiogQgBDB+mgueIq4p03v4V3XH6N/Iw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@datum-cloud/strapi-revalidate/-/strapi-revalidate-0.2.0.tgz",
+      "integrity": "sha512-3SUHeGtZBSK4qBlLM0oyg4FkjBCs7fbgDv3YBg6BmAdL0/SGD98L/giJwbR1xZb9rA4zHwxG5c5zYqkJkjvz9A==",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.23.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@astrojs/mdx": "^5.0.6",
     "@astrojs/node": "^10.1.3",
     "@astrojs/rss": "^4.0.18",
-    "@datum-cloud/strapi-revalidate": "^0.1.2",
+    "@datum-cloud/strapi-revalidate": "^0.2.0",
     "@kubernetes/client-node": "^1.4.0",
     "@lucide/astro": "^1.17.0",
     "@nanostores/persistent": "^1.3.4",

--- a/src/libs/strapi/_runtime.ts
+++ b/src/libs/strapi/_runtime.ts
@@ -45,15 +45,9 @@ function readSeconds(name: string, fallback: number): number {
 }
 
 const url = readEnv('STRAPI_URL') ?? DEFAULT_STRAPI_URL;
-// The package's zod schema requires a non-empty token. Fresh-clone builds without
-// secrets fall back to stale cache anyway, so a placeholder keeps init succeeding
-// — Strapi simply 401s and we serve from `.cache/strapi-fallback/`.
-const token = readEnv('STRAPI_TOKEN') ?? 'placeholder-no-token';
-
-/** True only when a real STRAPI_TOKEN is configured. */
-export const hasStrapiToken = !!readEnv('STRAPI_TOKEN');
-/** Full GraphQL endpoint URL, pre-built so fetchers don't repeat the string math. */
-export const STRAPI_GRAPHQL_URL = `${url.replace(/\/$/, '')}/graphql`;
+// Token is optional in 0.2.0+: omitting it skips the Authorization header,
+// allowing unauthenticated requests to publicly-readable Strapi endpoints.
+const token = readEnv('STRAPI_TOKEN');
 const debug = readEnv('STRAPI_DEBUG') === 'true' || readEnv('STRAPI_DEBUG') === '1';
 
 const strapiRevalidate = createStrapiRevalidate({

--- a/src/libs/strapi/authors.ts
+++ b/src/libs/strapi/authors.ts
@@ -15,7 +15,7 @@
  * All entries are tagged `authors`, so one webhook clears every derived view.
  */
 
-import { cache, client, hasStrapiToken, STRAPI_GRAPHQL_URL } from './_runtime';
+import { cache, client } from './_runtime';
 import type { CardCategory, StrapiAuthorsResponse, StrapiAuthorFull } from '../../types/strapi';
 
 const AUTHORS_CACHE_KEY = 'strapi-authors';
@@ -217,52 +217,29 @@ function sortStrapiTeamMembers(a: StrapiAuthorFull, b: StrapiAuthorFull): number
   return getFirstName(a.name).localeCompare(getFirstName(b.name));
 }
 
-/**
- * Execute a GraphQL query against Strapi. When no real token is configured
- * the package client sends a placeholder that triggers a 401, so we fall back
- * to an unauthenticated request (works for publicly-readable Strapi content).
- */
-async function strapiQuery<T>(
-  query: string,
-  variables?: Record<string, unknown>
-): Promise<T | null> {
-  const result = await client.query<T>(query, variables);
-  if (result !== null || hasStrapiToken) return result;
-
-  try {
-    const res = await fetch(STRAPI_GRAPHQL_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query, variables }),
-    });
-    if (!res.ok) return null;
-    const json = (await res.json()) as { data?: T };
-    return json.data ?? null;
-  } catch {
-    return null;
-  }
-}
-
 export async function fetchStrapiAuthors(): Promise<StrapiAuthorFull[]> {
   const cached = await cache.get<StrapiAuthorFull[]>(AUTHORS_CACHE_KEY);
-  if (cached && isValidCachedAuthors(cached)) return cached;
   if (cached) {
-    console.warn('Invalid cached Strapi authors data detected, fetching fresh data from API');
+    if (isValidCachedAuthors(cached)) return cached;
+    console.warn('Invalid cached Strapi authors data detected, clearing and refetching');
+    await cache.delete(AUTHORS_CACHE_KEY);
   }
 
-  const response = await strapiQuery<StrapiAuthorsResponse>(AUTHORS_QUERY);
-  if (!response?.authors) {
-    console.warn('No authors returned from Strapi API, trying fallback cache');
-    const fallback = await cache.getFallback<StrapiAuthorFull[]>(AUTHORS_CACHE_KEY);
-    if (fallback && isValidCachedAuthors(fallback)) return fallback;
-    return [];
-  }
+  const result = await cache.getWithFallback<StrapiAuthorFull[]>(
+    AUTHORS_CACHE_KEY,
+    async () => {
+      const response = await client.query<StrapiAuthorsResponse>(AUTHORS_QUERY);
+      if (!response?.authors) {
+        console.warn('No authors returned from Strapi API');
+        return null;
+      }
+      const authors = response.authors.map(normalizeAuthorFromGraphQL);
+      return authors.length > 0 ? authors : null;
+    },
+    { tags: ['authors'] }
+  );
 
-  const authors = response.authors.map(normalizeAuthorFromGraphQL);
-  if (authors.length > 0) {
-    await cache.set(AUTHORS_CACHE_KEY, authors, { tags: ['authors'] });
-  }
-  return authors;
+  return result ?? [];
 }
 
 /**
@@ -281,19 +258,21 @@ export async function fetchStrapiAuthorBySlug(slug: string): Promise<StrapiAutho
   const cacheKey = `${AUTHOR_SLUG_CACHE_PREFIX}${slug}`;
 
   const cached = await cache.get<StrapiAuthorFull>(cacheKey);
-  if (cached && isValidStrapiAuthor(cached)) return cached;
   if (cached) {
-    console.warn(
-      `Invalid cached Strapi author data detected for slug "${slug}", fetching fresh data from API`
-    );
+    if (isValidStrapiAuthor(cached)) return cached;
+    console.warn(`Invalid cached Strapi author data for slug "${slug}", clearing and refetching`);
+    await cache.delete(cacheKey);
   }
 
-  const response = await strapiQuery<StrapiAuthorsResponse>(AUTHOR_BY_SLUG_QUERY, { slug });
-  if (!response?.authors || response.authors.length === 0) return null;
-
-  const author = normalizeAuthorFromGraphQL(response.authors[0]);
-  await cache.set(cacheKey, author, { tags: ['authors', `author:${slug}`] });
-  return author;
+  return cache.getWithFallback<StrapiAuthorFull>(
+    cacheKey,
+    async () => {
+      const response = await client.query<StrapiAuthorsResponse>(AUTHOR_BY_SLUG_QUERY, { slug });
+      if (!response?.authors?.length) return null;
+      return normalizeAuthorFromGraphQL(response.authors[0]);
+    },
+    { tags: ['authors', `author:${slug}`] }
+  );
 }
 
 /**
@@ -303,20 +282,24 @@ export async function fetchStrapiAuthorBySlug(slug: string): Promise<StrapiAutho
  */
 export async function getStrapiTeamMembers(): Promise<StrapiAuthorFull[]> {
   const cached = await cache.get<StrapiAuthorFull[]>(TEAM_MEMBERS_CACHE_KEY);
-  if (cached && isValidCachedAuthors(cached)) return cached;
   if (cached) {
-    console.warn('Invalid cached Strapi team members data detected, fetching fresh data');
+    if (isValidCachedAuthors(cached)) return cached;
+    await cache.delete(TEAM_MEMBERS_CACHE_KEY);
   }
 
-  const authors = await fetchStrapiAuthors();
-  const teamMembers = authors
-    .filter((author) => author.isTeam === true)
-    .sort(sortStrapiTeamMembers);
+  const result = await cache.getWithFallback<StrapiAuthorFull[]>(
+    TEAM_MEMBERS_CACHE_KEY,
+    async () => {
+      const authors = await fetchStrapiAuthors();
+      const teamMembers = authors
+        .filter((author) => author.isTeam === true)
+        .sort(sortStrapiTeamMembers);
+      return teamMembers.length > 0 ? teamMembers : null;
+    },
+    { tags: ['authors'] }
+  );
 
-  if (teamMembers.length > 0) {
-    await cache.set(TEAM_MEMBERS_CACHE_KEY, teamMembers, { tags: ['authors'] });
-  }
-  return teamMembers;
+  return result ?? [];
 }
 
 /**
@@ -325,20 +308,24 @@ export async function getStrapiTeamMembers(): Promise<StrapiAuthorFull[]> {
  */
 export async function getStrapiCardMembers(): Promise<StrapiAuthorFull[]> {
   const cached = await cache.get<StrapiAuthorFull[]>(CARD_MEMBERS_CACHE_KEY);
-  if (cached && isValidCachedAuthors(cached)) return cached;
   if (cached) {
-    console.warn('Invalid cached Strapi card members data detected, fetching fresh data');
+    if (isValidCachedAuthors(cached)) return cached;
+    await cache.delete(CARD_MEMBERS_CACHE_KEY);
   }
 
-  const authors = await fetchStrapiAuthors();
-  const cardMembers = authors
-    .filter((author) => author.isCard === true)
-    .sort(sortStrapiTeamMembers);
+  const result = await cache.getWithFallback<StrapiAuthorFull[]>(
+    CARD_MEMBERS_CACHE_KEY,
+    async () => {
+      const authors = await fetchStrapiAuthors();
+      const cardMembers = authors
+        .filter((author) => author.isCard === true)
+        .sort(sortStrapiTeamMembers);
+      return cardMembers.length > 0 ? cardMembers : null;
+    },
+    { tags: ['authors'] }
+  );
 
-  if (cardMembers.length > 0) {
-    await cache.set(CARD_MEMBERS_CACHE_KEY, cardMembers, { tags: ['authors'] });
-  }
-  return cardMembers;
+  return result ?? [];
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #1394 now that `@datum-cloud/strapi-revalidate@0.2.0` is published.

The previous fix added workarounds directly in datum.net because the package had two gaps. Those gaps are now closed upstream, so the workarounds can be removed.

**Removed from `_runtime.ts`**
- `hasStrapiToken` export — no longer needed
- `STRAPI_GRAPHQL_URL` export — no longer needed
- `placeholder-no-token` fallback — token is now optional in the package; omitting it skips the `Authorization` header rather than sending a value Strapi rejects with 401

**Removed from `authors.ts`**
- `strapiQuery` helper — the package client now handles the no-token case correctly
- Manual `cache.get → fetch → cache.getFallback` chains replaced with `cache.getWithFallback()`
- Invalid cache entries (e.g. stale `[]`) are deleted before `getWithFallback` so the fetcher is always invoked on a corrupt entry

## Test plan

- [ ] `/about` shows team members locally (no `STRAPI_TOKEN` set)
- [ ] `/about` shows team members in staging
- [ ] No TypeScript errors (`npx tsc --noEmit`)
