### PR TITLE
style(nav): align active states across site navigation with figma

### DIFF
--- a/src/pages/download/[slug].astro
+++ b/src/pages/download/[slug].astro
@@ -350,6 +350,6 @@ const jsonLd = appSchema
         </Download>
       </div>
     </div>
-    <Footer class="z-10" />
+    <Footer class="z-10" showCTA={false} />
   </section>
 </Layout>

--- a/src/v1/styles/color-theme.css
+++ b/src/v1/styles/color-theme.css
@@ -44,10 +44,10 @@
 
 /* Target .expressive-code directly to match EC's own selector specificity */
 .expressive-code {
-  --ec-frm-inlBtnFg: var(--color-pine-forge);
-  --ec-code-background: var(--glacier-mist-700);
-  --ec-codeBg: var(--glacier-mist-700);
-  --ec-frm-edBg: var(--glacier-mist-700);
+  --ec-frm-inlBtnFg: var(--color-canyon-clay---links);
+  --ec-code-background: var(--glacier-mist-800);
+  --ec-codeBg: var(--glacier-mist-800);
+  --ec-frm-edBg: var(--glacier-mist-800);
   --ec-code-header-background: color-mix(in srgb, var(--color-glacier-mist-800) 40%, transparent);
 }
 

--- a/src/v1/styles/components-dark.css
+++ b/src/v1/styles/components-dark.css
@@ -27,5 +27,11 @@
         }
       }
     }
+
+    .nav--main {
+      .nav-menu-link {
+        @apply text-glacier-mist-700 opacity-100 hover:opacity-80;
+      }
+    }
   }
 }

--- a/src/v1/styles/components-download.css
+++ b/src/v1/styles/components-download.css
@@ -37,22 +37,18 @@
   }
 
   .download-nav-link {
-    @apply flex items-center gap-2;
-    @apply p-2;
-    @apply datum-text-base;
-    @apply text-midnight-fjord/80;
+    @apply flex items-center gap-2 rounded-md p-2;
+    @apply datum-text-sm text-midnight-fjord/60 font-medium;
     @apply transition-colors duration-200;
-    @apply hover:text-midnight-fjord;
+    @apply hover:text-midnight-fjord/80;
   }
 
   .download-nav-link--active {
-    /* Figma: Item → Link — glacier pill, midnight text, 8px pad, 6px radius */
-    @apply bg-glacier-mist-900 rounded-md p-2;
-    @apply text-midnight-fjord font-semibold;
-    @apply hover:bg-glacier-mist-900 hover:text-midnight-fjord;
+    @apply text-canyon-clay---links bg-white font-semibold;
+    @apply hover:text-canyon-clay---links hover:bg-white;
 
     .download-nav-icon {
-      @apply text-midnight-fjord;
+      @apply text-canyon-clay---links;
     }
   }
 
