### PR TITLE
feat(docker): add redis service for local dev compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,7 @@ STRAPI_CACHE_TTL=2592000
 # Per-request timeout in seconds (default 3); the fallback cache kicks in after this
 STRAPI_TIMEOUT=3
 # Set to "true" for verbose cache hit/miss + GraphQL retry logging
-STRAPI_DEBUG=false
+STRAPI_DEBUG=true
 
 PUBLIC_MINTLIFY_SUBDOMAIN=
 PUBLIC_MINTLIFY_ASSISTANT_KEY=
@@ -49,3 +49,6 @@ DOCS_REPO_URL='https://github.com/datum-cloud/doc'
 DOCS_REPO_BRANCH='main'
 
 ANTHROPIC_API_KEY=
+
+REDIS_URL=redis://redis:6379
+REDIS_KEY_PREFIX=datum-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,33 @@
 services:
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    networks:
+      - datum-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
   dev:
     build:
       context: .
       target: development
     ports:
-      - '4321:4321'
+      - "4321:4321"
     volumes:
       - .:/app
       - /app/node_modules
       - persistent-data:/app/.persistent
     environment:
       - NODE_ENV=development
+      - REDIS_URL=redis://redis:6379
     env_file:
       - .env
+    depends_on:
+      redis:
+        condition: service_healthy
     networks:
       - datum-network
     command: npm run dev --
@@ -22,7 +37,7 @@ services:
       context: .
       target: production
     ports:
-      - '4321:4321'
+      - "4321:4321"
     volumes:
       - persistent-data:/app/.persistent
     environment:


### PR DESCRIPTION
Wire REDIS_URL on the dev service so strapi-revalidate can use shared Redis when testing multi-replica locally. Document REDIS_URL and REDIS_KEY_PREFIX in .env.example.