### PR TITLE
feat(home): add scroll-triggered module animations

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -7,6 +7,7 @@ import type { FooterProps } from '@/src/types/common';
 import ImageFooter from '@assets/images/footer-illustration.png';
 import Button from '@components/Button.astro';
 import Icon from '@components/Icon.astro';
+import SectionEyebrow from '@components/SectionEyebrow.astro';
 import ImageTwoMen from '@assets/images/two-person-talking.png';
 import NewsletterModal from '@components/forms/NewsletterModal.astro';
 import FooterAiAgents from '@components/FooterAiAgents.astro';
@@ -32,9 +33,9 @@ const [platformSection, resourcesSection, companySection] = navData.footer;
       <div class="footer-prefooter px-4 sm:px-7">
         <div class="max-width-nav relative">
           <span class="section-line section-line--left section-line--top" />
-          <span class="section-eyebrow section-eyebrow--midnight-fjord section-eyebrow--left-top">
+          <SectionEyebrow variant="midnight-fjord" position="left-top">
             Get started
-          </span>
+          </SectionEyebrow>
 
           <div class="footer-prefooter-grid" aria-hidden="true">
             <svg

--- a/src/components/SectionEyebrow.astro
+++ b/src/components/SectionEyebrow.astro
@@ -1,0 +1,25 @@
+---
+// src/components/SectionEyebrow.astro
+import type { SectionEyebrowProps } from '@/src/types/common';
+
+const { class: className = '', variant, position } = Astro.props as SectionEyebrowProps;
+
+const variantClass =
+  variant === 'pine'
+    ? 'section-eyebrow--pine'
+    : variant === 'midnight-fjord'
+      ? 'section-eyebrow--midnight-fjord'
+      : '';
+
+const positionClass =
+  position === 'left-top'
+    ? 'section-eyebrow--left-top'
+    : position === 'left-top-keyline'
+      ? 'section-eyebrow--left-top-keyline'
+      : '';
+---
+
+<span class:list={['section-eyebrow', variantClass, positionClass, className]} data-eyebrow-typeout>
+  <span class="section-eyebrow-cursor" aria-hidden="true"></span>
+  <span class="section-eyebrow-text"><slot /></span>
+</span>

--- a/src/components/home/DatumPlatform.astro
+++ b/src/components/home/DatumPlatform.astro
@@ -3,6 +3,7 @@
 import { Image } from 'astro:assets';
 import Button from '@components/Button.astro';
 import Icon from '@components/Icon.astro';
+import SectionEyebrow from '@components/SectionEyebrow.astro';
 import dashboardImage from '@assets/images/datum-platform-dashboard.png';
 import dashboardImageMobile from '@assets/images/datum-platform-dashboard-mobile.png';
 const { class: className = '' } = Astro.props;
