### PR TITLE
style(nav,home,modal): align colors, weights, and modal blur

### DIFF
--- a/src/static/styles/components-home.css
+++ b/src/static/styles/components-home.css
@@ -33,7 +33,7 @@
     @apply datum-text-10xl xl:datum-text-11xl text-midnight-fjord m-0 max-w-none text-center leading-none! md:text-left;
 
     span {
-      @apply text-pine-forge---links box-decoration-clone px-1;
+      @apply text-canyon-clay---links box-decoration-clone px-1;
       background-image: linear-gradient(
         to bottom,
         transparent 42%,

--- a/src/static/styles/components-modal.css
+++ b/src/static/styles/components-modal.css
@@ -48,11 +48,11 @@
   }
 
   media-lightbox dialog::backdrop {
-    @apply bg-glacier-mist-900/80 backdrop-blur;
+    @apply bg-app---dark---utility-4/50 backdrop-blur-[7px];
   }
 
   .media-lightbox-frame {
-    @apply items-center justify-center;
+    @apply items-center justify-center p-4 md:p-10;
   }
 
   .media-lightbox-content {
@@ -100,7 +100,7 @@
   }
 
   .community-huddle-past-modal__dialog::backdrop {
-    @apply bg-glacier-mist-900/80 backdrop-blur-[9px];
+    @apply bg-app---dark---utility-4/50 backdrop-blur-[7px];
   }
 
   .community-huddle-past-modal__frame {
@@ -205,7 +205,7 @@
   }
 
   newsletter-modal dialog::backdrop {
-    @apply bg-glacier-mist-900/80 backdrop-blur;
+    @apply bg-app---dark---utility-4/50 backdrop-blur-[7px];
   }
 
   /* Newsletter modal — Figma Card (node 9185-41852): 360px, 40px pad, 9px radius */
@@ -276,7 +276,7 @@
   }
 
   markdown-lightbox dialog::backdrop {
-    @apply bg-glacier-mist-900/80 backdrop-blur;
+    @apply bg-app---dark---utility-4/50 backdrop-blur-[7px];
   }
 
   .markdown-lightbox__frame {

--- a/src/static/styles/components-nav.css
+++ b/src/static/styles/components-nav.css
@@ -81,23 +81,23 @@
     }
 
     .nav-menu-link {
-      @apply datum-text-base flex h-9 items-center gap-2 rounded-sm px-3 font-normal opacity-80 transition-colors duration-150;
+      @apply datum-text-base flex h-9 items-center gap-2 rounded-sm px-3 font-medium opacity-80 transition-colors duration-150;
 
       &.link--active {
         @apply font-semibold;
       }
     }
 
-    /* Pill: hover preview (normal weight) vs route-active pill (semibold) */
+    /* Pill: hover preview (medium weight) vs route-active pill (semibold) */
     .nav-menu-item:hover > .nav-menu-link:not(.link--active),
     .nav-dropdown:focus-within > .nav-menu-link:not(.link--active) {
-      @apply bg-glacier-mist-800 text-canyon-clay font-normal;
+      @apply bg-glacier-mist-800 text-canyon-clay---links font-medium;
     }
 
     .nav-menu:not(:has(.nav-menu-item:hover)) .nav-menu-link.link--active,
     .nav-menu-item:hover > .nav-menu-link.link--active,
     .nav-dropdown:focus-within > .nav-menu-link.link--active {
-      @apply bg-glacier-mist-800 text-canyon-clay font-semibold;
+      @apply bg-glacier-mist-800 text-canyon-clay---links font-semibold;
     }
   }
 

--- a/src/static/styles/page-about.css
+++ b/src/static/styles/page-about.css
@@ -56,7 +56,7 @@
   }
 
   profile-modal dialog::backdrop {
-    @apply bg-glacier-mist-900/80 backdrop-blur;
+    @apply bg-app---dark---utility-4/50 backdrop-blur-[7px];
   }
 
   .profile-modal--frame {

--- a/src/static/styles/page-hello.css
+++ b/src/static/styles/page-hello.css
@@ -267,7 +267,7 @@
   }
 
   hello-modal dialog::backdrop {
-    @apply bg-app---dark---utility-2/50 backdrop-blur;
+    @apply bg-app---dark---utility-4/50 backdrop-blur-[7px];
   }
 
   .hello-modal--frame {


### PR DESCRIPTION
Apply small design revisions from review feedback: highlight text and nav hover color now use Canyon Clay - Links, nav item font weight matches Figma's Medium spec, and all modal backdrops share the same blurred background used by the primary nav dropdown. Also reduce the video lightbox padding on mobile.