### PR TITLE
Reschedule community huddles and clean up event fields

### DIFF
--- a/src/content/events/08-2026-august-datum-monthly-community-huddle/index.mdx
+++ b/src/content/events/08-2026-august-datum-monthly-community-huddle/index.mdx
@@ -1,14 +1,12 @@
 ---
 name: August Community Huddle
 apiId: evt-IoElejp0AtYODZm
-startAt: "2026-08-12T16:00:00.000Z"
-endAt: "2026-08-12T17:00:00.000Z"
+startAt: "2026-08-19T16:00:00.000Z"
+endAt: "2026-08-19T17:00:00.000Z"
 timezone: America/New_York
-url: "https://luma.com/ewyvgsob"
+url: "https://luma.com/ewyvgsob?tk=UV9hrK"
 eventType: community-huddle
 coverImage: ./cover.png
-meetingUrl: "https://luma.com/6g9xhmzx"
-zoomMeetingUrl: "https://luma.com/6g9xhmzx"
 ---
 
 * To be announced

--- a/src/content/events/09-2026-september-datum-monthly-community-huddle/index.mdx
+++ b/src/content/events/09-2026-september-datum-monthly-community-huddle/index.mdx
@@ -1,14 +1,12 @@
 ---
 name: September Community Huddle
 apiId: evt-ypYTQkiIa2Dd1EO
-startAt: "2026-09-09T16:00:00.000Z"
-endAt: "2026-09-09T17:00:00.000Z"
+startAt: "2026-09-16T16:00:00.000Z"
+endAt: "2026-09-16T17:00:00.000Z"
 timezone: America/New_York
-url: "https://luma.com/l399k6qz"
+url: "https://luma.com/l399k6qz?tk=9auxAq"
 eventType: community-huddle
 coverImage: ./cover.png
-meetingUrl: "https://luma.com/6g9xhmzx"
-zoomMeetingUrl: "https://luma.com/6g9xhmzx"
 ---
 
 * To be announced


### PR DESCRIPTION
Update August and September community huddle events:
- Reschedule August event from Aug 12 to Aug 19
- Reschedule September event from Sep 9 to Sep 16
- Add tracking tokens to Luma event URLs
- Remove duplicate meetingUrl and zoomMeetingUrl fields