### PR TITLE
fix(home): retime and fix scroll-triggered module animations

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -30,7 +30,8 @@ const [platformSection, resourcesSection, companySection] = navData.footer;
 >
   {
     showCTA && (
-      <div class="footer-prefooter px-4 sm:px-7">
+      <div class="footer-prefooter px-4 sm:px-7" data-module-wipe>
+        <span class="module-border-wipe" aria-hidden="true" />
         <div class="max-width-nav relative">
           <span class="section-line section-line--left section-line--top" />
           <SectionEyebrow variant="midnight-fjord" position="left-top">

--- a/src/components/home/DatumPlatform.astro
+++ b/src/components/home/DatumPlatform.astro
@@ -72,8 +72,10 @@ const pillars: { icon: string; title: string; description: string }[] = [
         <span class="section-line-h bg-silver-mist -right-10 bottom-0 hidden md:block"></span>
 
         <div
-          class="border-silver-mist from-platinum to-aurora-moss grid grid-cols-1 gap-0 overflow-hidden border border-b-0 bg-linear-to-br from-55% to-71% md:grid-cols-[minmax(0,1fr)_auto] md:gap-11.5 xl:gap-18.5"
+          class="border-silver-mist from-platinum to-aurora-moss relative grid grid-cols-1 gap-0 overflow-hidden border-x border-t-0 border-b bg-linear-to-br from-55% to-71% md:grid-cols-[minmax(0,1fr)_auto] md:gap-11.5 xl:gap-18.5"
+          data-module-wipe
         >
+          <span class="module-border-wipe" aria-hidden="true"></span>
           <div class="flex min-w-0 flex-col gap-7 p-8 md:p-16">
             <h3 class="datum-text-7xl text-midnight-fjord">Private, protected, performant.</h3>
             <p class="datum-text-base text-app---dark---utility-2 opacity-80">

--- a/src/components/home/ModuleConnector.astro
+++ b/src/components/home/ModuleConnector.astro
@@ -6,9 +6,15 @@
 // border-wipe reveal on whichever module it currently sits beside (see
 // module-animate.js). Nested in a `max-width-nav` box so its left edge
 // lines up with every module's own `.section-line--left` at `left-0`.
+//
+// Rendered as one instance per wrapping `.relative` group in index.astro
+// rather than a single instance spanning the whole page, so it can be
+// suppressed (via `class`) over WhatIsDatum at `lg`+, where that module
+// shows its own blueprint-grid SVG corner instead of a plain line.
+const { class: className = '' } = Astro.props;
 ---
 
-<div class="module-connector" aria-hidden="true">
+<div class:list={['module-connector', className]} aria-hidden="true">
   <div class="max-width-nav relative h-full">
     <span class="module-connector-bar"></span>
   </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,9 +35,20 @@ const description = fm.description ? fm.description : '';
     </header>
     <div class="relative">
       <HomeHero title={fm.title} description={fm.description} />
+      <ModuleConnector />
+    </div>
 
+    <div class="relative">
       <WhatIsDatum />
+      {
+        /* WhatIsDatum shows its own blueprint-grid SVG corner at lg+ instead
+          of a plain line — suppress the connector there to avoid the two
+          competing side by side. */
+      }
+      <ModuleConnector class="lg:hidden" />
+    </div>
 
+    <div class="relative">
       <DatumPlatform />
 
       <DedicatedCloud />

--- a/src/static/scripts/module-animate.js
+++ b/src/static/scripts/module-animate.js
@@ -1,52 +1,72 @@
 // Scroll-driven reveal animations: section divider lines, blueprint-grid
-// graphics, module border wipes (cued by the sticky ModuleConnector bar),
-// and the CLI-style eyebrow typeout. Each observer fires once per element.
+// "glass" graphics, module border wipes, and the CLI-style eyebrow typeout.
+// Every reveal reverses when its element scrolls back out of view (either
+// direction), so scrolling back down replays it.
 
-const REVEAL_OFFSET_PX = 400;
+const REVEAL_OFFSET_PX = 150;
 const REVEAL_DELAY_MS = 150;
 const CHAR_TYPE_MS = 45;
+// Shared by the module border wipe and the blueprint-grid "glass" graphics —
+// both are cued by the sticky ModuleConnector bar, so both fire this many
+// pixels before their module's top edge reaches the top of the viewport,
+// giving their transitions time to finish before the bar visually arrives.
+const TOUCH_LEAD_PX = 150;
+
+let activeObservers = [];
+
+function trackObserver(obs) {
+  activeObservers.push(obs);
+  return obs;
+}
+
+function touchRootMargin() {
+  const bottomMargin = Math.max(window.innerHeight - TOUCH_LEAD_PX, 0);
+  return `-1px 0px -${bottomMargin}px 0px`;
+}
 
 function initSectionLabels() {
   const labels = document.querySelectorAll('.section-label, .mission-label, .text-highlight');
   for (const label of Array.from(labels)) {
-    let done = false;
-    const obs = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && !done) {
-          done = true;
-          label.classList.add('highlight-animate');
-          obs.unobserve(label);
-        }
-      },
-      { threshold: 0.8 }
+    const obs = trackObserver(
+      new IntersectionObserver(
+        (entries) => {
+          label.classList.toggle('highlight-animate', entries[0].isIntersecting);
+        },
+        { threshold: 0.3 }
+      )
     );
     obs.observe(label);
   }
 }
 
-// Section divider lines — draw in once each line scrolls ~400px into view,
-// with a short delay so the build-in is noticeable rather than instant.
+// Section divider lines — draw in once each line scrolls REVEAL_OFFSET_PX
+// into view, with a short delay so the build-in is noticeable rather than
+// instant. Reverses (cancelling any pending delayed reveal) on scroll-up.
 function initSectionLines() {
   const lines = document.querySelectorAll('.section-line, .section-line-h');
   for (const line of Array.from(lines)) {
     const offset = parseInt(line.dataset.revealOffset, 10) || REVEAL_OFFSET_PX;
-    let done = false;
-    const obs = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && !done) {
-          done = true;
-          obs.unobserve(line);
-          setTimeout(() => line.classList.add('is-inview'), REVEAL_DELAY_MS);
-        }
-      },
-      { threshold: 0, rootMargin: `0px 0px -${offset}px 0px` }
+    let timeoutId = null;
+    const obs = trackObserver(
+      new IntersectionObserver(
+        (entries) => {
+          clearTimeout(timeoutId);
+          if (entries[0].isIntersecting) {
+            timeoutId = setTimeout(() => line.classList.add('is-inview'), REVEAL_DELAY_MS);
+          } else {
+            line.classList.remove('is-inview');
+          }
+        },
+        { threshold: 0, rootMargin: `0px 0px -${offset}px 0px` }
+      )
     );
     obs.observe(line);
   }
 }
 
