### PR TITLE
fix(platform): add markdown export for platform hub pages

### DIFF
--- a/src/pages/[...mdslug].md.ts
+++ b/src/pages/[...mdslug].md.ts
@@ -37,7 +37,7 @@ export const GET: APIRoute = async ({ props }) => {
     );
     if (!entry) return new Response('Not found', { status: 404 });
 
-    const canonicalUrl = `https://www.datum.net${urlPath}/`;
+    const canonicalUrl = `https://www.datum.net${urlPath}`;
     const body = renderEntryMarkdown(entry, {
       // Demote body headings so a body-level H1 doesn't compete with the
       // frontmatter title. Safe for all pages — pages without a body H1

--- a/src/pages/about.md.ts
+++ b/src/pages/about.md.ts
@@ -70,7 +70,7 @@ export const GET: APIRoute = async () => {
         );
     }
 
-    const canonicalUrl = 'https://www.datum.net/about/';
+    const canonicalUrl = 'https://www.datum.net/about';
     sections.push('---', '', `Source: <${canonicalUrl}>`, '');
 
     const body = toAsciiMarkdown(sections.join('\n'));

--- a/src/pages/blog.md.ts
+++ b/src/pages/blog.md.ts
@@ -35,7 +35,7 @@ export const GET: APIRoute = async () => {
       list.push(`- [${a.title}](${url})${meta}${a.description ? ` - ${a.description}` : ''}`);
     }
 
-    const canonicalUrl = 'https://www.datum.net/blog/';
+    const canonicalUrl = 'https://www.datum.net/blog';
     const body = renderEntryMarkdown(page ?? { data: { title: 'Blog' } }, {
       trailingSections: [list.join('\n')],
       sourceUrl: canonicalUrl,

--- a/src/pages/blog/[slug].md.ts
+++ b/src/pages/blog/[slug].md.ts
@@ -30,7 +30,7 @@ export const GET: APIRoute = async ({ params }) => {
     const title = article.title ? `# ${article.title}\n\n` : '';
     const description = article.description ? `> ${article.description}\n\n` : '';
 
-    const canonicalUrl = `https://www.datum.net/blog/${slug}/`;
+    const canonicalUrl = `https://www.datum.net/blog/${slug}`;
     return new Response(`${title}${description}${body}`, {
       headers: {
         'Content-Type': 'text/markdown; charset=utf-8',

--- a/src/pages/brand.md.ts
+++ b/src/pages/brand.md.ts
@@ -22,7 +22,7 @@ export const GET: APIRoute = async () => {
       list.push(`- [${s.data.title ?? slug}](/brand/${slug}/)${desc}`);
     }
 
-    const canonicalUrl = 'https://www.datum.net/brand/';
+    const canonicalUrl = 'https://www.datum.net/brand';
     const body = renderEntryMarkdown(page ?? { data: { title: 'Brand' } }, {
       skipBody: true,
       trailingSections: sections.length ? [list.join('\n')] : [],

--- a/src/pages/changelog.md.ts
+++ b/src/pages/changelog.md.ts
@@ -38,7 +38,7 @@ export const GET: APIRoute = async () => {
       sections.push('');
     }
 
-    const canonicalUrl = 'https://www.datum.net/changelog/';
+    const canonicalUrl = 'https://www.datum.net/changelog';
     const body = renderEntryMarkdown(index ?? { data: { title: 'Changelog' } }, {
       trailingSections: sections.length ? [sections.join('\n').trim()] : [],
       sourceUrl: canonicalUrl,

--- a/src/pages/contact.md.ts
+++ b/src/pages/contact.md.ts
@@ -12,7 +12,7 @@ export const GET: APIRoute = async () => {
     const page = await getEntry('pages', 'contact');
     if (!page) return new Response('Not found', { status: 404 });
 
-    const canonicalUrl = 'https://www.datum.net/contact/';
+    const canonicalUrl = 'https://www.datum.net/contact';
     const body = renderEntryMarkdown(page, {
       trailingSections: [
         [

--- a/src/pages/dedicated-cloud.md.ts
+++ b/src/pages/dedicated-cloud.md.ts
@@ -16,7 +16,7 @@ export const GET: APIRoute = async () => {
     }
     sections.push('');
 
-    const canonicalUrl = 'https://www.datum.net/dedicated-cloud/';
+    const canonicalUrl = 'https://www.datum.net/dedicated-cloud';
     sections.push('---', '', `Source: <${canonicalUrl}>`, '');
 
     const body = toAsciiMarkdown(sections.join('\n'));

--- a/src/pages/download.md.ts
+++ b/src/pages/download.md.ts
@@ -29,7 +29,7 @@ export const GET: APIRoute = async () => {
       return `- [${label}](/download/${entry.id}/) - ${entry.data.description}`;
     });
 
-    const canonicalUrl = 'https://www.datum.net/download/';
+    const canonicalUrl = 'https://www.datum.net/download';
     const body = renderEntryMarkdown(page, {
       trailingSections: list.length ? [['## Available downloads', '', ...list].join('\n')] : [],
       sourceUrl: canonicalUrl,

--- a/src/pages/download/[slug].md.ts
+++ b/src/pages/download/[slug].md.ts
@@ -17,7 +17,7 @@ export const GET: APIRoute = async ({ props }) => {
   try {
     const entry = await getEntry('download', entryId);
     if (!entry) return new Response('Not found', { status: 404 });
-    const canonicalUrl = `https://www.datum.net/download/${entryId}/`;
+    const canonicalUrl = `https://www.datum.net/download/${entryId}`;
     const body = renderEntryMarkdown(entry, {
       demoteHeadings: true,
       sourceUrl: canonicalUrl,

--- a/src/pages/essentials.md.ts
+++ b/src/pages/essentials.md.ts
@@ -40,7 +40,7 @@ export const GET: APIRoute = async () => {
       }
     }
 
-    const canonicalUrl = 'https://www.datum.net/essentials/';
+    const canonicalUrl = 'https://www.datum.net/essentials';
     sections.push('', '---', '', `Source: <${canonicalUrl}>`, '');
 
     const body = toAsciiMarkdown(sections.join('\n'));

--- a/src/pages/events.md.ts
+++ b/src/pages/events.md.ts
@@ -61,7 +61,7 @@ export const GET: APIRoute = async () => {
       '- [Alt Cloud Meetups](/events/alt-cloud-meetups/)'
     );
 
-    const canonicalUrl = 'https://www.datum.net/events/';
+    const canonicalUrl = 'https://www.datum.net/events';
     const body = renderEntryMarkdown(page ?? { data: { title: 'Events' } }, {
       trailingSections: [sections.join('\n')],
       sourceUrl: canonicalUrl,

--- a/src/pages/features.md.ts
+++ b/src/pages/features.md.ts
@@ -71,7 +71,7 @@ export const GET: APIRoute = async () => {
       ''
     );
 
-    const canonicalUrl = 'https://www.datum.net/features/';
+    const canonicalUrl = 'https://www.datum.net/features';
     sections.push('---', '', `Source: <${canonicalUrl}>`, '');
 
     const body = toAsciiMarkdown(sections.join('\n'));

--- a/src/pages/handbook.md.ts
+++ b/src/pages/handbook.md.ts
@@ -21,7 +21,7 @@ export const GET: APIRoute = async () => {
       }
     }
 
-    const canonicalUrl = 'https://www.datum.net/handbook/';
+    const canonicalUrl = 'https://www.datum.net/handbook';
     const body = renderEntryMarkdown(index ?? { data: { title: 'Handbook' } }, {
       trailingSections: sections.length ? [sections.join('\n')] : [],
       sourceUrl: canonicalUrl,

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -6,6 +6,27 @@ import { extractDescription, buildUrl, stripHtml } from '@utils/llmsUtils';
 // Note: handbook entries intentionally excluded — internal company ops content
 // is not relevant to AI agents consuming platform documentation.
 
+// The `features/<hub>/*` pages entries back the /platform/<hub> hub pages
+// (src/pages/platform/{deliver,build,connect}.astro) — each hub composes an
+// `index` entry plus several sub-feature entries into one route with anchor
+// sections, so `buildUrl(page.id)` (which assumes one entry = one URL) would
+// otherwise point at dead `/features/<hub>/...` URLs. Override with the real
+// hub URL, anchored to the matching FeatureSection id for sub-features.
+const PLATFORM_HUB_URL_OVERRIDES: Record<string, string> = {
+  'features/deliver/index': '/platform/deliver',
+  'features/deliver/dns': '/platform/deliver#dns',
+  'features/deliver/application-load-balancer': '/platform/deliver#application-load-balancer',
+  'features/deliver/global-load-balancer': '/platform/deliver#global-load-balancer',
+  'features/build/index': '/platform/build',
+  'features/build/compute': '/platform/build#compute',
+  'features/build/object-storage': '/platform/build#object-storage',
+  'features/build/edge-apps': '/platform/build#edge-apps',
+  'features/connect/index': '/platform/connect',
+  'features/connect/galactic-vpc': '/platform/connect#galactic-vpc',
+  'features/connect/connectors': '/platform/connect#connectors',
+  'features/connect/interconnect': '/platform/connect#interconnect',
+};
+
 export const GET: APIRoute = async () => {
   try {
     // Get project info
@@ -28,7 +49,10 @@ export const GET: APIRoute = async () => {
         page.data.meta?.description ||
         page.data.description ||
         extractDescription(page.body, 'No description available');
-      const pageUrl = buildUrl(page.id);
+      const override = PLATFORM_HUB_URL_OVERRIDES[page.id];
+      const pageUrl = override
+        ? `${(site || '').replace(/\/+$/, '')}${override.replace(/^([^#]+)(#.*)?$/, '$1/$2')}`
+        : buildUrl(page.id);
       const pageTitle = stripHtml(page.data.title);
       llmsContent += `- [${pageTitle}](${pageUrl}) - ${description}\n`;
     }

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -51,7 +51,7 @@ export const GET: APIRoute = async () => {
         extractDescription(page.body, 'No description available');
       const override = PLATFORM_HUB_URL_OVERRIDES[page.id];
       const pageUrl = override
-        ? `${(site || '').replace(/\/+$/, '')}${override.replace(/^([^#]+)(#.*)?$/, '$1/$2')}`
+        ? `${(site || '').replace(/\/+$/, '')}${override}`
         : buildUrl(page.id);
       const pageTitle = stripHtml(page.data.title);
       llmsContent += `- [${pageTitle}](${pageUrl}) - ${description}\n`;

--- a/src/pages/locations.md.ts
+++ b/src/pages/locations.md.ts
@@ -66,7 +66,7 @@ export const GET: APIRoute = async () => {
       }
     }
 
-    const canonicalUrl = 'https://www.datum.net/locations/';
+    const canonicalUrl = 'https://www.datum.net/locations';
     sections.push(
       '',
       '## Why these cities',

--- a/src/pages/platform/build.md.ts
+++ b/src/pages/platform/build.md.ts
@@ -1,0 +1,53 @@
+// Dynamic markdown export of /platform/build. Reads the same sources the
+// rendered page consumes (src/pages/platform/build.astro):
+//   - src/content/pages/features/build/index.mdx (hub title + description)
+//   - .../compute.mdx, object-storage.mdx, edge-apps.mdx
+//     (one FeatureSection each, in render order)
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { getEntry } from 'astro:content';
+import { toAsciiMarkdown } from '@utils/markdownExport';
+import { markdownSeoHeaders, extractFeatureBodyParts } from '@utils/pageMarkdown';
+
+function stripHtml(input: string): string {
+  return input.replace(/<\/?[^>]+>/g, '').trim();
+}
+
+export const GET: APIRoute = async () => {
+  try {
+    const [index, compute, objectStorage, edgeApps] = await Promise.all([
+      getEntry('pages', 'features/build/index'),
+      getEntry('pages', 'features/build/compute'),
+      getEntry('pages', 'features/build/object-storage'),
+      getEntry('pages', 'features/build/edge-apps'),
+    ]);
+
+    const sections: string[] = [`# ${stripHtml(index?.data.title ?? 'Build')}`, ''];
+    if (index?.data.description) sections.push(index.data.description, '');
+
+    for (const entry of [compute, objectStorage, edgeApps]) {
+      if (!entry) continue;
+      sections.push(`## ${entry.data.title}`, '');
+      const { badge, linkHref, linkText } = extractFeatureBodyParts(entry.body);
+      if (badge) sections.push(`_${badge}_`, '');
+      if (entry.data.description) sections.push(entry.data.description, '');
+      if (linkHref && linkText) sections.push(`[${linkText}](${linkHref})`, '');
+    }
+
+    const canonicalUrl = 'https://www.datum.net/platform/build/';
+    sections.push('---', '', `Source: <${canonicalUrl}>`, '');
+
+    const body = toAsciiMarkdown(sections.join('\n'));
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'public, max-age=300, s-maxage=300',
+        ...markdownSeoHeaders(canonicalUrl),
+      },
+    });
+  } catch (error) {
+    console.error('Failed to serve /platform/build.md:', error);
+    return new Response('Error generating markdown', { status: 500 });
+  }
+};

--- a/src/pages/platform/build.md.ts
+++ b/src/pages/platform/build.md.ts
@@ -35,7 +35,7 @@ export const GET: APIRoute = async () => {
       if (linkHref && linkText) sections.push(`[${linkText}](${linkHref})`, '');
     }
 
-    const canonicalUrl = 'https://www.datum.net/platform/build/';
+    const canonicalUrl = 'https://www.datum.net/platform/build';
     sections.push('---', '', `Source: <${canonicalUrl}>`, '');
 
     const body = toAsciiMarkdown(sections.join('\n'));

--- a/src/pages/platform/connect.md.ts
+++ b/src/pages/platform/connect.md.ts
@@ -35,7 +35,7 @@ export const GET: APIRoute = async () => {
       if (linkHref && linkText) sections.push(`[${linkText}](${linkHref})`, '');
     }
 
-    const canonicalUrl = 'https://www.datum.net/platform/connect/';
+    const canonicalUrl = 'https://www.datum.net/platform/connect';
     sections.push('---', '', `Source: <${canonicalUrl}>`, '');
 
     const body = toAsciiMarkdown(sections.join('\n'));

--- a/src/pages/platform/connect.md.ts
+++ b/src/pages/platform/connect.md.ts
@@ -1,0 +1,53 @@
+// Dynamic markdown export of /platform/connect. Reads the same sources the
+// rendered page consumes (src/pages/platform/connect.astro):
+//   - src/content/pages/features/connect/index.mdx (hub title + description)
+//   - .../galactic-vpc.mdx, connectors.mdx, interconnect.mdx
+//     (one FeatureSection each, in render order)
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { getEntry } from 'astro:content';
+import { toAsciiMarkdown } from '@utils/markdownExport';
+import { markdownSeoHeaders, extractFeatureBodyParts } from '@utils/pageMarkdown';
+
+function stripHtml(input: string): string {
+  return input.replace(/<\/?[^>]+>/g, '').trim();
+}
+
+export const GET: APIRoute = async () => {
+  try {
+    const [index, galacticVpc, connectors, interconnect] = await Promise.all([
+      getEntry('pages', 'features/connect/index'),
+      getEntry('pages', 'features/connect/galactic-vpc'),
+      getEntry('pages', 'features/connect/connectors'),
+      getEntry('pages', 'features/connect/interconnect'),
+    ]);
+
+    const sections: string[] = [`# ${stripHtml(index?.data.title ?? 'Connect')}`, ''];
+    if (index?.data.description) sections.push(index.data.description, '');
+
+    for (const entry of [galacticVpc, connectors, interconnect]) {
+      if (!entry) continue;
+      sections.push(`## ${entry.data.title}`, '');
+      const { badge, linkHref, linkText } = extractFeatureBodyParts(entry.body);
+      if (badge) sections.push(`_${badge}_`, '');
+      if (entry.data.description) sections.push(entry.data.description, '');
+      if (linkHref && linkText) sections.push(`[${linkText}](${linkHref})`, '');
+    }
+
+    const canonicalUrl = 'https://www.datum.net/platform/connect/';
+    sections.push('---', '', `Source: <${canonicalUrl}>`, '');
+
+    const body = toAsciiMarkdown(sections.join('\n'));
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'public, max-age=300, s-maxage=300',
+        ...markdownSeoHeaders(canonicalUrl),
+      },
+    });
+  } catch (error) {
+    console.error('Failed to serve /platform/connect.md:', error);
+    return new Response('Error generating markdown', { status: 500 });
+  }
+};

--- a/src/pages/platform/deliver.md.ts
+++ b/src/pages/platform/deliver.md.ts
@@ -35,7 +35,7 @@ export const GET: APIRoute = async () => {
       if (linkHref && linkText) sections.push(`[${linkText}](${linkHref})`, '');
     }
 
-    const canonicalUrl = 'https://www.datum.net/platform/deliver/';
+    const canonicalUrl = 'https://www.datum.net/platform/deliver';
     sections.push('---', '', `Source: <${canonicalUrl}>`, '');
 
     const body = toAsciiMarkdown(sections.join('\n'));

--- a/src/pages/platform/deliver.md.ts
+++ b/src/pages/platform/deliver.md.ts
@@ -1,0 +1,53 @@
+// Dynamic markdown export of /platform/deliver. Reads the same sources the
+// rendered page consumes (src/pages/platform/deliver.astro):
+//   - src/content/pages/features/deliver/index.mdx (hub title + description)
+//   - .../dns.mdx, application-load-balancer.mdx, global-load-balancer.mdx
+//     (one FeatureSection each, in render order)
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { getEntry } from 'astro:content';
+import { toAsciiMarkdown } from '@utils/markdownExport';
+import { markdownSeoHeaders, extractFeatureBodyParts } from '@utils/pageMarkdown';
+
+function stripHtml(input: string): string {
+  return input.replace(/<\/?[^>]+>/g, '').trim();
+}
+
+export const GET: APIRoute = async () => {
+  try {
+    const [index, dns, applicationLoadBalancer, globalLoadBalancer] = await Promise.all([
+      getEntry('pages', 'features/deliver/index'),
+      getEntry('pages', 'features/deliver/dns'),
+      getEntry('pages', 'features/deliver/application-load-balancer'),
+      getEntry('pages', 'features/deliver/global-load-balancer'),
+    ]);
+
+    const sections: string[] = [`# ${stripHtml(index?.data.title ?? 'Deliver')}`, ''];
+    if (index?.data.description) sections.push(index.data.description, '');
+
+    for (const entry of [dns, applicationLoadBalancer, globalLoadBalancer]) {
+      if (!entry) continue;
+      sections.push(`## ${entry.data.title}`, '');
+      const { badge, linkHref, linkText } = extractFeatureBodyParts(entry.body);
+      if (badge) sections.push(`_${badge}_`, '');
+      if (entry.data.description) sections.push(entry.data.description, '');
+      if (linkHref && linkText) sections.push(`[${linkText}](${linkHref})`, '');
+    }
+
+    const canonicalUrl = 'https://www.datum.net/platform/deliver/';
+    sections.push('---', '', `Source: <${canonicalUrl}>`, '');
+
+    const body = toAsciiMarkdown(sections.join('\n'));
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'public, max-age=300, s-maxage=300',
+        ...markdownSeoHeaders(canonicalUrl),
+      },
+    });
+  } catch (error) {
+    console.error('Failed to serve /platform/deliver.md:', error);
+    return new Response('Error generating markdown', { status: 500 });
+  }
+};

--- a/src/pages/pricing.md.ts
+++ b/src/pages/pricing.md.ts
@@ -93,7 +93,7 @@ export const GET: APIRoute = async () => {
       }
     }
 
-    const canonicalUrl = 'https://www.datum.net/pricing/';
+    const canonicalUrl = 'https://www.datum.net/pricing';
     sections.push('', '---', '', `Source: <${canonicalUrl}>`, '');
 
     const body = toAsciiMarkdown(sections.join('\n'));

--- a/src/pages/roadmap.md.ts
+++ b/src/pages/roadmap.md.ts
@@ -68,7 +68,7 @@ export const GET: APIRoute = async () => {
       sections.push('', 'No roadmap milestones available yet.');
     }
 
-    const canonicalUrl = 'https://www.datum.net/roadmap/';
+    const canonicalUrl = 'https://www.datum.net/roadmap';
     sections.push(
       '',
       '## How we plan',

--- a/src/pages/roadmap/[slug].md.ts
+++ b/src/pages/roadmap/[slug].md.ts
@@ -67,7 +67,7 @@ export const GET: APIRoute = async ({ params }) => {
       sections.push(`[View on GitHub](${roadmap.githubUrl})`, '');
     }
 
-    const canonicalUrl = `https://www.datum.net/roadmap/${slug}/`;
+    const canonicalUrl = `https://www.datum.net/roadmap/${slug}`;
     sections.push('---', '', `Source: <${canonicalUrl}>`, '');
 
     const body = toAsciiMarkdown(sections.join('\n'));

--- a/src/pages/roadmap/backlog.md.ts
+++ b/src/pages/roadmap/backlog.md.ts
@@ -49,7 +49,7 @@ export const GET: APIRoute = async () => {
       }
     }
 
-    const canonicalUrl = 'https://www.datum.net/roadmap/backlog/';
+    const canonicalUrl = 'https://www.datum.net/roadmap/backlog';
     sections.push(
       '',
       '---',

--- a/src/utils/llmsUtils.ts
+++ b/src/utils/llmsUtils.ts
@@ -87,7 +87,8 @@ export const formatDate = (date: Date | string | undefined): string => {
   }
 };
 
-// Build URL for a content item
+// Build URL for a content item. The site uses trailingSlash: 'never', so
+// every URL below (other than the bare root) must NOT have a trailing slash.
 export const buildUrl = (id: string, basePath: string = ''): string => {
   // Normalize siteUrl - remove trailing slashes
   const siteUrl = (site || '').replace(/\/+$/, '');
@@ -97,10 +98,10 @@ export const buildUrl = (id: string, basePath: string = ''): string => {
   const cleanId = id.replace(/^\/+|\/+$/g, '');
 
   if (cleanId === '' || cleanId === 'index') {
-    return basePath ? `${siteUrl}/${basePath}/` : `${siteUrl}/`;
+    return basePath ? `${siteUrl}/${basePath}` : `${siteUrl}/`;
   } else if (cleanId.endsWith('/index')) {
-    return `${siteUrl}/${prefix}${cleanId.replace('/index', '')}/`;
+    return `${siteUrl}/${prefix}${cleanId.replace('/index', '')}`;
   } else {
-    return `${siteUrl}/${prefix}${cleanId}/`;
+    return `${siteUrl}/${prefix}${cleanId}`;
   }
 };

--- a/src/utils/markdownRegistry.ts
+++ b/src/utils/markdownRegistry.ts
@@ -40,6 +40,9 @@ const DEDICATED_ENDPOINTS = new Set<string>([
   '/brand',
   '/pricing',
   '/locations',
+  '/platform/deliver',
+  '/platform/build',
+  '/platform/connect',
 ]);
 
 /**

--- a/src/utils/pageMarkdown.ts
+++ b/src/utils/pageMarkdown.ts
@@ -121,6 +121,29 @@ export function renderEntryMarkdown(
 }
 
 /**
+ * Extracts the FeatureBadge status text and Button doc-link (href + label)
+ * from a feature entry's raw MDX body. Feature-section bodies (src/content/pages/
+ * features/<hub>/<slug>.mdx) are pure component composition — a heading that
+ * duplicates the title, an optional status badge, and an optional CTA link —
+ * with no independent prose, so these parsed pieces plus the frontmatter
+ * description are the whole story for a markdown export.
+ */
+export function extractFeatureBodyParts(body: string | undefined): {
+  badge?: string;
+  linkText?: string;
+  linkHref?: string;
+} {
+  if (!body) return {};
+  const badgeMatch = body.match(/<FeatureBadge[^>]*>(.*?)<\/FeatureBadge>/s);
+  const linkMatch = body.match(/<Button\s+href="([^"]+)"[^>]*\btext="([^"]+)"/);
+  return {
+    badge: badgeMatch?.[1]?.trim(),
+    linkHref: linkMatch?.[1],
+    linkText: linkMatch?.[2],
+  };
+}
+
+/**
  * Convenience factory for a basic GET handler that reads one entry from a
  * collection and returns it as ASCII markdown. For most static-content pages
  * the body alone is enough; for listing or composed pages use a custom


### PR DESCRIPTION
## Summary

- Add markdown export for the new `/platform/deliver`, `/platform/build`, and `/platform/connect` pages — they were never registered in `markdownRegistry.ts`, so the "Read as Markdown" footer trigger silently didn't render and `<path>.md` 404'd.
- Fix `llms.txt`, which built these pages' URLs generically from collection IDs and was advertising 12 dead `/features/<hub>/...` links (the routes moved to `/platform/<hub>` anchor sections). Overridden with the real `/platform/<hub>#<section>` URLs.
- Drop trailing slashes from every markdown-export canonical/source URL sitewide (`buildUrl()` in `llmsUtils.ts` and every dedicated `*.md.ts` endpoint). The site is `trailingSlash: 'never'`, so `/about/`, `/pricing/`, `/platform/deliver/`, etc. all 404'd while their no-slash equivalents 200 — meaning every entry in `llms.txt` and every markdown-export canonical/`Link` header pointed at a dead URL.

## Test plan

- [x] Confirmed via Playwright that the "Read as Markdown" trigger now renders on `/platform/deliver`, `/platform/build`, `/platform/connect`
- [x] Confirmed `/platform/{deliver,build,connect}.md` return 200 with clean markdown output
- [x] Confirmed all 12 previously-dead links in `/llms.txt` now resolve to real `/platform/<hub>#<section>` URLs
- [x] Confirmed `sitemap.xml` was already correct (lists `/platform/*`, no stale `/features/*`) — no change needed
- [x] Confirmed every `*.md.ts` endpoint and `llms.txt` entry now returns a URL that resolves without a trailing-slash 404
- [x] `tsc --noEmit` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
