### PR TITLE
fix(server): stop caching prerendered pages as immutable for a year

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -200,9 +200,15 @@ const staticServer = sirv(CLIENT_DIR, {
   extensions: ['html'], // Auto-append .html for clean URLs
   single: false, // Don't serve index.html for all routes (SPA mode)
   setHeaders: (res, pathname) => {
+    // sirv passes the request pathname here, e.g. "/locations" — clean-URL
+    // pages never carry a literal ".html" suffix, so matching on that suffix
+    // never fires and pages fall through to the immutable 1-year default
+    // meant for hashed /_astro/ assets. Treat any extensionless path as a
+    // page instead.
+    const isPage = pathname.match(/\.(html)$/) || !/\.[^/]+$/.test(pathname);
     if (pathname.includes('/_astro/')) {
       res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
-    } else if (pathname.match(/\.(html)$/)) {
+    } else if (isPage) {
       res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate');
     } else if (pathname.startsWith('/download/brand-assets/')) {
       res.setHeader('Cache-Control', 'no-store, must-revalidate');


### PR DESCRIPTION
## Summary
- Prerendered pages (`/`, `/locations`, etc.) were being served with `Cache-Control: public, max-age=31536000, immutable` — the 1-year "never revalidate" header intended only for content-hashed `/_astro/*` assets.
- `sirv`'s `setHeaders` callback receives the *clean request pathname* (e.g. `/locations`), which never carries a literal `.html` suffix, so `pathname.match(/\.(html)$/)` never matched and the intended `max-age=0, must-revalidate` override for pages never fired.
- Confirmed live on `https://www.datum.net/locations` and `/` before the fix (`cache-control: public,max-age=31536000,immutable`), matching a report of the site loading with no CSS applied — a later deploy prunes an old hashed CSS/JS file, and any browser/CDN holding the immutably-cached HTML keeps serving the stale page referencing the now-deleted asset, producing an unstyled page.

## Fix
Detect "is this a page" by absence of a file extension on the request path (clean URLs never have one) instead of a literal `.html` suffix. `/_astro/*` hashed assets are unaffected and keep their long-lived immutable cache.

## Test plan
- [x] `npm run build` succeeds
- [x] Local prod server (`node server.mjs`): `/locations` and `/` return `Cache-Control: public, max-age=0, must-revalidate`
- [x] `/_astro/*.css` assets still return `Cache-Control: public, max-age=31536000, immutable`
- [x] Brotli-compressed page response (`Accept-Encoding: br`) also returns the corrected page cache-control
