### PR TITLE
feat: add honeypot and time-based check to BookDemo form

### DIFF
--- a/src/actions/demo.ts
+++ b/src/actions/demo.ts
@@ -20,8 +20,14 @@ const BookDemo = defineAction({
     workloadType: z.string(),
     message: z.string().optional(),
     formType: z.enum(['demo', 'dedicated-cloud']),
+    website: z.string().optional(),
+    elapsedMs: z.number(),
   }),
   handler: async (input) => {
+    if (input.website || input.elapsedMs < 3000) {
+      return { success: true };
+    }
+
     await sendMail({
       from: FROM_ADDRESSES[input.formType],
       to: 'support@datum.net',

--- a/src/components/forms/BookDemo.astro
+++ b/src/components/forms/BookDemo.astro
@@ -19,6 +19,11 @@ const { formType = 'demo' } = Astro.props as Props;
       class="border-silver-mist bg-glacier-mist-700 flex flex-col gap-7 border p-6 md:p-10 lg:p-20"
       onsubmit="return false;"
     >
+      <label class="absolute -left-[9999px]" aria-hidden="true">
+        <span>Website</span>
+        <input type="text" name="website" tabindex="-1" autocomplete="off" />
+      </label>
+
       <label class="flex flex-col gap-2">
         <span class="datum-text-xs text-midnight-fjord/80 font-semibold">Name</span>
         <input
@@ -95,6 +100,7 @@ const { formType = 'demo' } = Astro.props as Props;
     submitBtnText: HTMLElement;
     status: HTMLElement;
     isSubmitting = false;
+    loadedAt = Date.now();
 
     constructor() {
       super();
@@ -124,6 +130,8 @@ const { formType = 'demo' } = Astro.props as Props;
           workloadType: String(data.get('workloadType') || ''),
           message: String(data.get('message') || ''),
           formType: this.dataset.formType === 'dedicated-cloud' ? 'dedicated-cloud' : 'demo',
+          website: String(data.get('website') || ''),
+          elapsedMs: Date.now() - this.loadedAt,
         })
         .then((result) => {
           if (result.error) {


### PR DESCRIPTION
## Summary
- Add a hidden honeypot field (`website`) to the BookDemo form to catch auto-fill spam bots
- Add a time-based check that silently rejects submissions made <3s after the form loads
- Both checks fail silently (fake success response) so bots don't learn they're blocked, and real users are unaffected

## Test plan
- [ ] Fill out and submit the form normally on `/book-demo` and `/dedicated-cloud` (or wherever it's used) — confirm email is sent and success message shows
- [ ] Verify the honeypot field is visually hidden and not reachable via Tab key
- [ ] Confirm a submission made programmatically within 3s of page load does not trigger an email