@@ -38,17 +39,19 @@ const pillars: { icon: string; title: string; description: string }[] = [
 <section
   id="datum-platform"
   class:list={[
-    'section--block section--block--x-pad border-silver-mist overflow-hidden border-t bg-white',
+    'section--block section--block--x-pad border-silver-mist relative overflow-hidden bg-white',
     className,
   ]}
+  data-module-wipe
 >
+  <span class="module-border-wipe" aria-hidden="true"></span>
   <div class="max-width-nav large-pad relative">
     <span class="section-line section-line--left section-line--bottom"></span>
     <span class="section-line section-line--left section-line--top"></span>
 
     <div class="max-width-nopad flex flex-col items-center gap-10 md:gap-16">
       <div class="spacing-pad flex w-full flex-col items-center gap-7 text-center">
-        <span class="section-eyebrow section-eyebrow--pine">The Datum Platform</span>
+        <SectionEyebrow variant="pine">The Datum Platform</SectionEyebrow>
         <h2 class="section--title text-midnight-fjord">
           A modern{' '}
           <span

--- a/src/components/home/DedicatedCloud.astro
+++ b/src/components/home/DedicatedCloud.astro
@@ -3,6 +3,7 @@
 import { Image } from 'astro:assets';
 import Button from '@components/Button.astro';
 import Icon from '@components/Icon.astro';
+import SectionEyebrow from '@components/SectionEyebrow.astro';
 import starfieldImage from '@assets/images/dedicated-cloud-starfield.png';
 
 const { class: className = '' } = Astro.props;
@@ -17,15 +18,17 @@ const expertiseItems = [
 <section
   id="dedicated-cloud"
   class:list={[
-    'section--block bg-platinum border-silver-mist section--block--x-pad relative overflow-hidden border-t',
+    'section--block bg-platinum border-silver-mist section--block--x-pad relative overflow-hidden',
     className,
   ]}
+  data-module-wipe
 >
+  <span class="module-border-wipe" aria-hidden="true"></span>
   <div class="max-width-nav large-pad relative">
     <span class="section-line section-line--left section-line--bottom"></span>
     <span class="section-line section-line--left section-line--top"></span>
     <span class="section-line section-line--right section-line--bottom"></span>
-    <span class="section-eyebrow section-eyebrow--left-top"> Dedicated cloud </span>
+    <SectionEyebrow position="left-top">Dedicated cloud</SectionEyebrow>
 
     <div class="max-width-nopad flex flex-col items-center gap-10 md:gap-16">
       <div class="flex w-full flex-col items-center gap-7">

--- a/src/components/home/HomeHero.astro
+++ b/src/components/home/HomeHero.astro
@@ -16,7 +16,7 @@ const { title = '', description = '' } = Astro.props as HomeHeroProps;
 
 <section class="section--block section--block--x-pad bg-white" aria-labelledby="home-hero-title">
   <div class="max-width-nav relative">
-    <span class="section-line section-line--left section-line--top"></span>
+    {/* Top-left line continues as the sticky module connector — see ModuleConnector.astro */}
     <span class="section-line section-line--left section-line--bottom"></span>
     <span class="section-line section-line--right section-line--top md:hidden"></span>
     <div

--- a/src/components/home/ModuleConnector.astro
+++ b/src/components/home/ModuleConnector.astro
@@ -1,0 +1,15 @@
+---
+// src/components/home/ModuleConnector.astro
+// Continuation of the hero's top-left `.section-line` — instead of scrolling
+// away with the hero, it sticks to the top of the viewport as the user
+// scrolls through the wrapped modules (see index.astro), cueing the
+// border-wipe reveal on whichever module it currently sits beside (see
+// module-animate.js). Nested in a `max-width-nav` box so its left edge
+// lines up with every module's own `.section-line--left` at `left-0`.
+---
+
+<div class="module-connector" aria-hidden="true">
+  <div class="max-width-nav relative h-full">
+    <span class="module-connector-bar"></span>
+  </div>
+</div>

--- a/src/components/home/WhatIsDatum.astro
+++ b/src/components/home/WhatIsDatum.astro
@@ -1,14 +1,17 @@
 ---
 // src/components/home/WhatIsDatum.astro
 import WhatIsDatumGrid from '@assets/svgs/what-is-datum-grid.svg';
+import SectionEyebrow from '@components/SectionEyebrow.astro';
 
 const { class: className = '' } = Astro.props;
 ---
 
 <section
   id="what-is-datum"
-  class="section--block bg-platinum border-silver-mist section--block--x-pad overflow-hidden border-t"
+  class="section--block bg-platinum border-silver-mist section--block--x-pad relative overflow-hidden"
+  data-module-wipe
 >
+  <span class="module-border-wipe" aria-hidden="true"></span>
   <div class="max-width-nav relative px-0">
     <span class="section-line section-line--left section-line--bottom lg:hidden"></span>
     <span class="section-line section-line--left section-line--top lg:hidden"></span>
@@ -21,7 +24,7 @@ const { class: className = '' } = Astro.props;
         class="relative z-10 mx-auto flex w-full flex-col gap-7 md:pr-30 md:pl-0 lg:pl-50 xl:pr-40 xl:pl-60 2xl:pr-40 2xl:pl-60"
       >
         <div class="spacing-pad flex flex-col gap-7">
-          <span class="section-eyebrow">What is Datum?</span>
+          <SectionEyebrow>What is Datum?</SectionEyebrow>
           <div
             class="datum-text-2xl text-midnight-fjord flex flex-col gap-7 text-pretty [&>p]:opacity-80"
           >

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -175,91 +175,9 @@ const twitterImageUrl = toAbsoluteUrl(twitterImage?.src ?? imageContent.src);
     </main>
     <script>
       import '@/src/static/scripts/scroll-effects.js';
+      import '@/src/static/scripts/module-animate.js';
     </script>
 
     <LayoutEmbedScripts isProduction={isProduction} />
-
-    <script>
-      // Section label highlight — fires once per label as it enters the viewport
-      (function initSectionLabels() {
-        const labels = document.querySelectorAll('.section-label, .mission-label, .text-highlight');
-        for (const label of Array.from(labels) as HTMLElement[]) {
-          let done = false;
-          const obs = new IntersectionObserver(
-            (entries) => {
-              if (entries[0].isIntersecting && !done) {
-                done = true;
-                label.classList.add('highlight-animate');
-              }
-            },
-            { threshold: 0.8 }
-          );
-          obs.observe(label);
-        }
-      })();
-
-      // Section divider lines — draw in once as their section enters the viewport
-      (function initSectionLines() {
-        const lines = document.querySelectorAll('.section-line, .section-line-h');
-        for (const line of Array.from(lines) as HTMLElement[]) {
-          let done = false;
-          const obs = new IntersectionObserver(
-            (entries) => {
-              if (entries[0].isIntersecting && !done) {
-                done = true;
-                line.classList.add('is-inview');
-                obs.unobserve(line);
-              }
-            },
-            { threshold: 0.1 }
-          );
-          obs.observe(line);
-        }
-      })();
-
-      // Blueprint-grid graphics (hero, next-row, pre-footer) — lines draw in,
-      // then accent squares pop, then any content panel fades in on top.
-      (function initLineDrawGraphics() {
-        const PATH_STEP_MS = 55;
-        const NODE_STEP_MS = 70;
-        const GROUP_GAP_MS = 120;
-
-        const graphics = document.querySelectorAll('.line-draw');
-        for (const graphic of Array.from(graphics) as HTMLElement[]) {
-          let done = false;
-          const obs = new IntersectionObserver(
-            (entries) => {
-              if (!entries[0].isIntersecting || done) return;
-              done = true;
-              obs.unobserve(graphic);
-
-              const paths = Array.from(
-                graphic.querySelectorAll('path[data-line-draw]')
-              ) as HTMLElement[];
-              const nodes = Array.from(
-                graphic.querySelectorAll('rect[data-line-draw]')
-              ) as HTMLElement[];
-              const panel = graphic.querySelector('[data-line-draw-panel]') as HTMLElement | null;
-
-              paths.forEach((el, i) =>
-                setTimeout(() => el.classList.add('is-inview'), i * PATH_STEP_MS)
-              );
-
-              const nodesStart = paths.length * PATH_STEP_MS + GROUP_GAP_MS;
-              nodes.forEach((el, i) =>
-                setTimeout(() => el.classList.add('is-inview'), nodesStart + i * NODE_STEP_MS)
-              );
-
-              if (panel) {
-                const panelStart = nodesStart + nodes.length * NODE_STEP_MS + GROUP_GAP_MS;
-                setTimeout(() => panel.classList.add('is-inview'), panelStart);
-              }
-            },
-            { threshold: 0.2 }
-          );
-          obs.observe(graphic);
-        }
-      })();
-    </script>
   </body>
 </html>

--- a/src/pages/dedicated-cloud.astro
+++ b/src/pages/dedicated-cloud.astro
@@ -5,6 +5,7 @@ import Layout from '@layouts/Layout.astro';
 import Hero from '@components/Hero.astro';
 import Footer from '@components/Footer.astro';
 import Icon from '@components/Icon.astro';
+import SectionEyebrow from '@components/SectionEyebrow.astro';
 import BookDemo from '@components/forms/BookDemo.astro';
 
 const title = 'Talk to our team';
@@ -37,7 +38,7 @@ const checklist = [
     <div class="section--block relative overflow-hidden bg-white px-7">
       <div class="max-width-nav large-pad relative">
         <span class="section-line section-line--left section-line--top"></span>
-        <span class="section-eyebrow section-eyebrow--left-top-keyline">Dedicated cloud</span>
+        <SectionEyebrow position="left-top-keyline">Dedicated cloud</SectionEyebrow>
 
         <div class="max-width-nopad">
           <div class="grid grid-cols-6 gap-8 md:gap-15 lg:gap-25 xl:gap-28">

--- a/src/pages/demo.astro
+++ b/src/pages/demo.astro
@@ -5,6 +5,7 @@ import Layout from '@layouts/Layout.astro';
 import Hero from '@components/Hero.astro';
 import Footer from '@components/Footer.astro';
 import Icon from '@components/Icon.astro';
+import SectionEyebrow from '@components/SectionEyebrow.astro';
 import BookDemo from '@components/forms/BookDemo.astro';
 
 const title = 'Book a demo';
@@ -30,7 +31,7 @@ const checklist = [
     <div class="section--block relative overflow-hidden bg-white px-7">
       <div class="max-width-nav large-pad relative">
         <span class="section-line section-line--left section-line--top"></span>
-        <span class="section-eyebrow section-eyebrow--left-top-keyline">Book a demo</span>
+        <SectionEyebrow position="left-top-keyline">Book a demo</SectionEyebrow>
 
         <div class="max-width-nopad">
           <div class="grid grid-cols-6 gap-8 md:gap-15 lg:gap-25 xl:gap-28">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import HomeHero from '@components/home/HomeHero.astro';
 import WhatIsDatum from '@components/home/WhatIsDatum.astro';
 import DatumPlatform from '@components/home/DatumPlatform.astro';
 import DedicatedCloud from '@components/home/DedicatedCloud.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
 import Footer from '@components/Footer.astro';
 
 import { getCollectionEntry } from '@utils/collectionUtils';
@@ -32,13 +33,17 @@ const description = fm.description ? fm.description : '';
       <Announcement />
       <Nav />
     </header>
-    <HomeHero title={fm.title} description={fm.description} />
+    <div class="relative">
+      <HomeHero title={fm.title} description={fm.description} />
 
-    <WhatIsDatum />
+      <WhatIsDatum />
 
-    <DatumPlatform />
+      <DatumPlatform />
 
-    <DedicatedCloud />
+      <DedicatedCloud />
+
+      <ModuleConnector />
+    </div>
 
     <Footer />
   </section>

--- a/src/static/scripts/module-animate.js
+++ b/src/static/scripts/module-animate.js
@@ -1,0 +1,166 @@
+// Scroll-driven reveal animations: section divider lines, blueprint-grid
+// graphics, module border wipes (cued by the sticky ModuleConnector bar),
+// and the CLI-style eyebrow typeout. Each observer fires once per element.
+
+const REVEAL_OFFSET_PX = 400;
+const REVEAL_DELAY_MS = 150;
+const CHAR_TYPE_MS = 45;
+
+function initSectionLabels() {
+  const labels = document.querySelectorAll('.section-label, .mission-label, .text-highlight');
+  for (const label of Array.from(labels)) {
+    let done = false;
+    const obs = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && !done) {
+          done = true;
+          label.classList.add('highlight-animate');
+          obs.unobserve(label);
+        }
+      },
+      { threshold: 0.8 }
+    );
+    obs.observe(label);
+  }
+}
+
+// Section divider lines — draw in once each line scrolls ~400px into view,
+// with a short delay so the build-in is noticeable rather than instant.
+function initSectionLines() {
+  const lines = document.querySelectorAll('.section-line, .section-line-h');
+  for (const line of Array.from(lines)) {
+    const offset = parseInt(line.dataset.revealOffset, 10) || REVEAL_OFFSET_PX;
+    let done = false;
+    const obs = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && !done) {
+          done = true;
+          obs.unobserve(line);
+          setTimeout(() => line.classList.add('is-inview'), REVEAL_DELAY_MS);
+        }
+      },
+      { threshold: 0, rootMargin: `0px 0px -${offset}px 0px` }
+    );
+    obs.observe(line);
+  }
+}
+
+// Blueprint-grid graphics (hero, next-row, pre-footer) — lines draw in,
+// then accent squares pop, then any content panel fades in on top.
+function initLineDrawGraphics() {
+  const PATH_STEP_MS = 55;
+  const NODE_STEP_MS = 70;
+  const GROUP_GAP_MS = 120;
+
+  const graphics = document.querySelectorAll('.line-draw');
+  for (const graphic of Array.from(graphics)) {
+    let done = false;
+    const obs = new IntersectionObserver(
+      (entries) => {
+        if (!entries[0].isIntersecting || done) return;
+        done = true;
+        obs.unobserve(graphic);
+
+        const paths = Array.from(graphic.querySelectorAll('path[data-line-draw]'));
+        const nodes = Array.from(graphic.querySelectorAll('rect[data-line-draw]'));
+        const panel = graphic.querySelector('[data-line-draw-panel]');
+
+        paths.forEach((el, i) => setTimeout(() => el.classList.add('is-inview'), i * PATH_STEP_MS));
+
+        const nodesStart = paths.length * PATH_STEP_MS + GROUP_GAP_MS;
+        nodes.forEach((el, i) =>
+          setTimeout(() => el.classList.add('is-inview'), nodesStart + i * NODE_STEP_MS)
+        );
+
+        if (panel) {
+          const panelStart = nodesStart + nodes.length * NODE_STEP_MS + GROUP_GAP_MS;
+          setTimeout(() => panel.classList.add('is-inview'), panelStart);
+        }
+      },
+      { threshold: 0.2 }
+    );
+    obs.observe(graphic);
+  }
+}
+
+// Module border wipe — fires exactly when a module's top edge crosses the
+// top of the viewport, i.e. when the sticky ModuleConnector bar visually
+// reaches that module (see components-module-animate.css).
+function initModuleBorderWipe() {
+  const modules = document.querySelectorAll('[data-module-wipe]');
+  for (const module of Array.from(modules)) {
+    const wipe = module.querySelector('.module-border-wipe');
+    if (!wipe) continue;
+    let done = false;
+    const obs = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && !done) {
+          done = true;
+          wipe.classList.add('is-inview');
+          obs.unobserve(module);
+        }
+      },
+      { threshold: 0, rootMargin: '-1px 0px -99% 0px' }
+    );
+    obs.observe(module);
+  }
+}
+
+// Eyebrow typeout — the coloured cursor square "types" the eyebrow text
+// character by character, then returns to its resting position on the left.
+// The full text stays in the DOM throughout (only visually clipped), so
+// accessibility and SEO are unaffected.
+function initEyebrowTypeout() {
+  const eyebrows = document.querySelectorAll('[data-eyebrow-typeout]');
+  for (const eyebrow of Array.from(eyebrows)) {
+    const text = eyebrow.querySelector('.section-eyebrow-text');
+    const cursor = eyebrow.querySelector('.section-eyebrow-cursor');
+    if (!text || !cursor) continue;
+
+    const chars = Math.max((text.textContent || '').trim().length, 1);
+    const offset = parseInt(eyebrow.dataset.revealOffset, 10) || REVEAL_OFFSET_PX;
+
+    eyebrow.style.setProperty('--eyebrow-chars', String(chars));
+    eyebrow.style.setProperty('--eyebrow-type-ms', `${chars * CHAR_TYPE_MS}ms`);
+
+    let done = false;
+    const obs = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && !done) {
+          done = true;
+          obs.unobserve(eyebrow);
+          setTimeout(() => {
+            eyebrow.classList.add('is-typing');
+            text.addEventListener('transitionend', () => eyebrow.classList.add('is-typed'), {
+              once: true,
+            });
+          }, REVEAL_DELAY_MS);
+        }
+      },
+      { threshold: 0, rootMargin: `0px 0px -${offset}px 0px` }
+    );
+    obs.observe(eyebrow);
+  }
+}
+
+function initModuleAnimate() {
+  initSectionLabels();
+  initSectionLines();
+  initLineDrawGraphics();
+  initModuleBorderWipe();
+  initEyebrowTypeout();
+}
+
+document.addEventListener('DOMContentLoaded', initModuleAnimate);
+
+// Handle page restoration from bfcache (back/forward navigation)
+window.addEventListener('pageshow', (event) => {
+  if (event.persisted) {
+    setTimeout(initModuleAnimate, 10);
+  }
+});
+
+// Handle navigation with history API (back/forward)
+window.addEventListener('popstate', () => {
+  setTimeout(initModuleAnimate, 10);
+});