-// Blueprint-grid graphics (hero, next-row, pre-footer) — lines draw in,
-// then accent squares pop, then any content panel fades in on top.
+// Blueprint-grid "glass" graphics (hero, next-row, pre-footer) — lines draw
+// in, accent squares pop, then any content panel fades in, cued by the same
+// touch-lead as the module border wipe. Reverses on scroll-up.
 function initLineDrawGraphics() {
   const PATH_STEP_MS = 55;
   const NODE_STEP_MS = 70;
@@ -54,53 +74,61 @@ function initLineDrawGraphics() {
 
   const graphics = document.querySelectorAll('.line-draw');
   for (const graphic of Array.from(graphics)) {
-    let done = false;
-    const obs = new IntersectionObserver(
-      (entries) => {
-        if (!entries[0].isIntersecting || done) return;
-        done = true;
-        obs.unobserve(graphic);
+    const paths = Array.from(graphic.querySelectorAll('path[data-line-draw]'));
+    const nodes = Array.from(graphic.querySelectorAll('rect[data-line-draw]'));
+    const panel = graphic.querySelector('[data-line-draw-panel]');
+    let timeoutIds = [];
 
-        const paths = Array.from(graphic.querySelectorAll('path[data-line-draw]'));
-        const nodes = Array.from(graphic.querySelectorAll('rect[data-line-draw]'));
-        const panel = graphic.querySelector('[data-line-draw-panel]');
+    const obs = trackObserver(
+      new IntersectionObserver(
+        (entries) => {
+          timeoutIds.forEach(clearTimeout);
+          timeoutIds = [];
 
-        paths.forEach((el, i) => setTimeout(() => el.classList.add('is-inview'), i * PATH_STEP_MS));
+          if (entries[0].isIntersecting) {
+            paths.forEach((el, i) =>
+              timeoutIds.push(setTimeout(() => el.classList.add('is-inview'), i * PATH_STEP_MS))
+            );
 
-        const nodesStart = paths.length * PATH_STEP_MS + GROUP_GAP_MS;
-        nodes.forEach((el, i) =>
-          setTimeout(() => el.classList.add('is-inview'), nodesStart + i * NODE_STEP_MS)
-        );
+            const nodesStart = paths.length * PATH_STEP_MS + GROUP_GAP_MS;
+            nodes.forEach((el, i) =>
+              timeoutIds.push(
+                setTimeout(() => el.classList.add('is-inview'), nodesStart + i * NODE_STEP_MS)
+              )
+            );
 
-        if (panel) {
-          const panelStart = nodesStart + nodes.length * NODE_STEP_MS + GROUP_GAP_MS;
-          setTimeout(() => panel.classList.add('is-inview'), panelStart);
-        }
-      },
-      { threshold: 0.2 }
+            if (panel) {
+              const panelStart = nodesStart + nodes.length * NODE_STEP_MS + GROUP_GAP_MS;
+              timeoutIds.push(setTimeout(() => panel.classList.add('is-inview'), panelStart));
+            }
+          } else {
+            paths.forEach((el) => el.classList.remove('is-inview'));
+            nodes.forEach((el) => el.classList.remove('is-inview'));
+            if (panel) panel.classList.remove('is-inview');
+          }
+        },
+        { threshold: 0, rootMargin: touchRootMargin() }
+      )
     );
     obs.observe(graphic);
   }
 }
 
-// Module border wipe — fires exactly when a module's top edge crosses the
-// top of the viewport, i.e. when the sticky ModuleConnector bar visually
-// reaches that module (see components-module-animate.css).
+// Module border wipe — fires TOUCH_LEAD_PX before a module's top edge
+// reaches the top of the viewport, i.e. before the sticky ModuleConnector
+// bar visually arrives there. Reverses on scroll-up.
 function initModuleBorderWipe() {
   const modules = document.querySelectorAll('[data-module-wipe]');
   for (const module of Array.from(modules)) {
     const wipe = module.querySelector('.module-border-wipe');
     if (!wipe) continue;
-    let done = false;
-    const obs = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && !done) {
-          done = true;
-          wipe.classList.add('is-inview');
-          obs.unobserve(module);
-        }
-      },
-      { threshold: 0, rootMargin: '-1px 0px -99% 0px' }
+    const obs = trackObserver(
+      new IntersectionObserver(
+        (entries) => {
+          wipe.classList.toggle('is-inview', entries[0].isIntersecting);
+        },
+        { threshold: 0, rootMargin: touchRootMargin() }
+      )
     );
     obs.observe(module);
   }
@@ -109,7 +137,7 @@ function initModuleBorderWipe() {
 // Eyebrow typeout — the coloured cursor square "types" the eyebrow text
 // character by character, then returns to its resting position on the left.
 // The full text stays in the DOM throughout (only visually clipped), so
-// accessibility and SEO are unaffected.
+// accessibility and SEO are unaffected. Reverses (untyping) on scroll-up.
 function initEyebrowTypeout() {
   const eyebrows = document.querySelectorAll('[data-eyebrow-typeout]');
   for (const eyebrow of Array.from(eyebrows)) {
@@ -123,27 +151,35 @@ function initEyebrowTypeout() {
     eyebrow.style.setProperty('--eyebrow-chars', String(chars));
     eyebrow.style.setProperty('--eyebrow-type-ms', `${chars * CHAR_TYPE_MS}ms`);
 
-    let done = false;
-    const obs = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && !done) {
-          done = true;
-          obs.unobserve(eyebrow);
-          setTimeout(() => {
-            eyebrow.classList.add('is-typing');
-            text.addEventListener('transitionend', () => eyebrow.classList.add('is-typed'), {
-              once: true,
-            });
-          }, REVEAL_DELAY_MS);
-        }
-      },
-      { threshold: 0, rootMargin: `0px 0px -${offset}px 0px` }
+    let timeoutId = null;
+    const onTransitionEnd = () => eyebrow.classList.add('is-typed');
+
+    const obs = trackObserver(
+      new IntersectionObserver(
+        (entries) => {
+          clearTimeout(timeoutId);
+          text.removeEventListener('transitionend', onTransitionEnd);
+
+          if (entries[0].isIntersecting) {
+            timeoutId = setTimeout(() => {
+              eyebrow.classList.add('is-typing');
+              text.addEventListener('transitionend', onTransitionEnd, { once: true });
+            }, REVEAL_DELAY_MS);
+          } else {
+            eyebrow.classList.remove('is-typing', 'is-typed');
+          }
+        },
+        { threshold: 0, rootMargin: `0px 0px -${offset}px 0px` }
+      )
     );
     obs.observe(eyebrow);
   }
 }
 
 function initModuleAnimate() {
+  activeObservers.forEach((obs) => obs.disconnect());
+  activeObservers = [];
+
   initSectionLabels();
   initSectionLines();
   initLineDrawGraphics();

--- a/src/static/styles/components-home.css
+++ b/src/static/styles/components-home.css
@@ -114,6 +114,9 @@
   }
 
   .home-hero-video-card-play {
-    @apply pointer-events-none absolute top-1/2 left-1/2 z-20 size-24 -translate-x-1/2 -translate-y-1/2 transition-transform duration-200 ease-out;
+    @apply pointer-events-none absolute top-1/2 left-1/2 z-20 size-24 -translate-x-1/2 transition-transform duration-200 ease-out;
+    /* Nudged up 10px from dead-center against the button box to read as
+       centered next to the surrounding dashboard/grid graphic. */
+    @apply -translate-y-[calc(50%+10px)];
   }
 }

