### PR TITLE
feat(branding): rename UFO to Datum Compute site-wide

### DIFF
--- a/public/features.md
+++ b/public/features.md
@@ -28,7 +28,7 @@ Route traffic where you want it.
 - **Fully Programmable** - Declarative VPC topology via Datum's Kubernetes-native control plane.
 - **Optimized for Private Paths** - Direct interconnect to AWS, GCP, and other clouds.
 
-## UFO (coming soon)
+## Datum Compute (coming soon)
 
 Isolated, cold-start compute.
 

--- a/public/index.md
+++ b/public/index.md
@@ -42,7 +42,7 @@ Unlike existing alternatives, our open network cloud is built specifically for m
 
 ## Explore
 
-- [Features](/features/) - AI Edge, Connectors, Galactic VPC, UFO, foundations
+- [Features](/features/) - AI Edge, Connectors, Galactic VPC, Datum Compute, foundations
 - [Essentials](/essentials/) - Enterprise-grade primitives included free
 - [Pricing](/pricing/) - Builder ($0), Scaler ($20/mo + usage), Provider (custom)
 - [Locations](/locations/) - 17+ global regions across NA, LATAM, EU, MEA, APAC

--- a/src/content/handbook/teams/biz-dev.md
+++ b/src/content/handbook/teams/biz-dev.md
@@ -40,7 +40,7 @@ We're working toward a more interconnected internet for AI, both in terms of net
 We seek partnerships with "best of breed" technology creators, and we're currently focused on companies that include a strong open-source ethos. Current examples include:
 
 - **Tetrate** — Envoy and the AI Gateway that powers our Internet Edge
-- **Unikraft** — the unikernel runtime behind UFOs, our edge compute units
+- **Unikraft** — the unikernel runtime behind Datum Compute, our edge compute product
 - **Iroh** — secure, QUIC-based tunnels behind our Connectors
 
 ### Design wins

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -293,7 +293,7 @@ const jsonLd = {
             </div>
           </section>
 
-          <!-- Section 4: Galactic VPC + UFO -->
+          <!-- Section 4: Galactic VPC + Datum Compute -->
           <div class="features-cards">
             <section class="features-card">
               <div class="features-card-header">
@@ -349,14 +349,14 @@ const jsonLd = {
             <section class="features-card">
               <div class="features-card-header">
                 <div class="features-card-labels">
-                  <span class="section-label">UFO_</span>
+                  <span class="section-label">Datum Compute_</span>
                   <span class="section-label section-label--muted"> (coming soon) </span>
                 </div>
                 <div class="features-section-header-text">
                   <h2 class="section-title--sm">Isolated, cold-start compute</h2>
                   <p class="features-section-description">
-                    That's why our "Unikernel Function Offload" feature provides 100% isolation,
-                    millisecond cold starts, and scale to zero snapshotting.
+                    Datum Compute provides 100% isolation, millisecond cold starts, and scale to
+                    zero snapshotting.
                   </p>
                 </div>
               </div>

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -180,7 +180,7 @@ A global virtual private backbone service built using **Segment Routing over IPv
 
 ---
 
-### 6. UFO — Unikernel Function Offload (Coming Soon)
+### 6. Datum Compute (Coming Soon)
 
 Edge compute layer built in partnership with **Unikraft**.
 


### PR DESCRIPTION
## Summary

- Replaces all references to "UFO" and "Unikernel Function Offload" with "Datum Compute" across the site
- Affected files: `public/index.md`, `public/features.md`, `src/content/handbook/teams/biz-dev.md`, `src/pages/features.astro`, `src/pages/llms-full.txt.ts`

## Test plan

- [ ] Visit `/features` — confirm section label reads "Datum Compute_" (not "UFO_")
- [ ] Visit `/features.md` — confirm heading reads "## Datum Compute (coming soon)"
- [ ] Visit `/llms-full.txt` — confirm section 6 heading reads "Datum Compute (Coming Soon)"
- [ ] Check handbook biz-dev page — confirm Unikraft blurb references "Datum Compute"