### PR TITLE
ci: add scheduled refresh for GitHub backlog cache

### DIFF
--- a/.github/workflows/refresh-backlog-cache.yml
+++ b/.github/workflows/refresh-backlog-cache.yml
@@ -1,0 +1,22 @@
+name: Refresh Backlog Cache
+
+on:
+  schedule:
+    # Every 10 minutes — keeps /roadmap/backlog close to the GitHub Projects
+    # board without waiting on the 24h cache TTL fallback.
+    - cron: '*/10 * * * *'
+  workflow_dispatch: {}
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Force-regenerate GitHub backlog cache
+        env:
+          STRAPI_WEBHOOK_SECRET: ${{ secrets.STRAPI_WEBHOOK_SECRET }}
+        run: |
+          set -euo pipefail
+          curl -sS -f -X POST "https://www.datum.net/api/cache/strapi" \
+            -H "X-Webhook-Secret: ${STRAPI_WEBHOOK_SECRET}" \
+            -H "Content-Type: application/json" \
+            -d '{"names":["github-backlog"]}'


### PR DESCRIPTION
## Summary
- `/roadmap/backlog` (GitHub Projects-backed) was only ever refreshed passively via its 24h cache TTL — a change made on the GitHub Projects board could take up to a full day to appear on the live site.
- Adds a scheduled GitHub Actions workflow that force-regenerates just the `github-backlog` cache entry every 10 minutes via the existing, secret-protected `POST /api/cache/strapi` endpoint (`{"names":["github-backlog"]}`).
- Scoped narrowly to the GitHub backlog cache only — the Strapi-backed `/roadmap` page already has its own webhook-driven invalidation and is untouched by this change.

## Test plan
- [ ] Confirm `STRAPI_WEBHOOK_SECRET` repo secret is set (required for the workflow's curl call to authenticate against `/api/cache/strapi`)
- [ ] Manually trigger the workflow via `workflow_dispatch` and confirm a 200 response
- [ ] Verify `/roadmap/backlog` reflects a GitHub Projects board change within ~10 minutes after merge