--- a/src/static/styles/base.css
+++ b/src/static/styles/base.css
@@ -76,6 +76,8 @@
 
 @import './components-line-draw.css';
 
+@import './components-module-animate.css';
+
 @import './components-hero.css';
 
 @import './components-nav.css';

--- a/src/static/styles/components-module-animate.css
+++ b/src/static/styles/components-module-animate.css
@@ -1,0 +1,81 @@
+@layer components {
+  /* Module connector — continuation of the hero's `.section-line--top`
+     (see HomeHero.astro), spanning the stacked group of home modules
+     (see ModuleConnector.astro). Same look as `.section-line` so the bar
+     reads as one continuous line rather than a new element. */
+  .module-connector {
+    @apply pointer-events-none absolute inset-y-0 left-0 z-20 w-full px-4 sm:px-7;
+  }
+
+  .module-connector-bar {
+    @apply bg-silver-mist sticky top-0 left-0 block w-px;
+    @apply h-5 md:h-10 lg:h-15 xl:h-20;
+  }
+
+  /* Module border wipe — top border of a module, hidden until the sticky
+     connector bar reaches it, then builds out left to right. */
+  .module-border-wipe {
+    @apply bg-silver-mist pointer-events-none absolute inset-x-0 top-0 block h-px origin-left scale-x-0;
+    transition: transform 0.7s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .module-border-wipe.is-inview {
+    @apply scale-x-100;
+  }
+
+  /* Eyebrow typeout cursor — a real element (was previously a ::before
+     square) so it can travel across the text while typing, then return to
+     its resting position on the left. */
+  .section-eyebrow-cursor {
+    @apply bg-canyon-clay inline-block h-3.5 w-3.25 shrink-0 rounded-[1.25px];
+    transform: translateX(0);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .section-eyebrow--pine .section-eyebrow-cursor {
+    @apply bg-pine-forge---links;
+  }
+
+  .section-eyebrow--midnight-fjord .section-eyebrow-cursor {
+    @apply bg-midnight-fjord;
+  }
+
+  /* Text stays in the DOM at full size (no layout shift) but is clipped
+     until typed — the monospace eyebrow font keeps clip-path steps evenly
+     spaced per character. */
+  .section-eyebrow-text {
+    clip-path: inset(0 100% 0 0);
+  }
+
+  .section-eyebrow.is-typing .section-eyebrow-text {
+    clip-path: inset(0 0 0 0);
+    transition: clip-path var(--eyebrow-type-ms, 0.5s) steps(var(--eyebrow-chars, 1));
+  }
+
+  .section-eyebrow.is-typing .section-eyebrow-cursor {
+    transform: translateX(calc(var(--eyebrow-chars, 1) * 1ch + 0.625rem));
+    transition: transform var(--eyebrow-type-ms, 0.5s) steps(var(--eyebrow-chars, 1));
+  }
+
+  /* Cursor returns to its resting position once typing completes. */
+  .section-eyebrow.is-typed .section-eyebrow-cursor {
+    transform: translateX(0);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .module-border-wipe,
+    .section-eyebrow-cursor,
+    .section-eyebrow-text {
+      transition: none !important;
+    }
+
+    .module-border-wipe {
+      @apply scale-x-100;
+    }
+
+    .section-eyebrow-text {
+      clip-path: inset(0 0 0 0) !important;
+    }
+  }
+}

--- a/src/static/styles/components.css
+++ b/src/static/styles/components.css
@@ -41,28 +41,18 @@
     }
   }
 
