### PR TITLE
fix(download): remove SDKs group from download nav

### DIFF
--- a/src/data/downloads.json
+++ b/src/data/downloads.json
@@ -39,32 +39,6 @@
           "icon": "workflow"
         }
       ]
-    },
-    {
-      "title": "SDKs",
-      "items": [
-        {
-          "id": "go",
-          "label": "Go",
-          "icon": "go",
-          "href": "/download/go",
-          "badge": "Coming"
-        },
-        {
-          "id": "typescript",
-          "label": "TypeScript",
-          "icon": "ts",
-          "href": "/download/typescript",
-          "badge": "Coming"
-        },
-        {
-          "id": "rust",
-          "label": "Rust",
-          "icon": "rust",
-          "href": "/download/rust",
-          "badge": "Coming"
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
Go/TypeScript/Rust SDK pages stay live, just unlinked from nav until ready to announce.