### PR TITLE
fix(cache): fall back to file cache when Redis disconnects

### DIFF
--- a/src/libs/strapi/_runtime.ts
+++ b/src/libs/strapi/_runtime.ts
@@ -28,8 +28,10 @@ import {
   FileCacheDriver,
   createWebhookHandler,
   revalidateConfigSchema,
+  type CacheDriver,
 } from '@datum-cloud/strapi-revalidate';
 import { RedisCacheDriver } from './drivers/redis';
+import { ResilientCacheDriver } from './drivers/resilient';
 import { createResilientStrapiClient } from './resilientGraphqlClient';
 
 const DEFAULT_STRAPI_URL = 'https://grateful-excitement-dfe9d47bad.strapiapp.com';
@@ -101,7 +103,7 @@ function createRedisClient(url: string): Redis {
 }
 
 async function resolvePrimaryCache(): Promise<{
-  primary: FileCacheDriver | RedisCacheDriver;
+  primary: CacheDriver;
   redisClient: Redis | null;
 }> {
   const filePrimary = new FileCacheDriver({ dir: '.cache' });
@@ -117,7 +119,11 @@ async function resolvePrimaryCache(): Promise<{
     await client.connect();
     await client.ping();
     if (debug) console.debug('[strapi-runtime] Primary cache: Redis at', redisUrl);
-    return { primary: new RedisCacheDriver(client, keyPrefix), redisClient: client };
+    const redisDriver = new RedisCacheDriver(client, keyPrefix);
+    return {
+      primary: new ResilientCacheDriver(redisDriver, filePrimary, { label: 'Redis', debug }),
+      redisClient: client,
+    };
   } catch {
     client.disconnect();
     console.warn(`[strapi-runtime] Redis not available at ${redisUrl}, using file cache (.cache)`);

--- a/src/libs/strapi/drivers/resilient.ts
+++ b/src/libs/strapi/drivers/resilient.ts
@@ -1,0 +1,102 @@
+// src/libs/strapi/drivers/resilient.ts
+/**
+ * Wraps a primary cache driver (Redis) with a file backup so transient or
+ * permanent primary outages degrade to local file cache instead of crashing SSR.
+ */
+import type { CacheDriver, CacheSetOptions } from '@datum-cloud/strapi-revalidate';
+
+export interface ResilientCacheDriverOptions {
+  /** Label used in warning logs (e.g. "Redis"). */
+  label?: string;
+  /** When true, log full errors via console.debug. */
+  debug?: boolean;
+}
+
+export class ResilientCacheDriver implements CacheDriver {
+  private readonly primary: CacheDriver;
+  private readonly backup: CacheDriver;
+  private readonly options: ResilientCacheDriverOptions;
+
+  constructor(
+    primary: CacheDriver,
+    backup: CacheDriver,
+    options: ResilientCacheDriverOptions = {}
+  ) {
+    this.primary = primary;
+    this.backup = backup;
+    this.options = options;
+  }
+
+  private warn(op: string, err: unknown): void {
+    const label = this.options.label ?? 'primary cache';
+    console.warn(`[strapi-runtime] ${label} ${op} failed, using file cache backup:`, err);
+    if (this.options.debug) {
+      console.debug(err);
+    }
+  }
+
+  private async withFallback<T>(
+    op: string,
+    primaryFn: () => Promise<T>,
+    backupFn: () => Promise<T>
+  ): Promise<T> {
+    try {
+      return await primaryFn();
+    } catch (err) {
+      this.warn(op, err);
+      return backupFn();
+    }
+  }
+
+  async get<T>(key: string): Promise<T | null> {
+    return this.withFallback(
+      'get',
+      () => this.primary.get<T>(key),
+      () => this.backup.get<T>(key)
+    );
+  }
+
+  async set<T>(key: string, data: T, options?: CacheSetOptions): Promise<void> {
+    try {
+      await this.primary.set(key, data, options);
+    } catch (err) {
+      this.warn('set', err);
+      await this.backup.set(key, data, options);
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    try {
+      await this.primary.delete(key);
+    } catch (err) {
+      this.warn('delete', err);
+      await this.backup.delete(key);
+    }
+  }
+
+  async deleteByTag(tag: string): Promise<void> {
+    try {
+      await this.primary.deleteByTag(tag);
+    } catch (err) {
+      this.warn('deleteByTag', err);
+      await this.backup.deleteByTag(tag);
+    }
+  }
+
+  async clear(): Promise<void> {
+    try {
+      await this.primary.clear();
+    } catch (err) {
+      this.warn('clear', err);
+      await this.backup.clear();
+    }
+  }
+
+  async keys(prefix?: string): Promise<string[]> {
+    return this.withFallback(
+      'keys',
+      () => this.primary.keys(prefix),
+      () => this.backup.keys(prefix)
+    );
+  }
+}


### PR DESCRIPTION
Wrap Redis primary cache in ResilientCacheDriver so SSR pages like /blog and /roadmap keep serving from file cache (or Strapi) instead of crashing with "Connection is closed" after Redis drops mid-process.