### PR TITLE
feat(roadmap): sync .md endpoints + fix nav dropdown

### DIFF
--- a/src/pages/roadmap.md.ts
+++ b/src/pages/roadmap.md.ts
@@ -5,22 +5,31 @@
 export const prerender = false;
 
 import type { APIRoute } from 'astro';
-import { fetchStrapiRoadmaps, groupRoadmapsByDate, getMonthAbbreviation } from '@libs/strapi';
+import {
+  fetchStrapiRoadmaps,
+  groupRoadmapsByDate,
+  getMonthAbbreviation,
+  getRoadmapSlug,
+} from '@libs/strapi';
 import type { StrapiRoadmap } from '@libs/strapi';
 import { STRAPI_SSR_CACHE_CONTROL } from '@libs/strapi/httpCache';
 import { toAsciiMarkdown } from '@utils/markdownExport';
 
-function renderMilestone(roadmap: StrapiRoadmap, includeSummary: boolean): string {
+function renderMilestone(roadmap: StrapiRoadmap, includeDetail: boolean): string {
   const month = getMonthAbbreviation(roadmap.releaseDate);
   const lines: string[] = [`### ${month} - ${roadmap.title}`];
   if (roadmap.description) {
     lines.push('', roadmap.description);
   }
-  if (includeSummary && roadmap.summary) {
+  if (includeDetail && roadmap.summary) {
     lines.push('', roadmap.summary);
   }
   if (roadmap.githubUrl) {
     lines.push('', `[GitHub](${roadmap.githubUrl})`);
+  }
+  if (includeDetail) {
+    const slug = getRoadmapSlug(roadmap);
+    lines.push('', `[Full details](/roadmap/${slug}.md)`);
   }
   return lines.join('\n');
 }
@@ -36,6 +45,8 @@ export const GET: APIRoute = async () => {
       "We plan and ship in monthly cycles. Each cycle is named for a cultural, literary or scientific pioneer whose story connects to the work we're doing.",
       '',
       "Here's a view of the road ahead. Vote for your favorites, or [request a new feature on GitHub](https://github.com/orgs/datum-cloud/discussions/categories/feature-requests).",
+      '',
+      'See also: [Product Backlog](/roadmap/backlog.md) - features planned but not yet assigned to a release.',
     ];
 
     if (upcoming.length > 0) {

--- a/src/pages/roadmap/[slug].md.ts
+++ b/src/pages/roadmap/[slug].md.ts
@@ -1,0 +1,82 @@
+// Dynamic markdown export of /roadmap/<slug> detail pages. Pulls from the
+// same Strapi source that RoadmapDetailContent.astro renders from. SSR so
+// webhook cache invalidations propagate immediately.
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import {
+  fetchStrapiRoadmapBySlug,
+  fetchStrapiRoadmaps,
+  getRoadmapMonthKey,
+  getRoadmapSlug,
+} from '@libs/strapi';
+import { STRAPI_SSR_CACHE_CONTROL } from '@libs/strapi/httpCache';
+import { toAsciiMarkdown } from '@utils/markdownExport';
+
+export const GET: APIRoute = async ({ params }) => {
+  const slug = params.slug;
+  if (!slug || typeof slug !== 'string') {
+    return new Response('Not found', { status: 404 });
+  }
+
+  try {
+    let roadmap = await fetchStrapiRoadmapBySlug(slug);
+
+    // Legacy YYYY-MM slugs: resolve to canonical slug the same way [slug].astro does.
+    if (!roadmap && /^\d{4}-\d{2}$/.test(slug)) {
+      const match = (await fetchStrapiRoadmaps()).find(
+        (r) => getRoadmapMonthKey(r.releaseDate) === slug
+      );
+      if (match) {
+        const canonical = getRoadmapSlug(match);
+        if (canonical !== slug) {
+          return new Response(null, {
+            status: 301,
+            headers: { Location: `/roadmap/${canonical}.md` },
+          });
+        }
+        roadmap = match;
+      }
+    }
+
+    if (!roadmap) {
+      return new Response('Not found', { status: 404 });
+    }
+
+    const releaseDate = new Date(roadmap.releaseDate);
+    const formattedDate = releaseDate.toLocaleString('en-US', { month: 'long', year: 'numeric' });
+
+    const titleParts = roadmap.title.split(':');
+    const releaseName = titleParts[0]?.trim() ?? roadmap.title;
+    const honorName = roadmap.cover?.caption?.trim() || releaseName;
+
+    const sections: string[] = [`# ${releaseName} - ${formattedDate} Roadmap`, ''];
+
+    if (roadmap.summary) {
+      sections.push(roadmap.summary, '');
+    } else {
+      sections.push('_Release notes coming soon._', '');
+    }
+
+    if (roadmap.description) {
+      sections.push(`## Named to honor ${honorName}`, '', roadmap.description, '');
+    }
+
+    if (roadmap.githubUrl) {
+      sections.push(`[View on GitHub](${roadmap.githubUrl})`, '');
+    }
+
+    sections.push('---', '', `Source: <https://www.datum.net/roadmap/${slug}/>`, '');
+
+    const body = toAsciiMarkdown(sections.join('\n'));
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': STRAPI_SSR_CACHE_CONTROL,
+      },
+    });
+  } catch (error) {
+    console.error(`Failed to serve /roadmap/${slug}.md:`, error);
+    return new Response('Error generating markdown', { status: 500 });
+  }
+};

