### PR TITLE
feat(ci): add Slack notification to SEO audit workflow

### DIFF
--- a/.github/workflows/seo-review.yml
+++ b/.github/workflows/seo-review.yml
@@ -126,6 +126,7 @@ jobs:
 
       - name: Open weekly audit issue
         if: github.event_name != 'pull_request'
+        id: audit-issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -139,7 +140,20 @@ jobs:
           gh issue list --label seo-audit --state open --json number,title \
             --jq '.[] | select(.title != "'"$TITLE"'") | .number' \
             | xargs -I{} gh issue close {} --comment "Superseded by ${TITLE}." || true
-          gh issue create \
+          ISSUE_URL="$(gh issue create \
             --title "$TITLE" \
             --label seo-audit \
-            --body-file "$BODY_FILE"
+            --body-file "$BODY_FILE")"
+          echo "url=$ISSUE_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Slack
+        if: github.event_name != 'pull_request' && secrets.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          ISSUE_URL: ${{ steps.audit-issue.outputs.url }}
+        run: |
+          set -euo pipefail
+          DATE="$(date -u +%Y-%m-%d)"
+          curl -s -f -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"*SEO Audit — ${DATE}* :mag:\n<${ISSUE_URL}|View full report on GitHub>\"}"


### PR DESCRIPTION
## Summary
- Captures the GitHub issue URL output from the `gh issue create` step
- Adds a new `Notify Slack` step that fires on schedule/manual dispatch (skipped on PRs)
- Posts a Slack message with date and a direct link to the created issue
- Uses `SLACK_WEBHOOK_URL` secret; step is skipped gracefully if secret is unset

## Test plan
- [ ] Set `SLACK_WEBHOOK_URL` secret in repo and trigger a manual `workflow_dispatch` run — confirm Slack message arrives with correct issue link
- [ ] Verify the step is skipped on PR runs (condition: `github.event_name != 'pull_request'`)
- [ ] Verify graceful skip when `SLACK_WEBHOOK_URL` secret is absent