### PR TITLE
fix: point download links to latest release

### DIFF
--- a/src/content/download/linux.mdx
+++ b/src/content/download/linux.mdx
@@ -24,7 +24,7 @@ import Button from '@components/Button.astro';
 <Button
     text="Download now"
     class="btn btn--pine-forge mt-3"
-    href="https://github.com/datum-cloud/app/releases/download/v0.0.41/Datum.AppImage"
+    href="https://github.com/datum-cloud/app/releases/latest/download/Datum.AppImage"
     target="_blank"
     iconPosition="right"
     icon={{ name: 'download', size: 'md' }}

--- a/src/content/download/windows.mdx
+++ b/src/content/download/windows.mdx
@@ -24,7 +24,7 @@ import Button from '@components/Button.astro';
 <Button
     text="Download now"
     class="btn btn--pine-forge mt-3"
-    href="https://github.com/datum-cloud/app/releases/download/v0.0.41/Datum-setup.exe"
+    href="https://github.com/datum-cloud/app/releases/latest/download/Datum-setup.exe"
     target="_blank"
     iconPosition="right"
     icon={{ name: 'download', size: 'md' }}


### PR DESCRIPTION
## Summary
- Update Linux and Windows download buttons to link to `releases/latest/download/...` instead of a pinned `v0.0.41` tag, so the download links stay current automatically.

Issue #1511

## Test plan
- [ ] Verify Linux download button links to the AppImage from the latest GitHub release
- [ ] Verify Windows download button links to the setup.exe from the latest GitHub release