### PR TITLE
fix(handbook): correct broken Milo link from build/milo to product/milo

### DIFF
--- a/src/content/handbook/product/index.md
+++ b/src/content/handbook/product/index.md
@@ -44,7 +44,7 @@ We're aggressively maturing various platform features that help users adopt best
 * Service accounts, SSO, RBAC, and secrets
 * Activity & audit logs
 
-Finally, we're investing ahead of our own needs [with Milo](https://www.datum.net/handbook/build/milo/), a "system of action" purpose built to help modern cloud providers grow. Our hope and expectation is that we will collectively see thousands of new specialized providers take shape, and we'd like to collaborate on reducing the amount of undifferentiated investment folks have to do to show up, and scale up.
+Finally, we're investing ahead of our own needs [with Milo](https://www.datum.net/handbook/product/milo/), a "system of action" purpose built to help modern cloud providers grow. Our hope and expectation is that we will collectively see thousands of new specialized providers take shape, and we'd like to collaborate on reducing the amount of undifferentiated investment folks have to do to show up, and scale up.
 
 ## Product values
 It's hard to translate high level company values directly into daily work, so we've created a short list of product values to primarily help engineers move faster and with more confidence:


### PR DESCRIPTION
The link in `product/index.md` pointed to `/handbook/build/milo/` which returns 404 on production. The Milo page lives at `src/content/handbook/product/milo.md`, so the correct URL is `/handbook/product/milo/`.

**Before:** `https://www.datum.net/handbook/build/milo/` → 404  
**After:** `https://www.datum.net/handbook/product/milo/` → 200