### PR TITLE
fix(seo): expand short titles and fix description lengths across 18 pages

### DIFF
--- a/src/content/handbook/about/model.md
+++ b/src/content/handbook/about/model.md
@@ -7,7 +7,7 @@ updatedDate: Nov 13, 2025
 authors: jacob
 meta:
   title: "Our Business Model - Datum Handbook"
-  description: "Datum's economic model includes consumption-based usage of our network cloud infrastructure; we've designed our business model to align with our customer's success."
+  description: "Datum's economic model uses consumption-based usage of our network cloud infrastructure — designed to align with customer success."
   og:
     title: "How we make money"
 ---

--- a/src/content/handbook/build/Infrastructure.md
+++ b/src/content/handbook/build/Infrastructure.md
@@ -6,7 +6,7 @@ sidebar:
 updatedDate: Nov 13, 2025
 authors: jacob
 meta:
-  title: "Infrastructure - Datum Handbook"
+  title: "Global Infrastructure Footprint - Datum Handbook"
   description: "Datum is available in 17+ global locations. This article is focused on how we think about our global infrastructure footprint."
   og:
     title: "Infrastructure"

--- a/src/content/handbook/build/service-tiers.md
+++ b/src/content/handbook/build/service-tiers.md
@@ -6,7 +6,7 @@ sidebar:
 updatedDate: May 4, 2026
 authors: jacob
 meta:
-  title: "Service Tiers - Datum Handbook"
+  title: "Service Tier Classification & Reliability - Datum Handbook"
   description: "How Datum classifies services by criticality — and why that shared language matters for reliability, incident response, and engineering decisions."
   og:
     title: "Service tiers"

--- a/src/content/handbook/eos/1-year-plan.md
+++ b/src/content/handbook/eos/1-year-plan.md
@@ -6,7 +6,7 @@ sidebar:
 updatedDate: Jan 21, 2026
 authors: jacob
 meta:
-  title: "1 Year Plan - Datum Handbook"
+  title: "1-Year Revenue & Growth Plan - Datum Handbook"
   description: "Datum's 1-year plan: measurable revenue targets, organizations and builders on the Datum Cloud Platform, and active ecosystem connections."
   og:
     title: "1 Year Plan"

--- a/src/content/handbook/eos/3-year-picture.md
+++ b/src/content/handbook/eos/3-year-picture.md
@@ -6,7 +6,7 @@ sidebar:
 updatedDate: Jan 21, 2026
 authors: jacob
 meta:
-  title: "3 Year Picture - Datum Handbook"
+  title: "3-Year Company Vision & Milestones - Datum Handbook"
   description: "Datum's 3-year vision: where we aim to be as an open network cloud company and the milestones guiding our growth and strategy."
   og:
     title: "3 Year Picture"

--- a/src/content/handbook/eos/index.mdx
+++ b/src/content/handbook/eos/index.mdx
@@ -8,7 +8,7 @@ updatedDate: Jan 21, 2026
 authors: jacob
 meta:
   title: "Entrepreneurial Operating System - Datum Handbook"
-  description: "Understanding the core elements of EOS (Entrepreneurial Operating System) that inform how we work"
+  description: "Datum runs on the Entrepreneurial Operating System (EOS) — learn the core elements, from Vision/Traction Organizers to Rocks, that shape how we work and grow."
   og:
       title: 'Why we lean into the "Entrepreneurial Operating System" as a business'
       description: "Understanding the core elements of EOS (Entrepreneurial Operating System) that inform how we work"

--- a/src/content/handbook/eos/marketing-strategy.md
+++ b/src/content/handbook/eos/marketing-strategy.md
@@ -6,7 +6,7 @@ sidebar:
 updatedDate: Jan 21, 2026
 authors: jacob
 meta:
-  title: "Marketing Strategy - Datum Handbook"
+  title: "Datum GTM & Marketing Strategy - Datum Handbook"
   description: "Datum is focused on helping alternative cloud providers win with a holistic commitment to building open source and elegant product experiences"
   og:
     title: "Datum's Marketing Strategy"

--- a/src/content/handbook/eos/weekly-scorecard.md
+++ b/src/content/handbook/eos/weekly-scorecard.md
@@ -6,7 +6,7 @@ sidebar:
 updatedDate: Jan 21, 2026
 authors: jacob
 meta:
-  title: "Weekly Scorecard - Datum Handbook"
+  title: "Weekly EOS Scorecard & Team Metrics - Datum Handbook"
   description: "How Datum tracks weekly metrics using our EOS scorecard — keeping the team accountable, aligned, and focused on measurable goals."
   og:
     title: "Weekly Scorecard"

--- a/src/content/handbook/operate/how-we-hire.md
+++ b/src/content/handbook/operate/how-we-hire.md
@@ -6,7 +6,7 @@ sidebar:
 updatedDate: Feb 2, 2026
 authors: jacob
 meta:
-  title: "How we hire - Datum Careers"
+  title: "How We Hire: Interview Process & Expectations - Datum"
   description: "A guide to Datum's hiring process: from applications and interviews to offers, so you know what to expect at every stage."
   og:
       title: "How we approach hiring for open roles"

--- a/src/content/handbook/operate/purchasing.md
+++ b/src/content/handbook/operate/purchasing.md
@@ -6,7 +6,7 @@ sidebar:
 updatedDate: Jan 21, 2026
 authors: jacob
 meta:
