### PR TITLE
fix(roadmap): rename Releases tab to Upcoming and add GitHub link

### DIFF
--- a/src/components/roadmap/RoadmapViewFilter.astro
+++ b/src/components/roadmap/RoadmapViewFilter.astro
@@ -1,6 +1,6 @@
 ---
 // src/components/roadmap/RoadmapViewFilter.astro
-// Client-side filter for /roadmap#shipped vs default releases view.
+// Client-side filter for /roadmap#shipped vs default upcoming view.
 ---
 
 <script>
@@ -15,12 +15,13 @@
     const cards = document.querySelectorAll<HTMLElement>('.roadmap-card');
 
     cards.forEach((card) => {
+      const shippedAttr = card.dataset.roadmapShipped;
+
       if (!shippedView) {
-        card.hidden = false;
+        card.hidden = shippedAttr === 'true';
         return;
       }
 
-      const shippedAttr = card.dataset.roadmapShipped;
       if (shippedAttr === undefined) {
         card.hidden = true;
         return;

--- a/src/data/navigation.json
+++ b/src/data/navigation.json
@@ -179,6 +179,12 @@
   ],
   "social": [
     {
+      "href": "https://github.com/datum-cloud/",
+      "text": "GitHub",
+      "icon": "github",
+      "isExternal": true
+    },
+    {
       "href": "https://link.datum.net/discord",
       "text": "Discord",
       "icon": "discord",

--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -4,7 +4,7 @@ export const prerender = false;
 
 import '@v1/styles/page-roadmap.css';
 import { getCollectionEntry } from '@utils/collectionUtils';
-import { fetchStrapiRoadmaps } from '@libs/strapi';
+import { fetchStrapiRoadmaps, isRoadmapShipped } from '@libs/strapi';
 
 import Layout from '@layouts/Layout.astro';
 import Hero from '@components/Hero.astro';
@@ -25,6 +25,13 @@ const heroYear = new Date().getFullYear();
 const heroTitle = `${heroYear} Roadmap`;
 
 const roadmaps = await fetchStrapiRoadmaps();
+const hasUpcoming = roadmaps.some((roadmap) => !isRoadmapShipped(roadmap));
+
+const tabItems = [
+  ...(hasUpcoming ? [{ label: 'Upcoming', href: '/roadmap', exact: true as const }] : []),
+  { label: 'Shipped', href: '/roadmap#shipped' },
+  { label: 'Backlog', href: '/roadmap/backlog' },
+];
 ---
 
 <Layout title={heroTitle} description={description} bodyClass="page-roadmap" meta={meta}>
@@ -37,11 +44,7 @@ const roadmaps = await fetchStrapiRoadmaps();
           <SecondaryTabNav
             ariaLabel="Roadmap sections"
             mobileLabel="Roadmap section"
-            items={[
-              { label: 'Releases', href: '/roadmap', exact: true },
-              { label: 'Shipped', href: '/roadmap#shipped' },
-              { label: 'Backlog', href: '/roadmap/backlog' },
-            ]}
+            items={tabItems}
           />
         </div>
         <RoadmapGrid roadmaps={roadmaps} />

--- a/src/pages/roadmap/backlog.astro
+++ b/src/pages/roadmap/backlog.astro
@@ -5,6 +5,7 @@ export const prerender = false;
 import '@v1/styles/page-roadmap.css';
 import { getCollectionEntry } from '@utils/collectionUtils';
 import { fetchGitHubBacklog } from '@libs/githubBacklog';
+import { fetchStrapiRoadmaps, isRoadmapShipped } from '@libs/strapi';
 
 import Layout from '@layouts/Layout.astro';
 import Hero from '@components/Hero.astro';
@@ -26,7 +27,14 @@ const heroDescription = roadmapPage.data.description;
 const layoutTitle = backlogMeta.title ?? 'Datum Product Backlog';
 const layoutDescription = backlogMeta.description ?? backlogPage.data.description;
 
-const backlogItems = await fetchGitHubBacklog();
+const [backlogItems, roadmaps] = await Promise.all([fetchGitHubBacklog(), fetchStrapiRoadmaps()]);
+const hasUpcoming = roadmaps.some((roadmap) => !isRoadmapShipped(roadmap));
+
+const tabItems = [
+  ...(hasUpcoming ? [{ label: 'Upcoming', href: '/roadmap', exact: true as const }] : []),
+  { label: 'Shipped', href: '/roadmap#shipped' },
+  { label: 'Backlog', href: '/roadmap/backlog', exact: true as const },
+];
 ---
 
 <Layout title={layoutTitle} description={layoutDescription} bodyClass="page-backlog" meta={meta}>
@@ -39,11 +47,7 @@ const backlogItems = await fetchGitHubBacklog();
           <SecondaryTabNav
             ariaLabel="Roadmap sections"
             mobileLabel="Roadmap section"
-            items={[
-              { label: 'Releases', href: '/roadmap', exact: true },
-              { label: 'Shipped', href: '/roadmap#shipped' },
-              { label: 'Backlog', href: '/roadmap/backlog', exact: true },
-            ]}
+            items={tabItems}
           />
         </div>
         <RoadmapBacklog items={backlogItems} />


### PR DESCRIPTION
Show Upcoming only when unshipped milestones exist and filter the default view to non-shipped cards. Add datum-cloud GitHub to footer social links.