### PR TITLE
feat(roadmap): improve backlog loading and cache refresh UX

### DIFF
--- a/src/components/roadmap/BacklogLiveUpdate.astro
+++ b/src/components/roadmap/BacklogLiveUpdate.astro
@@ -2,21 +2,27 @@
 // src/components/roadmap/BacklogLiveUpdate.astro
 interface Props {
   updatedAt: number | null;
+  isRefreshing?: boolean;
 }
 
-const { updatedAt } = Astro.props as Props;
+const { updatedAt, isRefreshing = false } = Astro.props as Props;
 
 const POLL_INTERVAL_MS = 3 * 60 * 1000;
 const FAST_POLL_INTERVAL_MS = 2 * 1000;
 ---
 
 <div
+  class="roadmap-backlog-live"
   x-data={`{
     updatedAt: ${JSON.stringify(updatedAt)},
+    isRefreshing: ${JSON.stringify(isRefreshing)},
     poll() {
       fetch('/api/roadmap/backlog-meta', { cache: 'no-store' })
         .then((res) => res.json())
         .then((data) => {
+          if (typeof data.isRefreshing === 'boolean') {
+            this.isRefreshing = data.isRefreshing;
+          }
           if (data.updatedAt && data.updatedAt !== this.updatedAt) {
             this.updatedAt = data.updatedAt;
             this.refresh();
@@ -34,12 +40,25 @@ const FAST_POLL_INTERVAL_MS = 2 * 1000;
         .catch(() => {});
     },
     schedule() {
-      const delay = this.updatedAt ? ${POLL_INTERVAL_MS} : ${FAST_POLL_INTERVAL_MS};
+      const delay = !this.updatedAt || this.isRefreshing ? ${FAST_POLL_INTERVAL_MS} : ${POLL_INTERVAL_MS};
       setTimeout(() => this.poll(), delay);
+    },
+    showRefreshIndicator() {
+      return this.isRefreshing && this.updatedAt !== null;
     }
   }`}
   x-init="schedule()"
 >
+  <div
+    class="roadmap-backlog-refresh-indicator"
+    x-show="showRefreshIndicator()"
+    x-cloak
+    aria-live="polite"
+  >
+    <span class="roadmap-backlog-refresh-spinner" aria-hidden="true"></span>
+    <span class="sr-only">Updating backlog</span>
+  </div>
+
   <div x-ref="list">
     <slot />
   </div>

--- a/src/components/roadmap/RoadmapBacklog.astro
+++ b/src/components/roadmap/RoadmapBacklog.astro
@@ -2,21 +2,29 @@
 // src/components/roadmap/RoadmapBacklog.astro
 import type { GitHubBacklogItem } from '@libs/githubBacklog';
 import RoadmapBacklogRow from './RoadmapBacklogRow.astro';
+import RoadmapBacklogSkeleton from './RoadmapBacklogSkeleton.astro';
 
 interface Props {
   items: GitHubBacklogItem[];
+  /** Last cache refresh timestamp; null means backlog is still being fetched. */
+  updatedAt?: number | null;
 }
 
-const { items } = Astro.props as Props;
+const { items, updatedAt = null } = Astro.props as Props;
+const isLoading = items.length === 0 && updatedAt === null;
 ---
 
-<section aria-label="Roadmap backlog">
-  {
-    items.length === 0 ? (
+{
+  isLoading ? (
+    <RoadmapBacklogSkeleton />
+  ) : items.length === 0 ? (
+    <section aria-label="Roadmap backlog">
       <p class="datum-text-base text-midnight-fjord/60 py-8 text-center">
         No items available at this time.
       </p>
-    ) : (
+    </section>
+  ) : (
+    <section aria-label="Roadmap backlog">
       <ul class="roadmap-backlog-list">
         {items.map((item) => (
           <li>
@@ -24,6 +32,6 @@ const { items } = Astro.props as Props;
           </li>
         ))}
       </ul>
-    )
-  }
-</section>
+    </section>
+  )
+}

