### PR TITLE
fix(ci): fix invalid secrets context usage in seo-review workflow

### DIFF
--- a/.github/workflows/seo-review.yml
+++ b/.github/workflows/seo-review.yml
@@ -40,6 +40,7 @@ jobs:
       NODE_ENV: development
       HUSKY: 0
       ASTRO_TELEMETRY_DISABLED: 1
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -147,7 +148,7 @@ jobs:
           echo "url=$ISSUE_URL" >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack
-        if: github.event_name != 'pull_request' && secrets.SLACK_WEBHOOK_URL != ''
+        if: github.event_name != 'pull_request' && env.SLACK_WEBHOOK_URL != ''
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           ISSUE_URL: ${{ steps.audit-issue.outputs.url }}


### PR DESCRIPTION
## Summary
- GitHub Actions rejects the `secrets` context inside step `if:` expressions, causing the SEO Review workflow to fail with `Unrecognized named-value: 'secrets'`.
- Mirror `SLACK_WEBHOOK_URL` into job-level `env` and check `env.SLACK_WEBHOOK_URL` in the `if:` condition instead.

## Test plan
- [x] Validated YAML syntax locally
- [x] Ran the workflow via `workflow_dispatch` on this branch: https://github.com/datum-cloud/datum.net/actions/runs/28512417936 — all steps completed successfully, including "Notify Slack" which posted to Slack successfully.