@@ -187,7 +183,7 @@
   }
 
   .download-nav-mobile-selected {
-    @apply truncate font-medium text-gray-900;
+    @apply text-canyon-clay---links truncate font-semibold;
   }
 
   .download-nav-mobile-chevron {
@@ -221,16 +217,14 @@
   }
 
   .download-nav-mobile-link {
-    @apply flex items-center gap-2;
-    @apply px-3 py-1;
-    @apply datum-text-base;
-    @apply text-midnight-fjord;
+    @apply flex items-center gap-2 rounded-md px-3 py-1;
+    @apply datum-text-sm text-midnight-fjord/60 font-medium;
     @apply transition-colors duration-300 ease-out;
-    @apply hover:text-canyon-clay---links;
+    @apply hover:text-midnight-fjord/80;
 
     &--active {
-      @apply text-canyon-clay---links font-semibold;
-      @apply hover:text-midnight-fjord;
+      @apply text-canyon-clay---links bg-white font-semibold;
+      @apply hover:text-canyon-clay---links hover:bg-white;
 
       .download-nav-mobile-icon {
         @apply text-canyon-clay---links;

--- a/src/v1/styles/components-handbook.css
+++ b/src/v1/styles/components-handbook.css
@@ -111,7 +111,7 @@
     @apply transition-colors duration-200 hover:bg-gray-50;
 
     .sidebar-mobile-toggle--text {
-      @apply text-midnight-fjord datum-text-base;
+      @apply text-canyon-clay---links datum-text-base font-semibold;
     }
 
     .sidebar-mobile-toggle--icon {
@@ -179,11 +179,12 @@
   }
 
   .handbook-sidebar .menu-link {
-    @apply text-midnight-fjord/80 hover:text-midnight-fjord datum-text-sm transition-colors duration-200 ease-out;
-    @apply inline-block w-full px-2 py-1;
+    @apply datum-text-sm text-midnight-fjord/60 inline-block w-full rounded-md p-2 font-medium transition-colors duration-150;
+    @apply hover:text-midnight-fjord/80;
   }
 
   .handbook-sidebar .menu-link--active {
-    @apply bg-glacier-mist-800 text-midnight-fjord font-semibold;
+    @apply text-canyon-clay---links bg-white font-semibold;
+    @apply hover:text-canyon-clay---links hover:bg-white;
   }
 }

--- a/src/v1/styles/components-nav.css
+++ b/src/v1/styles/components-nav.css
@@ -25,7 +25,7 @@
     @apply border-glacier-mist-900;
   }
   .nav--main {
-    @apply max-width relative z-80 m-auto flex w-full items-center justify-between gap-5 py-2.5 md:gap-10 md:py-3.5 lg:gap-20;
+    @apply max-width relative z-80 m-auto flex w-full items-center justify-between gap-5 py-2.5 md:gap-10 md:py-3.5 lg:gap-16;
 
     .nav-actions {
       @apply mr-3 ml-auto flex items-center gap-3 justify-self-end md:col-span-3 md:mr-0 md:gap-3.25;
@@ -49,19 +49,7 @@
     }
 
     .nav-menu {
-      @apply datum-text-base hidden items-center justify-start text-white md:flex md:gap-6 lg:gap-8 xl:gap-10;
-    }
-
-    .nav-menu-link.link--active {
-      & > span {
-        @apply relative;
-
-        &::after {
-          content: '';
-          @apply absolute bottom-0 left-0 h-0.5;
-          @apply bg-midnight-fjord w-full;
-        }
-      }
+      @apply datum-text-base hidden items-center justify-start text-white md:flex md:gap-3 lg:gap-5;
     }
 
     .nav-menu-item {
@@ -69,10 +57,10 @@
     }
 
     .nav-menu-link {
-      @apply flex items-center gap-2 font-normal hover:opacity-80;
+      @apply flex items-center gap-2 px-3 py-1.5 font-normal opacity-60 hover:opacity-80;
 
-      & > span {
-        @apply pb-1;
+      &.link--active {
+        @apply text-canyon-clay---links rounded-md bg-white opacity-100 hover:opacity-80;
       }
     }
   }

--- a/src/v1/styles/components-nav.css
+++ b/src/v1/styles/components-nav.css
@@ -60,7 +60,7 @@
       @apply flex items-center gap-2 px-3 py-1.5 font-normal opacity-60 hover:opacity-80;
 
       &.link--active {
-        @apply text-canyon-clay---links rounded-md bg-white opacity-100 hover:opacity-80;
+        @apply text-canyon-clay---links rounded-md bg-white font-semibold opacity-100 hover:opacity-80;
       }
     }
   }

--- a/src/v1/styles/components-secondary-tab-nav.css
+++ b/src/v1/styles/components-secondary-tab-nav.css
@@ -22,7 +22,7 @@
   }
 
   .secondary-tab-nav-mobile-selected {
-    @apply datum-text-sm text-midnight-fjord shrink-0 font-semibold;
+    @apply datum-text-sm text-canyon-clay---links shrink-0 font-semibold;
   }
 
   .secondary-tab-nav-mobile-chevron {
@@ -42,31 +42,32 @@
   }
 
   .secondary-tab-nav-mobile-link {
-    @apply datum-text-sm text-midnight-fjord/60 mx-2 flex items-center gap-2 rounded-sm px-4 py-3 font-medium no-underline;
-    @apply hover:bg-glacier-mist-700/50 hover:text-midnight-fjord/80;
+    @apply datum-text-sm text-midnight-fjord/60 mx-2 flex items-center gap-2 rounded-md px-4 py-3 font-medium no-underline;
+    @apply hover:text-midnight-fjord/80;
 
     &--active {
-      @apply bg-glacier-mist-900 text-midnight-fjord font-semibold;
-      @apply hover:bg-glacier-mist-900 hover:text-midnight-fjord;
+      @apply text-canyon-clay---links bg-white font-semibold;
+      @apply hover:text-canyon-clay---links hover:bg-white;
     }
   }
 