--- a/src/components/roadmap/RoadmapBacklogSkeleton.astro
+++ b/src/components/roadmap/RoadmapBacklogSkeleton.astro
@@ -1,0 +1,19 @@
+---
+// src/components/roadmap/RoadmapBacklogSkeleton.astro
+const SKELETON_ROWS = 5;
+---
+
+<section aria-label="Roadmap backlog" aria-busy="true">
+  <ul class="roadmap-backlog-list roadmap-backlog-skeleton">
+    {
+      Array.from({ length: SKELETON_ROWS }, (_, index) => (
+        <li class="roadmap-backlog-skeleton__row skeleton-item" data-index={String(index + 1)}>
+          <span class="skeleton-box roadmap-backlog-skeleton__number" />
+          <span class="skeleton-box roadmap-backlog-skeleton__title" />
+          <span class="skeleton-box roadmap-backlog-skeleton__status" />
+          <span class="skeleton-box roadmap-backlog-skeleton__link" />
+        </li>
+      ))
+    }
+  </ul>
+</section>

--- a/src/components/roadmap/RoadmapGrid.astro
+++ b/src/components/roadmap/RoadmapGrid.astro
@@ -15,7 +15,6 @@ const { roadmaps, year = new Date().getFullYear() } = Astro.props as Props;
 // Build a lookup: "YYYY-MM" → RoadmapMilestone (grid slot by release month)
 const roadmapByMonth = new Map<string, RoadmapMilestone>();
 for (const r of roadmaps) {
-  console.log(r);
   roadmapByMonth.set(getRoadmapMonthKey(r.releaseDate), r);
 }
 