--- a/src/static/styles/components-module-animate.css
+++ b/src/static/styles/components-module-animate.css
@@ -16,7 +16,9 @@
      connector bar reaches it, then builds out left to right. */
   .module-border-wipe {
     @apply bg-silver-mist pointer-events-none absolute inset-x-0 top-0 block h-px origin-left scale-x-0;
-    transition: transform 0.7s cubic-bezier(0.4, 0, 0.2, 1);
+    /* Tailwind v4 compiles scale-x-* to the `scale` property, not `transform` —
+       transition that property, not `transform`, or the wipe snaps instantly. */
+    transition: scale 0.7s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   .module-border-wipe.is-inview {
@@ -45,11 +47,13 @@
      spaced per character. */
   .section-eyebrow-text {
     clip-path: inset(0 100% 0 0);
+    /* On the base rule (not just `.is-typing`) so removing `.is-typing` on
+       scroll-up un-types character by character instead of snapping shut. */
+    transition: clip-path var(--eyebrow-type-ms, 0.5s) steps(var(--eyebrow-chars, 1));
   }
 
   .section-eyebrow.is-typing .section-eyebrow-text {
     clip-path: inset(0 0 0 0);
-    transition: clip-path var(--eyebrow-type-ms, 0.5s) steps(var(--eyebrow-chars, 1));
   }
 
   .section-eyebrow.is-typing .section-eyebrow-cursor {

--- a/src/static/styles/components.css
+++ b/src/static/styles/components.css
@@ -147,7 +147,6 @@
 
   .footer-prefooter {
     @apply text-midnight-fjord bg-aurora-moss/30 relative z-10 mx-auto;
-    @apply border-silver-mist border-t;
   }
 
   .footer-prefooter-label {


### PR DESCRIPTION
## Summary

Follow-up fixes to the homepage scroll-triggered module animations (Ollie's revision notes on #1490's animation feature), covering gaps Ronggur's original pass missed plus new requirements from the review:

- **Border wipe wasn't animating.** Its CSS transitioned `transform`, but Tailwind v4 compiles `scale-x-*` to the `scale` property — the wipe snapped open instantly instead of easing in. Now transitions `scale`.
- **Trigger fired too late.** The wipe used to fire almost exactly when the module's border reached the top of the viewport, so the 0.7s transition finished *after* it had already scrolled past. Now fires with lead time so it completes before arrival.
- **Sticky connector clashed with WhatIsDatum's SVG corner.** At `lg`+, WhatIsDatum swaps its plain corner tick for a blueprint-grid SVG graphic, which the always-on connector line didn't account for — two competing lines showed up side by side. Split `ModuleConnector` into per-section instances and suppress it over WhatIsDatum at `lg:hidden`.
- **Two rows never got the wipe treatment at all.** The "Private, protected, performant." card in DatumPlatform and the footer's "Start here, go anywhere" prefooter both used plain static borders, disconnected from the animation system. Wired both into `data-module-wipe`/`.module-border-wipe`.
- **Blueprint-grid "glass" graphics fired independently.** They used their own 20%-visibility threshold instead of the connector-touch trigger the border wipe uses. Now shares the same touch-lead timing.
- **Nothing reversed on scroll-up.** Every observer fired once and unobserved. All of them (section lines, glass graphics, border wipes, eyebrow typeout, text highlights) now toggle their reveal classes based on intersection state, so scrolling back up rewinds the animation and scrolling back down replays it.
- **Hero video play icon was off-center.** `button-play.svg`'s viewBox reserves empty space at the bottom for its drop-shadow, so centering its full box left the visible play card looking off relative to the surrounding hero card. Nudged up 10px.

## Test plan

- [x] `astro check` passes with 0 errors
- [x] Verified via Playwright: border-wipe now eases via `scale` instead of snapping
- [x] Verified via Playwright across viewport widths (768–1920px): connector line no longer doubles up with WhatIsDatum's SVG corner at `lg`+
- [x] Verified via Playwright: full reveal → stays revealed while on-screen → rewinds on scroll-up → replays on scroll-down cycle, for both the border wipe and the glass graphic + eyebrow typeout
- [ ] Manual pass in a real browser across breakpoints to confirm feel/timing subjectively

🤖 Generated with [Claude Code](https://claude.com/claude-code)
