### PR TITLE
fix(nav): activate platform menu on essentials/locations pages

### DIFF
--- a/src/components/NavMenu.astro
+++ b/src/components/NavMenu.astro
@@ -33,13 +33,17 @@ function isActivePath(href: string, currentPath: string): boolean {
   return false;
 }
 
-// Helper function to check if any child items are active
-function hasActiveChild(sections: NavData['main'][0]['children'], currentPath: string): boolean {
-  return (
-    sections?.some((section) =>
-      section.items?.some((item) => isActivePath(item.href, currentPath))
-    ) ?? false
-  );
+// Helper function to check if any child items (including aside cards) are active
+function hasActiveChild(item: NavMainItem, currentPath: string): boolean {
+  const hasActiveSection =
+    item.children?.some((section) =>
+      section.items?.some((childItem) => isActivePath(childItem.href, currentPath))
+    ) ?? false;
+
+  const hasActiveAsideCard =
+    item.asideCards?.some((card) => isActivePath(card.href, currentPath)) ?? false;
+
+  return hasActiveSection || hasActiveAsideCard;
 }
 
 /** Stable class for top-level nav label, e.g. `nav-dropdown-parent--product`. */
@@ -58,9 +62,7 @@ function navDropdownParentClass(text: string): string {
     {
       items.map((item) => {
         const isActive = isActivePath(item.href, currentPath);
-        const hasActiveChildItem = item.children
-          ? hasActiveChild(item.children, currentPath)
-          : false;
+        const hasActiveChildItem = hasActiveChild(item, currentPath);
         const isParentActive = isActive || hasActiveChildItem;
 
         return (

--- a/src/static/styles/components-essentials.css
+++ b/src/static/styles/components-essentials.css
@@ -15,14 +15,7 @@
     @apply rounded-sm;
     @apply flex items-center justify-center;
     @apply size-10;
-    background-image: linear-gradient(var(--color-iris-pale), var(--color-iris-pale));
-    background-size: 0% 100%;
-    background-repeat: no-repeat;
-    background-position: left center;
-    transition: background-size 0.5s cubic-bezier(0.4, 0, 0.2, 1);
-    &.highlight-animate {
-      background-size: 100% 100%;
-    }
+    @apply bg-iris-highlight-accent;
 
     svg {
       @apply text-iris size-5;

--- a/src/static/styles/theme.css
+++ b/src/static/styles/theme.css
@@ -63,6 +63,7 @@
   --color-connect-slate: #5c7693;
   --color-iris: #7a6f8a;
   --color-iris-pale: #e5e3f3;
+  --color-iris-highlight-accent: #d3cfe5;
   --color-platinum: #f9f9f8;
   --color-pine-forge---links: #417958;
   --color-aurora-mist: #e2ede7;


### PR DESCRIPTION
Check aside cards (Essentials, Locations) in addition to dropdown sections when determining whether the Platform nav item is active.

Also add the --color-iris-highlight-accent theme token and use it as a static background for the essentials icon instead of the hover-triggered gradient animation.