### PR TITLE
fix(events): replace Zoom meeting URLs with Luma and remove Zoom link CTA

### DIFF
--- a/src/components/events/EventCalendarSection.astro
+++ b/src/components/events/EventCalendarSection.astro
@@ -449,15 +449,6 @@ const eventsJson = JSON.stringify(eventsData);
                       d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path></svg
                   >
                 </a>
-
-                <template x-if="event.zoom_meeting_url">
-                  <a
-                    x-bind:href="event.zoom_meeting_url"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="event-calendar-list__zoom-link">Zoom link</a
-                  >
-                </template>
               </div>
             </div>
           </template>

--- a/src/components/events/EventSeriesCard.astro
+++ b/src/components/events/EventSeriesCard.astro
@@ -245,17 +245,6 @@ const timezoneAbbr = event.timezone
             Register
             <Icon name="external-link" size="sm" class="ml-1" />
           </a>
-
-          {event.zoom_meeting_url && (
-            <a
-              href={event.zoom_meeting_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="event-series-card__zoom-link"
-            >
-              Zoom link
-            </a>
-          )}
         </div>
       </div>
     </article>

--- a/src/content/events/02-2026-february-datum-monthly-community-huddle/index.mdx
+++ b/src/content/events/02-2026-february-datum-monthly-community-huddle/index.mdx
@@ -7,8 +7,8 @@ timezone: America/New_York
 url: "https://luma.com/dhsayj2y"
 eventType: community-huddle
 coverImage: ./cover.png
-meetingUrl: "https://us06web.zoom.us/j/82253289187?pwd=HvB2ZgSeIXofKW2pbheYCYFclvnu5b.1"
-zoomMeetingUrl: "https://us06web.zoom.us/j/82253289187?pwd=HvB2ZgSeIXofKW2pbheYCYFclvnu5b.1"
+meetingUrl: "https://luma.com/dhsayj2y"
+zoomMeetingUrl: "https://luma.com/dhsayj2y"
 youtubeUrl: "https://www.youtube.com/watch?v=_QR_hfzhaAw"
 ---
 

--- a/src/content/events/03-2026-march-datum-monthly-community-huddle/index.mdx
+++ b/src/content/events/03-2026-march-datum-monthly-community-huddle/index.mdx
@@ -7,8 +7,8 @@ timezone: America/New_York
 url: "https://luma.com/wjzienjy"
 eventType: community-huddle
 coverImage: ./cover.png
-meetingUrl: "https://us06web.zoom.us/j/82253289187?pwd=HvB2ZgSeIXofKW2pbheYCYFclvnu5b.1"
-zoomMeetingUrl: "https://us06web.zoom.us/j/82253289187?pwd=HvB2ZgSeIXofKW2pbheYCYFclvnu5b.1"
+meetingUrl: "https://luma.com/wjzienjy"
+zoomMeetingUrl: "https://luma.com/wjzienjy"
 youtubeUrl: "https://www.youtube.com/watch?v=IiWFPgR2ygY"
 ---
 

--- a/src/content/events/04-2026-april-datum-monthly-community-huddle/index.mdx
+++ b/src/content/events/04-2026-april-datum-monthly-community-huddle/index.mdx
@@ -7,8 +7,8 @@ timezone: America/New_York
 url: "https://luma.com/38rq6j50"
 eventType: community-huddle
 coverImage: ./cover.png
-meetingUrl: "https://us06web.zoom.us/j/82253289187?pwd=HvB2ZgSeIXofKW2pbheYCYFclvnu5b.1"
-zoomMeetingUrl: "https://us06web.zoom.us/j/82253289187?pwd=HvB2ZgSeIXofKW2pbheYCYFclvnu5b.1"
+meetingUrl: "https://luma.com/38rq6j50"
+zoomMeetingUrl: "https://luma.com/38rq6j50"
 youtubeUrl: "https://youtu.be/ny3ptP6cink"
 ---
 

--- a/src/content/events/05-2026-may-datum-monthly-community-huddle/index.mdx
+++ b/src/content/events/05-2026-may-datum-monthly-community-huddle/index.mdx
@@ -7,8 +7,8 @@ timezone: America/New_York
 url: "https://luma.com/14yu1e9j"
 eventType: community-huddle
 coverImage: ./cover.png
-meetingUrl: "https://us06web.zoom.us/j/82253289187?pwd=HvB2ZgSeIXofKW2pbheYCYFclvnu5b.1"
-zoomMeetingUrl: "https://us06web.zoom.us/j/82253289187?pwd=HvB2ZgSeIXofKW2pbheYCYFclvnu5b.1"
+meetingUrl: "https://luma.com/14yu1e9j"
+zoomMeetingUrl: "https://luma.com/14yu1e9j"
 youtubeUrl: "https://youtu.be/WLEzo6_wWnw"
 ---
 

--- a/src/content/events/06-2026-june-datum-monthly-community-huddle/index.mdx
+++ b/src/content/events/06-2026-june-datum-monthly-community-huddle/index.mdx
@@ -7,9 +7,9 @@ timezone: America/New_York
 url: "https://luma.com/6g9xhmzx"
 eventType: community-huddle
 coverImage: ./cover.png
-meetingUrl: "https://us06web.zoom.us/j/81882732147?pwd=TOsMxTvZrJJgNjTQIucbyT8qrg1Fyd.1"
-zoomMeetingUrl: "https://us06web.zoom.us/j/81882732147?pwd=TOsMxTvZrJJgNjTQIucbyT8qrg1Fyd.1"
-youtubeUrl: "https://youtu.be/WLEzo6_wWnw"
+meetingUrl: "https://luma.com/6g9xhmzx"
+zoomMeetingUrl: "https://luma.com/6g9xhmzx"
+youtubeUrl: ""
 ---
 
 - Release 1.5 Recap (TimBL)

--- a/src/content/events/07-2026-july-datum-monthly-community-huddle/index.mdx
+++ b/src/content/events/07-2026-july-datum-monthly-community-huddle/index.mdx
@@ -7,8 +7,8 @@ timezone: America/New_York
 url: "https://luma.com/6h3txna0"
 eventType: community-huddle
 coverImage: ./cover.png
-meetingUrl: "https://us06web.zoom.us/j/81882732147?pwd=TOsMxTvZrJJgNjTQIucbyT8qrg1Fyd.1"
-zoomMeetingUrl: "https://us06web.zoom.us/j/81882732147?pwd=TOsMxTvZrJJgNjTQIucbyT8qrg1Fyd.1"
+meetingUrl: "https://luma.com/6g9xhmzx"
+zoomMeetingUrl: "https://luma.com/6g9xhmzx"
 ---
 
 * To be announced

--- a/src/content/events/08-2026-august-datum-monthly-community-huddle/index.mdx
+++ b/src/content/events/08-2026-august-datum-monthly-community-huddle/index.mdx
@@ -7,8 +7,8 @@ timezone: America/New_York
 url: "https://luma.com/ewyvgsob"
 eventType: community-huddle
 coverImage: ./cover.png
-meetingUrl: "https://us06web.zoom.us/j/81882732147?pwd=TOsMxTvZrJJgNjTQIucbyT8qrg1Fyd.1"
-zoomMeetingUrl: "https://us06web.zoom.us/j/81882732147?pwd=TOsMxTvZrJJgNjTQIucbyT8qrg1Fyd.1"
+meetingUrl: "https://luma.com/6g9xhmzx"
+zoomMeetingUrl: "https://luma.com/6g9xhmzx"
 ---
 
 * To be announced

--- a/src/content/events/09-2026-september-datum-monthly-community-huddle/index.mdx
+++ b/src/content/events/09-2026-september-datum-monthly-community-huddle/index.mdx
@@ -7,8 +7,8 @@ timezone: America/New_York
 url: "https://luma.com/l399k6qz"
 eventType: community-huddle
 coverImage: ./cover.png
-meetingUrl: "https://us06web.zoom.us/j/81882732147?pwd=TOsMxTvZrJJgNjTQIucbyT8qrg1Fyd.1"
-zoomMeetingUrl: "https://us06web.zoom.us/j/81882732147?pwd=TOsMxTvZrJJgNjTQIucbyT8qrg1Fyd.1"
+meetingUrl: "https://luma.com/6g9xhmzx"
+zoomMeetingUrl: "https://luma.com/6g9xhmzx"
 ---
 
 * To be announced

--- a/src/content/events/10-2026-october-datum-monthly-community-huddle/index.mdx
+++ b/src/content/events/10-2026-october-datum-monthly-community-huddle/index.mdx
@@ -7,8 +7,8 @@ timezone: America/New_York
 url: "https://luma.com/g5exvdit"
 eventType: community-huddle
 coverImage: ./cover.png
-meetingUrl: "https://us06web.zoom.us/j/81882732147?pwd=TOsMxTvZrJJgNjTQIucbyT8qrg1Fyd.1"
-zoomMeetingUrl: "https://us06web.zoom.us/j/81882732147?pwd=TOsMxTvZrJJgNjTQIucbyT8qrg1Fyd.1"
+meetingUrl: "https://luma.com/6g9xhmzx"
+zoomMeetingUrl: "https://luma.com/6g9xhmzx"
 ---
 
 * To be announced


### PR DESCRIPTION
## Summary

- Replace outdated Zoom meeting URLs with event-specific Luma links for Feb–Jun past community huddles
- Future events (Jul–Oct) retain a placeholder Luma link until their individual links are confirmed
- Remove the "Zoom link" button from `EventSeriesCard` and `EventCalendarSection` — the Register button on each Luma event page already provides the join link

## Test plan

- [ ] Visit `/events/community-huddles` and confirm no "Zoom link" button appears on any event card
- [ ] Confirm the "Register" button is present and links to the correct Luma page for each event
