### PR TITLE
fix: reject unsupported HTTP methods and drop unused tsconfig baseUrl

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -468,9 +468,18 @@ function handleSSR(req, res) {
   handler(req, res);
 }
 
+const ALLOWED_METHODS = new Set(['GET', 'HEAD', 'POST', 'OPTIONS']);
+
 const server = createServer((req, res) => {
   if (process.env.NODE_ENV !== 'production') {
     console.log(`[${new Date().toISOString()}] ${req.method} ${req.url}`);
+  }
+
+  // Reject TRACE and other unsupported methods (prevents Cross-Site Tracing / XST)
+  if (!ALLOWED_METHODS.has(req.method)) {
+    res.writeHead(405, { Allow: [...ALLOWED_METHODS].join(', ') });
+    res.end();
+    return;
   }
 
   const url = req.url.split('?')[0];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
   "compilerOptions": {
     "strictNullChecks": true,
     "allowJs": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"],
       "@components/*": ["./src/components/*"],


### PR DESCRIPTION
## Summary
- Reject TRACE and other non-standard HTTP methods with 405, preventing Cross-Site Tracing (XST)
- Remove unused `baseUrl` from tsconfig.json (redundant with existing path aliases)

## Test plan
- [x] Verify server still responds normally to GET/HEAD/POST/OPTIONS
- [x] Verify TRACE/other methods return 405 with correct Allow header
- [x] Verify TypeScript path aliases still resolve correctly