### PR TITLE
fix(roadmap): move backlog status tag to the right of title

### DIFF
--- a/src/components/roadmap/RoadmapBacklogRow.astro
+++ b/src/components/roadmap/RoadmapBacklogRow.astro
@@ -25,11 +25,11 @@ const statusClassMap: Record<GitHubBacklogStatus, string> = {
 >
   <span class="roadmap-backlog-number">#{item.number}</span>
 
+  <h3 class="roadmap-backlog-title">{item.title}</h3>
+
   <span class:list={['roadmap-backlog-status', statusClassMap[item.status]]}>
     {item.status}
   </span>
-
-  <h3 class="roadmap-backlog-title">{item.title}</h3>
 
   <span class="roadmap-backlog-link">
     GitHub


### PR DESCRIPTION
## Summary
- Reorders the backlog row markup so the status tag renders to the right of the title instead of before it.

## Test plan
- [ ] Visually check `/roadmap/backlog` to confirm the status tag sits right of the title on each row