-  title: "Purchasing - Datum Handbook"
+  title: "Purchasing & Expense Policy - Datum Handbook"
   description: "Our philosophy on company spending. We trust you to spend responsibly. Read the Datum purchasing guidelines for travel, procurement, and reimbursements."
   og:
     title: "Spending money"

--- a/src/content/handbook/operate/using-github.md
+++ b/src/content/handbook/operate/using-github.md
@@ -6,7 +6,7 @@ sidebar:
 updatedDate: Jan 21, 2026
 authors: jacob
 meta:
-  title: "How we operate - Datum Handbook"
+  title: "Using GitHub for Engineering Workflows - Datum Handbook"
   description: "GitHub is a critical piece of infrastructure and a daily working environment for everyone at Datum; we organize our work in releases, enhancements and issues."
   og:
     title: "Using GitHub"

--- a/src/content/handbook/pay-perks/career-progression.md
+++ b/src/content/handbook/pay-perks/career-progression.md
@@ -10,7 +10,7 @@ meta:
   description: "How career growth works at Datum: impact over ladder-climbing, real autonomy, and an open-source portfolio that speaks for itself."
   og:
     title: "Career Progression at Datum"
-    description: "How to grow your career at Datum."
+    description: "How career growth works at Datum: impact over ladder-climbing, real autonomy, and an open-source portfolio that speaks for itself."
 ---
 
 **TLDR:** Helping Datum succeed helps you succeed. The best way to progress your career at Datum is to understand your team's and the company's objectives, then:

--- a/src/content/handbook/pay-perks/stock-options.md
+++ b/src/content/handbook/pay-perks/stock-options.md
@@ -6,7 +6,7 @@ sidebar:
 updatedDate: May 11, 2026
 authors: jacob
 meta:
-  title: "Stock Options - Datum Handbook"
+  title: "Stock Options & Equity Vesting - Datum Handbook"
   description: "How Datum's stock option program works, including vesting, exercise windows, tax considerations, and what happens when you leave."
   og:
     title: "Stock Options at Datum"

--- a/src/content/handbook/pay-perks/time-off.md
+++ b/src/content/handbook/pay-perks/time-off.md
@@ -6,7 +6,7 @@ sidebar:
 updatedDate: May 11, 2026
 authors: jacob
 meta:
-  title: "Time Off - Datum Handbook"
+  title: "Time Off & Leave Policies - Datum Handbook"
   description: "Datum's approach to unlimited time off, holidays, flexible working, sick leave, maternity leave, and other leave policies."
   og:
     title: "Time Off at Datum"

--- a/src/content/handbook/teams/engineering.md
+++ b/src/content/handbook/teams/engineering.md
@@ -6,7 +6,7 @@ sidebar:
 updatedDate: May 11, 2026
 authors: jacob
 meta:
-  title: "Engineering Team - Datum Handbook"
+  title: "Engineering Team: Roles & Responsibilities - Datum Handbook"
   description: "Engineering builds and runs Datum's products, from software and release cycles to physical and logical capacity, security, and operations."
   og:
     title: "Engineering at Datum"

--- a/src/content/legal/terms.mdx
+++ b/src/content/legal/terms.mdx
@@ -4,7 +4,7 @@ slug: terms
 description: "Understand the terms governing the use of Datum Cloud and its related technologies."
 meta:
   title: "General Terms & Conditions - Datum User Agreement"
-  description: "Read the Datum Terms of Service. The legal agreement governing your access to and use of our open network cloud, including account responsibilities and acceptable use."
+  description: "Read the Datum Terms of Service — the legal agreement governing your access to our open network cloud, including account responsibilities and acceptable use."
   og:
     title: "Datum Terms of Service — Network Infrastructure Agreement"
 ---

--- a/src/content/pages/brand/iconography.mdx
+++ b/src/content/pages/brand/iconography.mdx
@@ -2,7 +2,7 @@
 title: "Iconography"
 meta:
   title: "Datum Iconography: Official Icon Set & Usage Guidelines"
-  description: "Datum uses the open-source Lucide icon library to provide lightweight, scalable vector symbols with a friendly yet precise tone across all digital experiences."
+  description: "Datum uses the open-source Lucide icon library: lightweight, scalable vector symbols with a friendly yet precise tone across all digital experiences."
   og:
     title: "Datum Iconography"
     image: "../../images/og/brand.png"

--- a/src/content/pages/brand/index.mdx
+++ b/src/content/pages/brand/index.mdx
@@ -9,7 +9,7 @@ meta:
   description: "Explore the Datum brand design system: design principles, typography, color palettes, logos, and illustration suite for a hyperscale-ready framework."
   og:
     title: Our visual identity
-    description: Explore the Datum brand design system
+    description: "Explore the Datum brand design system: principles, typography, color palettes, logos, and illustration suite."
     image: "../../images/og/brand.png"
 ---
 


### PR DESCRIPTION
## Summary

- Expand 12 handbook page titles from ≤30 chars to ≥43 chars for better SERP differentiation and keyword signal
- Trim 3 descriptions exceeding the 160-char cutoff (`/legal/terms`, `/handbook/about/model`, `/brand/iconography`)
- Expand `/handbook/eos` description from 97 chars to 159 chars (below recommended 120-char floor)
- Fix 2 `og:description` values that were too short for social sharing (`/brand`, `/handbook/pay-perks/career-progression`)

Closes #1404

## Test plan

- [ ] Build the site and confirm no frontmatter parse errors
- [ ] Spot-check a few affected pages in the browser to confirm titles render correctly in `<title>` and og tags
