### PR TITLE
feat(home): animate hero/grid graphics and text highlights on scroll

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -39,16 +39,21 @@ const [platformSection, resourcesSection, companySection] = navData.footer;
           </span>
 
           <div class="footer-prefooter-grid" aria-hidden="true">
-            <svg viewBox="0 0 255 282" fill="none" preserveAspectRatio="xMaxYMin slice">
-              <rect x="135" y="81.5" width="80" height="80" fill="#E6F59F" />
-              <rect x="16" y="121.5" width="40" height="40" fill="#E6F59F" />
-              <rect x="136" y="241.5" width="40" height="40" fill="#E6F59F" />
-              <path d="M215 0.5L215 120.5" stroke="#C3C6C9" />
-              <path d="M136 41.5L136 280.5" stroke="#C3C6C9" />
-              <path d="M56 121.5L56 160.5" stroke="#C3C6C9" />
-              <path d="M96 240.5H176" stroke="#C3C6C9" />
-              <path d="M0 160.5L176 160.5" stroke="#C3C6C9" />
-              <path d="M96 80.5L255 80.5" stroke="#C3C6C9" />
+            <svg
+              class="line-draw"
+              viewBox="0 0 255 282"
+              fill="none"
+              preserveAspectRatio="xMaxYMin slice"
+            >
+              <rect data-line-draw x="135" y="81.5" width="80" height="80" fill="#E6F59F" />
+              <rect data-line-draw x="16" y="121.5" width="40" height="40" fill="#E6F59F" />
+              <rect data-line-draw x="136" y="241.5" width="40" height="40" fill="#E6F59F" />
+              <path data-line-draw pathLength="1" d="M215 0.5L215 120.5" stroke="#C3C6C9" />
+              <path data-line-draw pathLength="1" d="M136 41.5L136 280.5" stroke="#C3C6C9" />
+              <path data-line-draw pathLength="1" d="M56 121.5L56 160.5" stroke="#C3C6C9" />
+              <path data-line-draw pathLength="1" d="M96 240.5H176" stroke="#C3C6C9" />
+              <path data-line-draw pathLength="1" d="M0 160.5L176 160.5" stroke="#C3C6C9" />
+              <path data-line-draw pathLength="1" d="M96 80.5L255 80.5" stroke="#C3C6C9" />
             </svg>
           </div>
           <div class="max-width-nopad flex flex-col items-center gap-5.5 pt-14 text-center md:gap-10 md:pt-24 lg:pt-28 xl:pt-32 2xl:pt-40">

