### PR TITLE
fix: prevent ERR_HTTP_HEADERS_SENT crash in proxy error handler

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -384,6 +384,10 @@ function handleProxy(req, res, target, cache = false) {
 
   proxyReq.on('error', (err) => {
     console.error('Proxy error:', err);
+    if (res.headersSent) {
+      res.destroy(err);
+      return;
+    }
     res.writeHead(502);
     res.end('Bad Gateway');
   });


### PR DESCRIPTION
## Summary
- The Mintlify reverse-proxy error handler in `server.mjs` (`handleProxy()`) always called `res.writeHead(502)` on any `proxyReq` error, even when the response had already started streaming to the client (headers already flushed).
- When the upstream connection to Mintlify drops mid-stream (socket reset, keep-alive close, etc. — common under k8s), this threw `ERR_HTTP_HEADERS_SENT` in production.
- Fix: check `res.headersSent` before writing a fresh 502 response; if headers were already sent, destroy the connection instead.

## Test plan
- [ ] Confirm `/docs/*` and other Mintlify-proxied routes still return 502 with a body when the upstream is unreachable from the start (headers not yet sent).
- [ ] Confirm no `ERR_HTTP_HEADERS_SENT` errors in logs after deploying, when upstream connections drop mid-response.