--- a/src/pages/roadmap/backlog.md.ts
+++ b/src/pages/roadmap/backlog.md.ts
@@ -1,0 +1,73 @@
+// Dynamic markdown export of /roadmap/backlog. Pulls from the same GitHub
+// Projects source that RoadmapBacklog.astro renders from, so the list stays
+// current without manual edits. SSR so cache invalidations propagate.
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { getCollectionEntry } from '@utils/collectionUtils';
+import { fetchGitHubBacklog } from '@libs/githubBacklog';
+import type { GitHubBacklogItem } from '@libs/githubBacklog';
+import { toAsciiMarkdown } from '@utils/markdownExport';
+
+function renderItem(item: GitHubBacklogItem): string {
+  const labels = item.labels.length > 0 ? ` _(${item.labels.join(', ')})_` : '';
+  return `- [#${item.number} ${item.title}](${item.url})${labels}`;
+}
+
+export const GET: APIRoute = async () => {
+  try {
+    const [backlogPage, roadmapPage] = await Promise.all([
+      getCollectionEntry('pages', 'backlog'),
+      getCollectionEntry('pages', 'roadmap'),
+    ]);
+
+    const title = backlogPage?.data.title ?? 'Product Backlog';
+    const description =
+      backlogPage?.data.meta?.description ??
+      backlogPage?.data.description ??
+      roadmapPage?.data.description ??
+      'Planned improvements and features not yet scheduled into a release cycle.';
+
+    const items = await fetchGitHubBacklog();
+
+    const sections: string[] = [
+      `# ${title}`,
+      '',
+      description,
+      '',
+      `_${items.length} item${items.length === 1 ? '' : 's'} in the backlog._`,
+    ];
+
+    if (items.length === 0) {
+      sections.push('', 'No backlog items available at this time.');
+    } else {
+      // Flat list matching the order the page renders — no grouping.
+      sections.push('');
+      for (const item of items) {
+        sections.push(renderItem(item));
+      }
+    }
+
+    sections.push(
+      '',
+      '---',
+      '',
+      'Want to propose a new feature? [Start a discussion on GitHub](https://github.com/orgs/datum-cloud/discussions/categories/feature-requests).',
+      '',
+      'Source: <https://www.datum.net/roadmap/backlog/>',
+      ''
+    );
+
+    const body = toAsciiMarkdown(sections.join('\n'));
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        // Backlog is cached for 24 h on GitHub's side; match that TTL.
+        'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+      },
+    });
+  } catch (error) {
+    console.error('Failed to serve /roadmap/backlog.md:', error);
+    return new Response('Error generating markdown', { status: 500 });
+  }
+};

--- a/src/utils/markdownExport.ts
+++ b/src/utils/markdownExport.ts
@@ -51,6 +51,16 @@ export async function resolveMarkdownUrl(pathname: string): Promise<string | nul
     return `${path}.md`;
   }
 
