### PR TITLE
fix(roadmap): show real backlog status instead of GitHub labels

### DIFF
--- a/src/components/roadmap/RoadmapBacklogRow.astro
+++ b/src/components/roadmap/RoadmapBacklogRow.astro
@@ -9,9 +9,6 @@ interface Props {
 
 const { item } = Astro.props as Props;
 
-/** Temporarily hide status badges on the backlog list; set true to show again. */
-const SHOW_BACKLOG_STATUS = false;
-
 const statusClassMap: Record<GitHubBacklogStatus, string> = {
   'In progress': 'roadmap-backlog-status--in-progress',
   Planned: 'roadmap-backlog-status--planned',
@@ -28,27 +25,11 @@ const statusClassMap: Record<GitHubBacklogStatus, string> = {
 >
   <span class="roadmap-backlog-number">#{item.number}</span>
 
-  {
-    SHOW_BACKLOG_STATUS && (
-      <span class:list={['roadmap-backlog-status', statusClassMap[item.status]]}>
-        {item.status}
-      </span>
-    )
-  }
+  <span class:list={['roadmap-backlog-status', statusClassMap[item.status]]}>
+    {item.status}
+  </span>
 
   <h3 class="roadmap-backlog-title">{item.title}</h3>
-
-  {
-    item.labels.length > 0 && (
-      <ul class="roadmap-backlog-labels" aria-label="Labels">
-        {item.labels.map((label) => (
-          <li>
-            <span class="roadmap-backlog-badge">{label}</span>
-          </li>
-        ))}
-      </ul>
-    )
-  }
 
   <span class="roadmap-backlog-link">
     GitHub

--- a/src/data/navigation.json
+++ b/src/data/navigation.json
@@ -80,9 +80,9 @@
   ],
   "footer": [
     {
-      "title": "Platform features",
+      "title": "Platform",
       "items": [
-        { "text": "Product Features", "href": "/features" },
+        { "text": "Features", "href": "/features" },
         { "text": "Essentials", "href": "/essentials" },
         { "text": "Locations", "href": "/locations" }
       ]

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -199,11 +199,11 @@ const jsonLd = {
             </div>
           </section>
 
-          <!-- Section 3: Connectors -->
+          <!-- Section 3: Connections -->
           <section class="features-section">
             <div class="features-section-header">
               <div>
-                <span class="section-label">Connectors_</span>
+                <span class="section-label">Connections_</span>
               </div>
               <div class="features-section-header-text">
                 <h2 class="section-title max-w-2xl">


### PR DESCRIPTION
Issue #1484

## Summary
- Roadmap backlog list was rendering raw GitHub labels, which didn't align with the Planned/In progress/Backlog status columns and confused users — now shows the actual status badge and drops the label list.
- Minor nav copy tweak: "Platform features" → "Platform", "Product Features" → "Features".
- Renamed the features page "Connectors" section to "Connections".

## Test plan
- [ ] Visit `/roadmap/backlog/` and confirm each item shows the correct status (Backlog/Planned/In progress) instead of GitHub labels
- [ ] Check nav dropdown renders "Platform" / "Features" correctly
- [ ] Check `/features` page Section 3 heading reads "Connections_"