--- a/src/libs/githubBacklog.ts
+++ b/src/libs/githubBacklog.ts
@@ -437,6 +437,18 @@ export async function fetchGitHubBacklog(): Promise<GitHubBacklogItem[]> {
  * no cache entry exists yet. Cheap — reads the cache only, never calls GitHub.
  */
 export async function getGitHubBacklogUpdatedAt(): Promise<number | null> {
+  const meta = await getGitHubBacklogMeta();
+  return meta.updatedAt;
+}
+
+/** Lightweight backlog cache status for live-update polling. */
+export async function getGitHubBacklogMeta(): Promise<{
+  updatedAt: number | null;
+  isRefreshing: boolean;
+}> {
   const cached = await readCache();
-  return cached?.updatedAt ?? null;
+  return {
+    updatedAt: cached?.updatedAt ?? null,
+    isRefreshing: refreshInFlight !== null,
+  };
 }

--- a/src/pages/api/roadmap/backlog-meta.ts
+++ b/src/pages/api/roadmap/backlog-meta.ts
@@ -3,12 +3,12 @@
 export const prerender = false;
 
 import type { APIRoute } from 'astro';
-import { getGitHubBacklogUpdatedAt } from '@libs/githubBacklog';
+import { getGitHubBacklogMeta } from '@libs/githubBacklog';
 
 export const GET: APIRoute = async () => {
-  const updatedAt = await getGitHubBacklogUpdatedAt();
+  const meta = await getGitHubBacklogMeta();
 
-  return new Response(JSON.stringify({ updatedAt }), {
+  return new Response(JSON.stringify(meta), {
     status: 200,
     headers: {
       'Content-Type': 'application/json',

--- a/src/pages/roadmap/backlog-fragment.astro
+++ b/src/pages/roadmap/backlog-fragment.astro
@@ -3,12 +3,15 @@
 export const prerender = false;
 export const partial = true;
 
-import { fetchGitHubBacklog } from '@libs/githubBacklog';
+import { fetchGitHubBacklog, getGitHubBacklogUpdatedAt } from '@libs/githubBacklog';
 import RoadmapBacklog from '@components/roadmap/RoadmapBacklog.astro';
 
-const backlogItems = await fetchGitHubBacklog();
+const [backlogItems, backlogUpdatedAt] = await Promise.all([
+  fetchGitHubBacklog(),
+  getGitHubBacklogUpdatedAt(),
+]);
 
 Astro.response.headers.set('Cache-Control', 'no-store');
 ---
 
-<RoadmapBacklog items={backlogItems} />
+<RoadmapBacklog items={backlogItems} updatedAt={backlogUpdatedAt} />

--- a/src/pages/roadmap/backlog.astro
+++ b/src/pages/roadmap/backlog.astro
@@ -4,7 +4,7 @@ export const prerender = false;
 
 import '@styles/page-roadmap.css';
 import { getCollectionEntry } from '@utils/collectionUtils';
-import { fetchGitHubBacklog, getGitHubBacklogUpdatedAt } from '@libs/githubBacklog';
+import { fetchGitHubBacklog, getGitHubBacklogMeta } from '@libs/githubBacklog';
 import { fetchGitHubRoadmaps, isRoadmapShipped } from '@libs/githubRoadmap';
 
 import Layout from '@layouts/Layout.astro';
@@ -29,7 +29,8 @@ const layoutTitle = backlogMeta.title ?? 'Datum Product Backlog';
 const layoutDescription = backlogMeta.description ?? backlogPage.data.description;
 
 const [backlogItems, roadmaps] = await Promise.all([fetchGitHubBacklog(), fetchGitHubRoadmaps()]);
-const backlogUpdatedAt = await getGitHubBacklogUpdatedAt();
+const { updatedAt: backlogUpdatedAt, isRefreshing: backlogIsRefreshing } =
+  await getGitHubBacklogMeta();
 const hasUpcoming = roadmaps.some((roadmap) => !isRoadmapShipped(roadmap));
 
 const tabItems = [
@@ -52,8 +53,8 @@ const tabItems = [
             items={tabItems}
           />
         </div>
-        <BacklogLiveUpdate updatedAt={backlogUpdatedAt}>
-          <RoadmapBacklog items={backlogItems} />
+        <BacklogLiveUpdate updatedAt={backlogUpdatedAt} isRefreshing={backlogIsRefreshing}>
+          <RoadmapBacklog items={backlogItems} updatedAt={backlogUpdatedAt} />
         </BacklogLiveUpdate>
       </div>
     </div>

--- a/src/static/styles/components-roadmap.css
+++ b/src/static/styles/components-roadmap.css
@@ -178,6 +178,67 @@
     @apply opacity-80;
   }
 
+  .roadmap-backlog-skeleton__row {
+    @apply border-app---dark---utility-1 flex flex-col items-start gap-4 border-t py-8 md:gap-8 lg:flex-row lg:items-center lg:gap-10;
+  }
+
+  .roadmap-backlog-skeleton .skeleton-box {
+    @apply bg-midnight-fjord/10 rounded;
+    animation: skeleton-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  }
+
+  .roadmap-backlog-skeleton__number {
+    @apply h-6 w-12 shrink-0;
+  }
+
+  .roadmap-backlog-skeleton__title {
+    @apply h-6 min-w-0 flex-1;
+  }
+
+  .roadmap-backlog-skeleton__status {
+    @apply h-7 w-24 shrink-0;
+  }
+
+  .roadmap-backlog-skeleton__link {
+    @apply h-5 w-20 shrink-0;
+  }
+
+  .roadmap-backlog-skeleton .skeleton-item {
+    animation-delay: calc(var(--index, 0) * 100ms);
+  }
+
+  .roadmap-backlog-skeleton .skeleton-item[data-index='1'] {
+    --index: 0;
+  }
+
+  .roadmap-backlog-skeleton .skeleton-item[data-index='2'] {
+    --index: 1;
+  }
+
+  .roadmap-backlog-skeleton .skeleton-item[data-index='3'] {
+    --index: 2;
+  }
+
+  .roadmap-backlog-skeleton .skeleton-item[data-index='4'] {
+    --index: 3;
+  }
+
+  .roadmap-backlog-skeleton .skeleton-item[data-index='5'] {
+    --index: 4;
+  }
+
+  .roadmap-backlog-live {
+    @apply flex flex-col;
+  }
+
+  .roadmap-backlog-refresh-indicator {
+    @apply flex min-h-5 items-center justify-end pb-4;
+  }
+
+  .roadmap-backlog-refresh-spinner {
+    @apply border-glacier-mist-800 border-t-canyon-clay block size-5 animate-spin rounded-full border-2;
+  }
+
   /* ─────────────────────────────────────────────────────────────────────────
    * Roadmap v1 — legacy table layout (kept for backwards compatibility)
    * ───────────────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
Show skeleton rows while the backlog cache is cold, add a refresh spinner during background revalidation, and expose isRefreshing via backlog-meta polling. Remove stray roadmap grid debug logging.