### PR TITLE
fix(nav): remove layout-shifting margin on dropdown chevron

### DIFF
--- a/src/v1/styles/components-nav.css
+++ b/src/v1/styles/components-nav.css
@@ -83,12 +83,12 @@
   }
 
   .nav-dropdown-arrow {
-    @apply -mt-1 transition-transform duration-200 ease-in-out;
+    @apply transition-transform duration-200 ease-in-out;
   }
 
   .nav-dropdown:hover .nav-dropdown-arrow,
   .nav-dropdown:focus-within .nav-dropdown-arrow {
-    @apply mt-0 rotate-180;
+    @apply rotate-180;
   }
 
   .nav-dropdown-menu {


### PR DESCRIPTION
## Summary

- Removes `-mt-1` / `mt-0` margin toggle on `.nav-dropdown-arrow`
- Margin changes are not CSS transitions, so the header height jolted on dropdown open/close
- `items-center` on the parent flex row already centers the chevron — no nudge needed

## Test plan

- [ ] Open the nav on any page with a dropdown (Platform, Resources)
- [ ] Hover/click to open the dropdown — header height should not shift
- [ ] Chevron rotates smoothly without positional jump