+  /* Cursor square + typeout animation states live in
+     components-module-animate.css alongside the other scroll-driven reveals. */
   .section-eyebrow {
     @apply font-dejavu datum-text-sm text-canyon-clay---links inline-flex items-center gap-2.5 whitespace-nowrap uppercase;
-
-    &::before {
-      @apply bg-canyon-clay h-3.5 w-3.25 shrink-0 rounded-[1.25px] content-[''];
-    }
   }
 
   .section-eyebrow--pine {
     @apply text-pine-forge---links;
-
-    &::before {
-      @apply bg-pine-forge---links;
-    }
   }
 
   .section-eyebrow--midnight-fjord {
     @apply text-midnight-fjord;
-
-    &::before {
-      @apply bg-midnight-fjord;
-    }
   }
 
   .section-eyebrow--left-top {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -194,4 +194,12 @@ export interface SecondaryTabNavProps {
   idPrefix?: string;
 }
 
+export interface SectionEyebrowProps {
+  class?: string;
+  /** Text colour + cursor colour. Defaults to canyon-clay. */
+  variant?: 'pine' | 'midnight-fjord';
+  /** Absolute positioning against the nearest `relative` ancestor. */
+  position?: 'left-top' | 'left-top-keyline';
+}
+
 // TOC interfaces removed - now using Astro's built-in MarkdownHeading type


### PR DESCRIPTION
Delay section-line and pillar reveals until modules scroll ~400px into view instead of firing near page load, add a sticky connector bar that continues the hero's top-left section-line down through the stacked WhatIsDatum/DatumPlatform/DedicatedCloud modules (wiping in each module's top border as it arrives), and convert the section-eyebrow cursor into a real DOM node that types out the label before returning to its resting position.