### PR TITLE
fix: skip PR comment when seo-review has nothing to check

### DIFF
--- a/.github/workflows/seo-review.yml
+++ b/.github/workflows/seo-review.yml
@@ -109,6 +109,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run SEO review
+        id: seo-review
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           SCAN_MODE: ${{ steps.mode.outputs.value }}
@@ -119,7 +120,7 @@ jobs:
         run: node scripts/seo-review.mjs
 
       - name: Post or update PR comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.seo-review.outputs.mode != 'skipped-no-changes'
         uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: seo-review-bot

--- a/scripts/seo-review.mjs
+++ b/scripts/seo-review.mjs
@@ -18,7 +18,7 @@
  *   SITE_URL            default: https://www.datum.net (host used to recognise internal links)
  */
 
-import { readFile, writeFile, readdir, stat, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, appendFile, readdir, stat, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { load } from 'cheerio';
 
@@ -803,6 +803,10 @@ async function main() {
   await mkdir(path.dirname(OUTPUT_FILE), { recursive: true });
   await writeFile(OUTPUT_FILE, body, 'utf8');
   console.log(`Wrote ${OUTPUT_FILE} (${body.length} bytes, ${picked.length} pages).`);
+
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(process.env.GITHUB_OUTPUT, `mode=${mode}\n`, 'utf8');
+  }
 
   if (tokenTotals.calls > 0) {
     const totalIn = tokenTotals.input + tokenTotals.cacheRead + tokenTotals.cacheCreate;


### PR DESCRIPTION
## Summary
- `scripts/seo-review.mjs` now reports its resolved scan `mode` via `$GITHUB_OUTPUT`.
- `seo-review.yml` gates the sticky PR comment step on `mode != 'skipped-no-changes'`, so PRs that don't touch `src/pages/**` or `src/content/**` no longer get a "Skipped (mode: skipped-no-changes)" comment.
- Other skip modes (`skipped-broad-change`, `skipped-no-pages`) still post a comment, since those indicate a relevant change was made but scanned differently.

## Test plan
- [ ] Open a PR that doesn't touch `src/pages/**`/`src/content/**` and confirm no seo-review comment is posted.
- [ ] Open a PR that does touch a page and confirm the comment still posts as before.