--- a/src/components/home/DatumPlatform.astro
+++ b/src/components/home/DatumPlatform.astro
@@ -52,7 +52,7 @@ const pillars: { icon: string; title: string; description: string }[] = [
         <h2 class="section--title text-midnight-fjord">
           A modern{' '}
           <span
-            class="text-pine-forge---links bg-[linear-gradient(to_bottom,transparent_42%,var(--color-aurora-moss)_42%,var(--color-aurora-moss)_92%,transparent_92%)] box-decoration-clone px-1"
+            class="text-pine-forge---links text-highlight bg-[linear-gradient(to_bottom,transparent_42%,var(--color-aurora-moss)_42%,var(--color-aurora-moss)_92%,transparent_92%)] box-decoration-clone px-1"
             >edge cloud</span
           >, backed by open source
         </h2>

--- a/src/components/home/DedicatedCloud.astro
+++ b/src/components/home/DedicatedCloud.astro
@@ -31,7 +31,7 @@ const expertiseItems = [
       <div class="flex w-full flex-col items-center gap-7">
         <h2 class="section--title text-midnight-fjord text-center">
           <span
-            class="text-canyon-clay---links bg-[linear-gradient(to_bottom,transparent_42%,var(--color-blush-quartz)_42%,var(--color-blush-quartz)_92%,transparent_92%)] box-decoration-clone px-1"
+            class="text-canyon-clay---links text-highlight bg-[linear-gradient(to_bottom,transparent_42%,var(--color-blush-quartz)_42%,var(--color-blush-quartz)_92%,transparent_92%)] box-decoration-clone px-1"
             >Single-tenant</span
           >{' '}
           GPU, CPU, and network infrastructure.

--- a/src/components/home/HomeHero.astro
+++ b/src/components/home/HomeHero.astro
@@ -32,9 +32,9 @@ const { title = '', description = '' } = Astro.props as HomeHeroProps;
         <ButtonPlay class="home-hero-video-card-play" aria-hidden="true" />
       </button>
 
-      <HomeHeroGrid class="home-hero-xl:block z-11 hidden max-h-full" />
-      <HomeHeroGridLg class="home-hero-xl:hidden z-11 hidden min-h-full lg:block" />
-      <HomeHeroGridMd class="z-11 hidden min-h-full md:block lg:hidden" />
+      <HomeHeroGrid class="home-hero-xl:block line-draw z-11 hidden max-h-full" />
+      <HomeHeroGridLg class="home-hero-xl:hidden line-draw z-11 hidden min-h-full lg:block" />
+      <HomeHeroGridMd class="line-draw z-11 hidden min-h-full md:block lg:hidden" />
     </div>
 
     <div class="home-hero-layout max-width-nopad relative z-10">

--- a/src/components/home/WhatIsDatum.astro
+++ b/src/components/home/WhatIsDatum.astro
@@ -13,7 +13,7 @@ const { class: className = '' } = Astro.props;
     <span class="section-line section-line--left section-line--bottom lg:hidden"></span>
     <span class="section-line section-line--left section-line--top lg:hidden"></span>
     <WhatIsDatumGrid
-      class="pointer-events-none absolute top-0 left-0 z-0 hidden h-full max-h-[600px] w-auto lg:-left-8.25 lg:block xl:-left-10 2xl:-left-9"
+      class="line-draw pointer-events-none absolute top-0 left-0 z-0 hidden h-full max-h-[600px] w-auto lg:-left-8.25 lg:block xl:-left-10 2xl:-left-9"
       aria-hidden="true"
     />
     <div class:list={['large-pad relative', className]}>

--- a/src/content/pages/home.mdx
+++ b/src/content/pages/home.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Connected <br>infrastructure <br><span>for AI companies.</span>"
+title: "Connected <br>infrastructure <br><span class=\"text-highlight\">for AI companies.</span>"
 description: "Datum is a modern alternative to legacy CDN's, complex networks, and colocation. For alt clouds and tech-forward enterprises looking to scale, we provide \"hyperscale-style\" edge networking and connected CPU / GPU capacity."
 publishDate: 2025-03-04
 slug: "/"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -177,7 +177,7 @@ const twitterImageUrl = toAbsoluteUrl(twitterImage?.src ?? imageContent.src);
     <script>
       // Section label highlight — fires once per label as it enters the viewport
       (function initSectionLabels() {
-        const labels = document.querySelectorAll('.section-label, .mission-label');
+        const labels = document.querySelectorAll('.section-label, .mission-label, .text-highlight');
         for (const label of Array.from(labels) as HTMLElement[]) {
           let done = false;
           const obs = new IntersectionObserver(
@@ -190,6 +190,69 @@ const twitterImageUrl = toAbsoluteUrl(twitterImage?.src ?? imageContent.src);
             { threshold: 0.8 }
           );
           obs.observe(label);
+        }
+      })();
+
+      // Section divider lines — draw in once as their section enters the viewport
+      (function initSectionLines() {
+        const lines = document.querySelectorAll('.section-line, .section-line-h');
+        for (const line of Array.from(lines) as HTMLElement[]) {
+          let done = false;
+          const obs = new IntersectionObserver(
+            (entries) => {
+              if (entries[0].isIntersecting && !done) {
+                done = true;
+                line.classList.add('is-inview');
+                obs.unobserve(line);
+              }
+            },
+            { threshold: 0.1 }
+          );
+          obs.observe(line);
+        }
+      })();
+
+      // Blueprint-grid graphics (hero, next-row, pre-footer) — lines draw in,
+      // then accent squares pop, then any content panel fades in on top.
+      (function initLineDrawGraphics() {
+        const PATH_STEP_MS = 55;
+        const NODE_STEP_MS = 70;
+        const GROUP_GAP_MS = 120;
+
+        const graphics = document.querySelectorAll('.line-draw');
+        for (const graphic of Array.from(graphics) as HTMLElement[]) {
+          let done = false;
+          const obs = new IntersectionObserver(
+            (entries) => {
+              if (!entries[0].isIntersecting || done) return;
+              done = true;
+              obs.unobserve(graphic);
+
+              const paths = Array.from(
+                graphic.querySelectorAll('path[data-line-draw]')
+              ) as HTMLElement[];
+              const nodes = Array.from(
+                graphic.querySelectorAll('rect[data-line-draw]')
+              ) as HTMLElement[];
+              const panel = graphic.querySelector('[data-line-draw-panel]') as HTMLElement | null;
+
+              paths.forEach((el, i) =>
+                setTimeout(() => el.classList.add('is-inview'), i * PATH_STEP_MS)
+              );
+
+              const nodesStart = paths.length * PATH_STEP_MS + GROUP_GAP_MS;
+              nodes.forEach((el, i) =>
+                setTimeout(() => el.classList.add('is-inview'), nodesStart + i * NODE_STEP_MS)
+              );
+
+              if (panel) {
+                const panelStart = nodesStart + nodes.length * NODE_STEP_MS + GROUP_GAP_MS;
+                setTimeout(() => panel.classList.add('is-inview'), panelStart);
+              }
+            },
+            { threshold: 0.2 }
+          );
+          obs.observe(graphic);
         }
       })();
     </script>

--- a/src/static/assets/svgs/player-full-lg.svg
+++ b/src/static/assets/svgs/player-full-lg.svg
@@ -1,24 +1,24 @@
 <svg width="468" height="637" viewBox="0 0 468 637" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect opacity="0.7" x="360" y="40" width="80" height="80" fill="#F6F6F5" />
-  <rect opacity="0.7" y="504" width="40" height="40" fill="#F6F6F5" />
-  <rect opacity="0.7" x="360" y="504" width="80" height="80" fill="#F6F6F5" />
-  <rect opacity="0.7" x="321" y="584" width="40" height="40" fill="#F6F6F5" />
-  <rect opacity="0.7" x="241" y="80" width="40" height="40" fill="#F6F6F5" />
-  <path d="M440 -80L440 79" stroke="#C3C6C9" />
-  <path d="M361 40L361 119" stroke="#C3C6C9" />
-  <path d="M281 80L281 119" stroke="#C3C6C9" />
-  <path d="M281 504L281 543" stroke="#C3C6C9" />
-  <path d="M337.495 423.496L376.495 423.496" stroke="#C3C6C9" />
-  <path d="M338.495 199.496L377.495 199.496" stroke="#C3C6C9" />
-  <path d="M225 119L401 119" stroke="#C3C6C9" />
-  <path d="M321 39L440 39" stroke="#C3C6C9" />
-  <path d="M361 504L361 624" stroke="#C3C6C9" />
-  <path d="M40 504L40 544" stroke="#C3C6C9" />
-  <path d="M0 504H40" stroke="#C3C6C9" />
-  <path d="M202 504H401" stroke="#C3C6C9" />
-  <path d="M440 544L440 729" stroke="#C3C6C9" />
-  <path d="M322 584H441" stroke="#C3C6C9" />
-  <g filter="url(#filter0_d_15440_2049)">
+  <rect data-line-draw opacity="0.7" x="360" y="40" width="80" height="80" fill="#F6F6F5" />
+  <rect data-line-draw opacity="0.7" y="504" width="40" height="40" fill="#F6F6F5" />
+  <rect data-line-draw opacity="0.7" x="360" y="504" width="80" height="80" fill="#F6F6F5" />
+  <rect data-line-draw opacity="0.7" x="321" y="584" width="40" height="40" fill="#F6F6F5" />
+  <rect data-line-draw opacity="0.7" x="241" y="80" width="40" height="40" fill="#F6F6F5" />
+  <path data-line-draw pathLength="1" d="M440 -80L440 79" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M361 40L361 119" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M281 80L281 119" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M281 504L281 543" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M337.495 423.496L376.495 423.496" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M338.495 199.496L377.495 199.496" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M225 119L401 119" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M321 39L440 39" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M361 504L361 624" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M40 504L40 544" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M0 504H40" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M202 504H401" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M440 544L440 729" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M322 584H441" stroke="#C3C6C9" />
+  <g data-line-draw-panel filter="url(#filter0_d_15440_2049)">
     <rect x="40" y="119" width="532" height="385" fill="url(#paint0_linear_15440_2049)"
       shape-rendering="crispEdges" />
     <rect x="40" y="119" width="532" height="385" stroke="#C3C6C9" shape-rendering="crispEdges" />

--- a/src/static/assets/svgs/player-full-md.svg
+++ b/src/static/assets/svgs/player-full-md.svg
@@ -1,21 +1,21 @@
 <svg width="307" height="531" viewBox="0 0 307 531" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect opacity="0.7" x="199" y="-9" width="80" height="80" fill="#F6F6F5" />
-  <rect opacity="0.7" y="455" width="40" height="40" fill="#F6F6F5" />
-  <rect opacity="0.7" x="199" y="455" width="80" height="80" fill="#F6F6F5" />
-  <rect opacity="0.7" x="80" y="31" width="40" height="40" fill="#F6F6F5" />
-  <path d="M279 -129L279 30" stroke="#C3C6C9" />
-  <path d="M200 -9L200 70" stroke="#C3C6C9" />
-  <path d="M120 31L120 70" stroke="#C3C6C9" />
-  <path d="M120 455L120 494" stroke="#C3C6C9" />
-  <path d="M176.495 374.496L215.495 374.496" stroke="#C3C6C9" />
-  <path d="M177.495 150.496L216.495 150.496" stroke="#C3C6C9" />
-  <path d="M64 70L240 70" stroke="#C3C6C9" />
-  <path d="M200 455L200 575" stroke="#C3C6C9" />
-  <path d="M40 455L40 495" stroke="#C3C6C9" />
-  <path d="M0 455H40" stroke="#C3C6C9" />
-  <path d="M41 455H240" stroke="#C3C6C9" />
-  <path d="M279 495L279 680" stroke="#C3C6C9" />
-  <g filter="url(#filter0_d_15440_2053)">
+  <rect data-line-draw opacity="0.7" x="199" y="-9" width="80" height="80" fill="#F6F6F5" />
+  <rect data-line-draw opacity="0.7" y="455" width="40" height="40" fill="#F6F6F5" />
+  <rect data-line-draw opacity="0.7" x="199" y="455" width="80" height="80" fill="#F6F6F5" />
+  <rect data-line-draw opacity="0.7" x="80" y="31" width="40" height="40" fill="#F6F6F5" />
+  <path data-line-draw pathLength="1" d="M279 -129L279 30" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M200 -9L200 70" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M120 31L120 70" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M120 455L120 494" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M176.495 374.496L215.495 374.496" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M177.495 150.496L216.495 150.496" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M64 70L240 70" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M200 455L200 575" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M40 455L40 495" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M0 455H40" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M41 455H240" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M279 495L279 680" stroke="#C3C6C9" />
+  <g data-line-draw-panel filter="url(#filter0_d_15440_2053)">
     <rect x="40" y="70" width="532" height="385" fill="url(#paint0_linear_15440_2053)"
       shape-rendering="crispEdges" />
     <rect x="40" y="70" width="532" height="385" stroke="#C3C6C9" shape-rendering="crispEdges" />

--- a/src/static/assets/svgs/player-full.svg
+++ b/src/static/assets/svgs/player-full.svg
@@ -1,25 +1,25 @@
 <svg width="675" height="804" viewBox="0 0 675 804" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect opacity="0.7" x="594" y="120" width="80" height="80" fill="#F6F6F5" />
-  <rect opacity="0.7" y="584" width="40" height="40" fill="#F6F6F5" />
-  <rect opacity="0.7" x="594" y="584" width="80" height="80" fill="#F6F6F5" />
-  <rect opacity="0.7" x="555" y="664" width="40" height="40" fill="#F6F6F5" />
-  <rect opacity="0.7" x="475" y="160" width="40" height="40" fill="#F6F6F5" />
-  <path d="M674 0L674 159" stroke="#C3C6C9" />
-  <path d="M595 120L595 199" stroke="#C3C6C9" />
-  <path d="M515 160L515 199" stroke="#C3C6C9" />
-  <path d="M515 584L515 623" stroke="#C3C6C9" />
-  <path d="M571.495 503.496L610.495 503.496" stroke="#C3C6C9" />
-  <path d="M0.495117 503.496L39.4951 503.496" stroke="#C3C6C9" />
-  <path d="M572.495 279.496L611.495 279.496" stroke="#C3C6C9" />
-  <path d="M459 199L635 199" stroke="#C3C6C9" />
-  <path d="M555 119L674 119" stroke="#C3C6C9" />
-  <path d="M595 584L595 704" stroke="#C3C6C9" />
-  <path d="M40 584L40 624" stroke="#C3C6C9" />
-  <path d="M0 584H40" stroke="#C3C6C9" />
-  <path d="M436 584H635" stroke="#C3C6C9" />
-  <path d="M674 624L674 809" stroke="#C3C6C9" />
-  <path d="M556 664H675" stroke="#C3C6C9" />
-  <g filter="url(#filter0_d_15383_44993)">
+  <rect data-line-draw opacity="0.7" x="594" y="120" width="80" height="80" fill="#F6F6F5" />
+  <rect data-line-draw opacity="0.7" y="584" width="40" height="40" fill="#F6F6F5" />
+  <rect data-line-draw opacity="0.7" x="594" y="584" width="80" height="80" fill="#F6F6F5" />
+  <rect data-line-draw opacity="0.7" x="555" y="664" width="40" height="40" fill="#F6F6F5" />
+  <rect data-line-draw opacity="0.7" x="475" y="160" width="40" height="40" fill="#F6F6F5" />
+  <path data-line-draw pathLength="1" d="M674 0L674 159" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M595 120L595 199" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M515 160L515 199" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M515 584L515 623" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M571.495 503.496L610.495 503.496" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M0.495117 503.496L39.4951 503.496" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M572.495 279.496L611.495 279.496" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M459 199L635 199" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M555 119L674 119" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M595 584L595 704" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M40 584L40 624" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M0 584H40" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M436 584H635" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M674 624L674 809" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M556 664H675" stroke="#C3C6C9" />
+  <g data-line-draw-panel filter="url(#filter0_d_15383_44993)">
     <rect x="40" y="199" width="532" height="385" fill="url(#paint0_linear_15383_44993)"
       shape-rendering="crispEdges" />
     <rect x="40" y="199" width="532" height="385" stroke="#C3C6C9" shape-rendering="crispEdges" />
@@ -79,8 +79,7 @@
       <feColorMatrix type="matrix"
         values="0 0 0 0 0.0470588 0 0 0 0 0.113725 0 0 0 0 0.192157 0 0 0 0.6 0" />
       <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_15383_44993" />
-      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_15383_44993"
-        result="shape" />
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_15383_44993" result="shape" />
     </filter>
     <linearGradient id="paint0_linear_15383_44993" x1="306" y1="199" x2="306" y2="584"
       gradientUnits="userSpaceOnUse">

--- a/src/static/assets/svgs/what-is-datum-grid.svg
+++ b/src/static/assets/svgs/what-is-datum-grid.svg
@@ -1,15 +1,15 @@
 <svg width="201" height="600" viewBox="0 0 201 600" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect opacity="0.6" x="120" y="160" width="80" height="80" fill="#EFEFED"/>
-<rect opacity="0.6" x="80" y="80" width="40" height="40" fill="#EFEFED"/>
-<path d="M40 0L40 160" stroke="#C3C6C9"/>
-<path d="M120 80L120 200" stroke="#C3C6C9"/>
-<path d="M0 80H160" stroke="#C3C6C9"/>
-<path d="M200 446L200 120" stroke="#C3C6C9"/>
-<path d="M120 160H200" stroke="#C3C6C9"/>
-<rect opacity="0.6" x="159" y="400" width="40" height="40" fill="#EFEFED"/>
-<path d="M120 440L120 560" stroke="#C3C6C9"/>
-<path d="M200 480L200 440" stroke="#C3C6C9"/>
-<path d="M40 520H120" stroke="#C3C6C9"/>
-<path d="M80 440H200" stroke="#C3C6C9"/>
-<path d="M40 520L40 600" stroke="#C3C6C9"/>
+<rect data-line-draw opacity="0.6" x="120" y="160" width="80" height="80" fill="#EFEFED"/>
+<rect data-line-draw opacity="0.6" x="80" y="80" width="40" height="40" fill="#EFEFED"/>
+<path data-line-draw pathLength="1" d="M40 0L40 160" stroke="#C3C6C9"/>
+<path data-line-draw pathLength="1" d="M120 80L120 200" stroke="#C3C6C9"/>
+<path data-line-draw pathLength="1" d="M0 80H160" stroke="#C3C6C9"/>
+<path data-line-draw pathLength="1" d="M200 446L200 120" stroke="#C3C6C9"/>
+<path data-line-draw pathLength="1" d="M120 160H200" stroke="#C3C6C9"/>
+<rect data-line-draw opacity="0.6" x="159" y="400" width="40" height="40" fill="#EFEFED"/>
+<path data-line-draw pathLength="1" d="M120 440L120 560" stroke="#C3C6C9"/>
+<path data-line-draw pathLength="1" d="M200 480L200 440" stroke="#C3C6C9"/>
+<path data-line-draw pathLength="1" d="M40 520H120" stroke="#C3C6C9"/>
+<path data-line-draw pathLength="1" d="M80 440H200" stroke="#C3C6C9"/>
+<path data-line-draw pathLength="1" d="M40 520L40 600" stroke="#C3C6C9"/>
 </svg>

--- a/src/static/styles/base.css
+++ b/src/static/styles/base.css
@@ -74,6 +74,8 @@
 
 @import './components.css';
 
+@import './components-line-draw.css';
+
 @import './components-hero.css';
 
 @import './components-nav.css';

--- a/src/static/styles/components-line-draw.css
+++ b/src/static/styles/components-line-draw.css
@@ -1,0 +1,86 @@
+@layer components {
+  /* Scroll-triggered "line draw" reveal for decorative blueprint-grid SVGs
+     (hero graphic, next-row grid, pre-footer grid) and section divider lines.
+     Classes are toggled by the observers in src/layouts/Layout.astro. */
+
+  .line-draw path[data-line-draw] {
+    stroke-dasharray: 1;
+    stroke-dashoffset: 1;
+    transition: stroke-dashoffset 0.65s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .line-draw path[data-line-draw].is-inview {
+    stroke-dashoffset: 0;
+  }
+
+  .line-draw rect[data-line-draw] {
+    transform-box: fill-box;
+    transform-origin: center;
+    transform: scale(0.4);
+    transition: transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+
+  .line-draw rect[data-line-draw].is-inview {
+    transform: scale(1);
+  }
+
+  .line-draw [data-line-draw-panel] {
+    opacity: 0;
+    transition: opacity 0.6s ease;
+  }
+
+  .line-draw [data-line-draw-panel].is-inview {
+    opacity: 1;
+  }
+
+  .section-line,
+  .section-line-h {
+    transition: transform 0.55s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .section-line {
+    transform: scaleY(0);
+    transform-origin: top;
+  }
+
+  .section-line--bottom {
+    transform-origin: bottom;
+  }
+
+  .section-line-h {
+    transform: scaleX(0);
+    transform-origin: left;
+  }
+
+  .section-line.is-inview,
+  .section-line-h.is-inview {
+    transform: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .line-draw path[data-line-draw],
+    .line-draw rect[data-line-draw],
+    .line-draw [data-line-draw-panel],
+    .section-line,
+    .section-line-h {
+      transition: none !important;
+    }
+
+    .line-draw path[data-line-draw] {
+      stroke-dashoffset: 0 !important;
+    }
+
+    .line-draw rect[data-line-draw] {
+      transform: none !important;
+    }
+
+    .line-draw [data-line-draw-panel] {
+      opacity: 1 !important;
+    }
+
+    .section-line,
+    .section-line-h {
+      transform: none !important;
+    }
+  }
+}

--- a/src/static/styles/components.css
+++ b/src/static/styles/components.css
@@ -29,6 +29,18 @@
     background-image: linear-gradient(var(--color-glacier-mist-900), var(--color-glacier-mist-900));
   }
 
+  /* Inline text highlight (marker-style band behind text) — reveals left to
+     right on scroll, same background-size mechanic as .section-label. */
+  .text-highlight {
+    background-size: 0% 100%;
+    background-repeat: no-repeat;
+    background-position: left center;
+    transition: background-size 0.7s cubic-bezier(0.4, 0, 0.2, 1);
+    &.highlight-animate {
+      background-size: 100% 100%;
+    }
+  }
+
   .section-eyebrow {
     @apply font-dejavu datum-text-sm text-canyon-clay---links inline-flex items-center gap-2.5 whitespace-nowrap uppercase;
 


### PR DESCRIPTION
## Summary
- Adds a scroll-triggered "line draw" reveal for the homepage's decorative blueprint-grid SVGs — hero graphic (`player-full*.svg`), "next row" grid (`what-is-datum-grid.svg`), and the footer pre-footer grid. Grid lines draw in via `stroke-dashoffset`, accent squares pop in staggered after, and (hero only) the card mockup panel fades in last.
- Extends the site's existing `.section-label` IntersectionObserver convention in `Layout.astro` to also cover `.section-line`/`.section-line-h` divider spans (site-wide) and two inline text highlights (hero title "for AI companies.", DedicatedCloud "Single-tenant"), reusing the same background-size reveal mechanic already used for `.section-label`.
- Respects `prefers-reduced-motion: reduce` (final state shown immediately, no transitions).
- Reverted a bad first pass on `DedicatedCloud.astro`'s two corner divider lines — they intentionally use `bg-midnight-fjord` (matching the dark card) so the ~40px segment that overlaps the card blends in, while the segment outside the card shows as a normal divider line.

## Test plan
- [x] Verified in a real browser (Playwright) that hero, next-row, and pre-footer graphics all draw in correctly on scroll, sequenced lines → squares → panel
- [x] Verified `.section-line` dividers reveal site-wide via the shared observer
- [x] Verified both text highlights ("for AI companies.", "Single-tenant") sweep in on scroll
- [x] Confirmed no console errors during animation playback
- [x] `prettier --check` and `eslint` pass on all changed files
