### PR TITLE
fix: correct locations map label and deliver title styling

### DIFF
--- a/src/components/locations/LocationsList.astro
+++ b/src/components/locations/LocationsList.astro
@@ -7,7 +7,7 @@ const groupMeta: Record<string, { name: string; inline?: boolean }> = {
   NA: { name: 'North America' },
   LATAM: { name: 'Latin America' },
   EU: { name: 'Europe' },
-  MEA: { name: 'Middle East & Africa', inline: true },
+  MEA: { name: 'Middle East & Africa' },
   APAC: { name: 'Asia Pacific' },
 };
 

--- a/src/content/pages/features/deliver/index.mdx
+++ b/src/content/pages/features/deliver/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Protect, manage, and route traffic."
+title: "Protect, manage, and route <span class=\"text-pine-forge\">traffic</span>."
 slug: "features/deliver/index"
 description: "Route, filter, and accelerate traffic across every location without managing a separate CDN, WAF, or inference proxy."
 meta:

--- a/src/pages/locations.astro
+++ b/src/pages/locations.astro
@@ -59,7 +59,7 @@ const jsonLd = {
       class="section--block border-silver-mist bg-platinum section--block--x-pad overflow-hidden border-t"
     >
       <SectionGroup
-        label="NAP"
+        label="MAP"
         eyebrowVariant="app"
         class="small-pad"
         listClass="section-group-list max-w-8xl "


### PR DESCRIPTION
Rename the locations section label from NAP to MAP, drop MEA inline layout, and highlight traffic in the Deliver feature title.