-  /* Track color on the list avoids a white→gray flash before tab backgrounds paint */
   .secondary-tab-nav__list {
-    @apply md:border-glacier-mist-900 md:bg-glacier-mist-700 m-0 hidden list-none p-0 md:inline-flex md:overflow-hidden md:rounded-md md:border;
+    @apply bg-glacier-mist-800 m-0 hidden list-none gap-0 p-0.5 md:inline-flex md:overflow-hidden md:rounded-lg;
+
     li {
-      @apply last:[&>a]:border-r-0;
+      @apply m-0 p-0;
     }
   }
 
   .secondary-tab-nav__tab {
-    @apply datum-text-sm text-midnight-fjord/60 border-glacier-mist-900 inline-flex items-center justify-center border-r bg-transparent px-6 py-1.25 font-medium no-underline;
-    @apply hover:bg-glacier-mist-700/40 hover:text-midnight-fjord/75;
+    @apply datum-text-sm text-midnight-fjord/60 inline-flex items-center justify-center rounded-md bg-transparent font-medium no-underline;
+    @apply hover:text-midnight-fjord/80;
     @apply focus-visible:ring-midnight-fjord/30 focus-visible:relative focus-visible:z-10 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset;
+    @apply px-6 py-1.5;
   }
 
   .secondary-tab-nav__tab--active {
-    @apply bg-glacier-mist-900 text-midnight-fjord font-semibold;
-    @apply hover:bg-glacier-mist-900 hover:text-midnight-fjord;
+    @apply text-canyon-clay---links bg-white font-semibold;
+    @apply hover:text-canyon-clay---links hover:bg-white;
   }
 }

--- a/src/v1/styles/page-legal.css
+++ b/src/v1/styles/page-legal.css
@@ -28,25 +28,27 @@
   }
 
   .legal-sidenav-item {
-    @apply datum-text-sm text-midnight-fjord/60 hover:text-midnight-fjord block rounded-md px-2 py-2 font-medium transition-colors duration-150;
+    @apply datum-text-sm text-midnight-fjord/60 block rounded-md p-2 font-medium transition-colors duration-150;
+    @apply hover:text-midnight-fjord/80;
 
     &.legal-sidenav-item--active {
-      @apply bg-glacier-mist-800 text-midnight-fjord font-semibold opacity-100;
+      @apply text-canyon-clay---links bg-white font-semibold;
+      @apply hover:text-canyon-clay---links hover:bg-white;
     }
 
     /* Mobile only: match brand nav dropdown style */
     @media (max-width: 767px) {
-      @apply datum-text-base text-midnight-fjord rounded-none px-3 py-1;
+      @apply datum-text-base text-midnight-fjord/60 rounded-md px-3 py-2;
 
       &:hover {
-        @apply text-canyon-clay---links;
+        @apply text-midnight-fjord/80;
       }
 
       &.legal-sidenav-item--active {
-        @apply text-canyon-clay---links bg-transparent;
+        @apply text-canyon-clay---links bg-white font-semibold;
 
         &:hover {
-          @apply text-midnight-fjord;
+          @apply text-canyon-clay---links bg-white;
         }
       }
     }


### PR DESCRIPTION
## Summary

- Update main nav active state to a white pill with `canyon-clay---links` text and semibold weight, replacing the underline indicator
- Restyle `SecondaryTabNav` to the Figma `Temp/Tablist` pattern: `glacier-mist-800` track, white active pill, and muted inactive tabs at 60% opacity
- Align download sidebar active items with the same white + canyon-clay treatment (desktop and mobile), tune download code block theme tokens, and hide the footer CTA on download pages
- Apply the same active pattern to legal sidenav items and handbook child menu links

Design reference: [Datum Master Design File — Active State Consolidation](https://www.figma.com/design/bBEQ8YeTP4SngNl5EkkQdH/Datum---Master-Design-File?node-id=14230-54677)

## Test plan

- [ ] Main nav: active top-level item shows white pill + canyon-clay text on light and dark hero backgrounds
- [ ] Secondary tabs (Features / Essentials / Pricing): active tab is white on gray track; inactive tabs are muted
- [ ] Download pages: active platform in sidebar uses white pill + canyon-clay text/icon; mobile dropdown matches
- [ ] Legal pages (`/legal/*`): active sidenav item matches Figma; mobile toggle/dropdown behave correctly
- [ ] Handbook pages: active child menu link uses white pill + canyon-clay text; mobile toggle shows selected label in canyon-clay
- [ ] No regressions to hover/focus states or keyboard navigation on updated nav components