+  // Strapi-backed roadmap detail pages: /roadmap/<slug>.
+  // /roadmap itself is a dedicated endpoint handled below by hasMarkdownForPath.
+  // /roadmap/backlog is in DEDICATED_ENDPOINTS so hasMarkdownForPath catches it too,
+  // but all sub-paths — dedicated or dynamic — resolve to the same .md URL.
+  if (path.startsWith('/roadmap/')) {
+    const subpath = path.slice('/roadmap/'.length);
+    if (!subpath) return null;
+    return `${path}.md`;
+  }
+
   // Static assets, dedicated endpoints, and auto-derived registry entries are
   // all checked uniformly by hasMarkdownForPath.
   if (await hasMarkdownForPath(path)) {

--- a/src/utils/markdownRegistry.ts
+++ b/src/utils/markdownRegistry.ts
@@ -25,6 +25,7 @@ const DEDICATED_ENDPOINTS = new Set<string>([
   '/blog',
   '/changelog',
   '/roadmap',
+  '/roadmap/backlog',
   '/events',
   '/handbook',
   '/brand',

--- a/src/v1/styles/components-nav.css
+++ b/src/v1/styles/components-nav.css
@@ -92,12 +92,25 @@
   }
 
   .nav-dropdown-menu {
-    @apply shadow-modal pointer-events-none invisible absolute top-full left-0 z-90 w-max min-w-[250px] cursor-pointer rounded-[var(--radius-lg)] bg-white p-6 opacity-0 transition-all duration-200 ease-in-out;
+    @apply shadow-modal absolute top-full left-0 z-90 w-max min-w-[250px] cursor-pointer rounded-[var(--radius-lg)] bg-white p-6;
+    opacity: 0;
+    visibility: hidden;
+    /* Close: 300ms hold, then 200ms fade-out, then hide. Using visibility (not
+       pointer-events-none) so the dropdown stays interactive during the hold —
+       moving back into it re-activates :hover on the parent. */
+    transition:
+      opacity 200ms ease-in-out 150ms,
+      visibility 0s 350ms;
   }
 
   .nav-dropdown:hover .nav-dropdown-menu,
   .nav-dropdown:focus-within .nav-dropdown-menu {
-    @apply pointer-events-auto visible opacity-100;
+    opacity: 1;
+    visibility: visible;
+    /* Open: no delay — show immediately, fade in fast. */
+    transition:
+      opacity 200ms ease-in-out,
+      visibility 0s;
   }
 
   .nav-dropdown-items {


### PR DESCRIPTION
## Summary

### Roadmap markdown endpoints
- Add `src/pages/roadmap/backlog.md.ts` — flat list of GitHub Projects backlog items matching the render order of `/roadmap/backlog`
- Add `src/pages/roadmap/[slug].md.ts` — per-milestone detail pages backed by Strapi; includes summary, honor attribution, and GitHub link; handles legacy `YYYY-MM` slug redirects
- Register `/roadmap/backlog` in `DEDICATED_ENDPOINTS` (`markdownRegistry.ts`)
- Add `/roadmap/<slug>` resolver in `markdownExport.ts` so the "Read as Markdown" footer trigger lights up on detail pages
- Update `roadmap.md.ts` to link to the backlog page and add per-milestone detail page links on upcoming releases

### Nav dropdown fixes
- Remove `-mt-1`/`mt-0` margin toggle on chevron — margin changes are not CSS transitions so the header height jolted on dropdown open/close
- Replace `transition-all` on dropdown menu with explicit `opacity`/`visibility` transitions; 150ms hold before fade-out gives enough time for diagonal mouse movement to child items

## Test plan

- [ ] Visit `/roadmap.md` — should include backlog link and per-milestone detail links
- [ ] Visit `/roadmap/backlog.md` — flat list matching the order on `/roadmap/backlog`
- [ ] Visit `/roadmap/<slug>.md` for an active milestone — summary, attribution, GitHub link
- [ ] Footer "Read as Markdown" trigger appears on `/roadmap/backlog` and `/roadmap/<slug>` pages
- [ ] Open Platform / Resources dropdown — header height does not shift on open/close
- [ ] Chevron rotates smoothly with no positional jump
- [ ] Moving diagonally from trigger to dropdown items works without the menu closing