### PR TITLE
fix(demo): disable prerendering on demo form pages

### DIFF
--- a/src/components/forms/BookDemo.astro
+++ b/src/components/forms/BookDemo.astro
@@ -1,5 +1,7 @@
 ---
 // src/components/forms/BookDemo.astro
+export const prerender = false;
+
 import Icon from '@components/Icon.astro';
 
 interface Props {

--- a/src/pages/dedicated-cloud.astro
+++ b/src/pages/dedicated-cloud.astro
@@ -1,5 +1,7 @@
 ---
 // src/pages/demo.astro
+export const prerender = false;
+
 import '@styles/global.css';
 import Layout from '@layouts/Layout.astro';
 import Hero from '@components/Hero.astro';

--- a/src/pages/demo.astro
+++ b/src/pages/demo.astro
@@ -1,5 +1,7 @@
 ---
 // src/pages/demo.astro
+export const prerender = false;
+
 import '@styles/global.css';
 import Layout from '@layouts/Layout.astro';
 import Hero from '@components/Hero.astro';


### PR DESCRIPTION
## Summary
- Add `export const prerender = false` to the demo form component and its pages
- Fixes an issue where the first submission of the demo form errored out while an identical second submission succeeded (caused by stale prerendered SSR/form state)

## Test plan
- [ ] Load `/demo` and `/dedicated-cloud` fresh, submit the form once, confirm it succeeds without error
- [ ] Confirm pages still render correctly (no functional regressions from disabling prerender)

🤖 Generated with [Claude Code](https://claude.com/claude-code)