### PR TITLE
docs(handbook): document our SDLC across planning, design, implementation, and monitoring

### DIFF
--- a/src/content/handbook/build/control-plane.md
+++ b/src/content/handbook/build/control-plane.md
@@ -35,11 +35,11 @@ Within an aggregated API server, only the resources that actually need custom be
 
 ## What to expect once you build one
 
-Both of these are durable, customer-facing API surfaces, not internal implementation detail, so they carry a higher bar than a typical feature:
+These carry different bars, because they aren't the same kind of commitment:
 
-- **Design review first** - this almost always meets the bar for a written [design](/handbook/build/design) — it's a new API, and usually touches more than one component
-- **A [service tier](/handbook/build/service-tiers) and matching [production readiness](/handbook/build/production-readiness)** - a controller or API server that customers or other services depend on needs real monitoring and alerting from day one, not added after the fact
-- **Backward compatibility from the first version** - once a resource is in customers' hands, changing its shape is a breaking change; get the [API design](/handbook/build/design#api-design) right before it ships, not after
-- **An owner on the hook long-term** - these aren't "ship and forget" — someone needs to be on the [on-call](/handbook/build/oncall) rotation for it and keep maintaining it as the platform evolves
+- **An aggregated API server is a new API almost by definition**, which means it automatically meets the [design](/handbook/build/design) page's bar for a written design — and because customers or other services will build against its shape, get the [API design](/handbook/build/design#api-design) right before it ships, since changing it later is a breaking change.
+- **A controller isn't automatically a new API** - it's often reconciling a resource that already exists. Whether it needs a written design follows the ordinary rule: does it touch more than one component, is it hard to reverse, is the service Tier 1 or higher. Plenty of controllers are small and don't clear that bar.
+- **Both need a [service tier](/handbook/build/service-tiers) and matching [production readiness](/handbook/build/production-readiness) once they're running against production** - a controller that misbehaves can silently drift or delete customer resources just as easily as a bad API response, so "it's just a controller, not an API" isn't a reason to skip monitoring and alerting.
+- **Both need an owner on the hook long-term** - someone needs to be on the [on-call](/handbook/build/oncall) rotation for it and keep maintaining it as the platform evolves, whichever one it is.
 
 If you're standing up a new control-plane service and think you need one of these, talk to the team first — it's a bigger commitment than a CRD, and there's precedent to build from rather than starting from scratch.

--- a/src/content/handbook/build/control-plane.md
+++ b/src/content/handbook/build/control-plane.md
@@ -16,6 +16,8 @@ This is a detail page under [implementation standards](/handbook/build/standards
 
 ## Controllers
 
+Reach for a controller when something needs to continuously enforce a desired state rather than just respond to a single request — the resource can drift, depends on other resources changing over time, or needs cleanup logic that has to run reliably before it's deleted. If a request comes in, you do the work, and you return a result, that's a normal API handler — it doesn't need a controller. The signal for "this needs a controller" is ongoing reconciliation, not a one-off action.
+
 Every controller we build follows the same reconciler shape: one handler per resource that gets called whenever that resource (or something it watches) changes, rather than a service polling in a loop. A few conventions hold consistently across our control-plane services:
 
 - **Finalizers for cleanup** - cleanup-before-delete logic is registered as a finalizer, not handled as a special case inline
@@ -31,4 +33,13 @@ A CRD registered against the existing API server is the default — reach for it
 
 Within an aggregated API server, only the resources that actually need custom behavior should get hand-written storage — anything that persists normally can still use conventional storage underneath. Going the aggregated route doesn't mean every resource inside it has to be special-cased.
 
-If you're standing up a new control-plane service and think you need this, talk to the team first — it's a bigger commitment than a CRD, and there's precedent to build from rather than starting from scratch.
+## What to expect once you build one
+
+Both of these are durable, customer-facing API surfaces, not internal implementation detail, so they carry a higher bar than a typical feature:
+
+- **Design review first** - this almost always meets the bar for a written [design](/handbook/build/design) — it's a new API, and usually touches more than one component
+- **A [service tier](/handbook/build/service-tiers) and matching [production readiness](/handbook/build/production-readiness)** - a controller or API server that customers or other services depend on needs real monitoring and alerting from day one, not added after the fact
+- **Backward compatibility from the first version** - once a resource is in customers' hands, changing its shape is a breaking change; get the [API design](/handbook/build/design#api-design) right before it ships, not after
+- **An owner on the hook long-term** - these aren't "ship and forget" — someone needs to be on the [on-call](/handbook/build/oncall) rotation for it and keep maintaining it as the platform evolves
+
+If you're standing up a new control-plane service and think you need one of these, talk to the team first — it's a bigger commitment than a CRD, and there's precedent to build from rather than starting from scratch.

--- a/src/content/handbook/build/control-plane.md
+++ b/src/content/handbook/build/control-plane.md
@@ -1,0 +1,46 @@
+---
+title: "Control plane implementation"
+sidebar:
+  label: Control plane implementation
+  order: 2.6
+updatedDate: Jul 24, 2026
+authors: jacob
+meta:
+  title: "Controller & Aggregated API Server Patterns - Datum Handbook"
+  description: "How Datum's control-plane services implement controllers and aggregated API servers — conventions for reconcilers, finalizers, and when to reach for a custom API server."
+  og:
+    title: "Control plane implementation"
+---
+
+This is a detail page under [implementation standards](/handbook/build/standards) — the general standards there (version control, code review, CI) apply here too. This page is specifically about how our control-plane services (`milo`, `search`, `activity`, and similar) implement two recurring building blocks: controllers and aggregated API servers.
+
+## Controllers
+
+Every controller we build is a `controller-runtime` reconciler: one `Reconciler` struct per resource, with a `SetupWithManager(mgr ctrl.Manager) error` that wires it up via `ctrl.NewControllerManagedBy(mgr).For(&Type{}).Complete(r)`. The conventions that show up consistently across `milo`, `search`, and `activity`:
+
+- **Finalizers for cleanup** - register cleanup logic with `controllerutil.AddFinalizer`/`RemoveFinalizer` (or the newer `controller-runtime` finalizer registry) rather than handling deletion as a special case inline
+- **Status via conditions** - use `metav1.Condition` and `apimeta.SetStatusCondition` (a `Ready` condition plus resource-specific ones), not a single status enum
+- **Idempotent, requeue-driven reconciliation** - Get → check → Create/Update, and requeue transient failures with `ctrl.Result{RequeueAfter: ...}` instead of hand-rolled retry loops
+- **Cross-cluster watches when a resource depends on another cluster's state** - wire a `WatchesRawSource` against the other cluster's cache rather than polling
+
+`milo/internal/controllers/resourcemanager/project_controller.go` is the clearest example of all four conventions together (finalizer, cross-cluster reconcile via `sigs.k8s.io/multicluster-runtime`, status conditions, `SetupWithManager`), with its design documented at `milo/docs/architecture/controllers/project-controller/README.md`. `search/internal/controllers/policy/policy_controller.go` shows the same shape applied to a lighter-weight case — a policy reconciler that only manages lifecycle, while the actual work (indexing) runs as a separate NATS-driven worker rather than inside the reconcile loop. That split — a `controller-runtime` reconciler for lifecycle/policy, plus an event-driven worker for the hot path — is worth copying whenever the "real work" is too high-throughput to live comfortably inside a reconcile loop.
+
+Leader election is one place `milo` diverges from `search`/`activity`: `milo`'s controller-manager is a close fork of upstream `kube-controller-manager` and uses `client-go`'s leader election directly (`milo/cmd/milo/controller-manager/controllermanager.go`), while `search` and `activity` use the simpler `EnableLeaderElection` flag built into a plain `controller-runtime` manager. Default to the plain manager flag unless you have milo's reasons (multiple cooperating controller processes) to do otherwise.
+
+## Aggregated API servers
+
+A CRD registered against the existing API server is the default — reach for it first. An aggregated API server (`k8s.io/apiserver`'s `genericapiserver`) is worth the extra machinery specifically when a resource **can't be modeled as etcd-backed CRUD**: `activity`'s `AuditLogQuery` is the clearest real example — it executes a query against ClickHouse and returns a computed, non-persisted result, which a CRD's create-and-store model can't express.
+
+When an aggregated API server is warranted, `search/internal/apiserver/apiserver.go` and `activity/internal/apiserver/apiserver.go` are the two reference implementations to copy from — both follow the standard `k8s.io/sample-apiserver` shape:
+
+- A package-level `Scheme`/`Codecs`, with an `init()` that installs versioned and internal types
+- An `ExtraConfig` struct for service-specific dependencies (search's Meilisearch client, activity's ClickHouse/NATS config)
+- `Config{GenericConfig, ExtraConfig}` → `Complete()` → `CompletedConfig` (the "completed config" idiom, not a bare struct)
+- `New()` calling `GenericConfig.New(...)`, building `map[string]rest.Storage` per API group/version, and `InstallAPIGroup(...)`
+- Registration under a service-owned group (e.g. `search.miloapis.com/v1alpha1`), proxied in via an `APIService`
+
+Storage within an aggregated API server can still be conventional etcd-backed REST storage for resources that do persist (`activity`'s `ActivityPolicy`, `search`'s `ResourceIndexPolicy`) — going the aggregated-API-server route doesn't mean every resource inside it has to be custom. Only hand-write storage for the resources that actually need it.
+
+`milo` is the exception, not the model to start from: its API server chains `apiextensions-apiserver` (CRDs) → the vendored upstream `controlplane` apiserver → `kube-aggregator` (`milo/cmd/milo/apiserver/server.go`) — it's effectively a customized Kubernetes control-plane binary, built to host every other service's CRDs and aggregated APIs, not a pattern to re-derive for a new service.
+
+There's no shared Milo scaffold or code generator behind any of this — `search` and `activity` don't depend on `milo` or on each other; each hand-wires the same upstream idiom independently. If you're standing up a new control-plane service, start from whichever of `search` or `activity`'s `apiserver.go` is closer to your resource shape (persisted-but-custom vs. computed-and-ephemeral) rather than starting from scratch.

--- a/src/content/handbook/build/control-plane.md
+++ b/src/content/handbook/build/control-plane.md
@@ -16,31 +16,19 @@ This is a detail page under [implementation standards](/handbook/build/standards
 
 ## Controllers
 
-Every controller we build is a `controller-runtime` reconciler: one `Reconciler` struct per resource, with a `SetupWithManager(mgr ctrl.Manager) error` that wires it up via `ctrl.NewControllerManagedBy(mgr).For(&Type{}).Complete(r)`. The conventions that show up consistently across `milo`, `search`, and `activity`:
+Every controller we build follows the same reconciler shape: one handler per resource that gets called whenever that resource (or something it watches) changes, rather than a service polling in a loop. A few conventions hold consistently across our control-plane services:
 
-- **Finalizers for cleanup** - register cleanup logic with `controllerutil.AddFinalizer`/`RemoveFinalizer` (or the newer `controller-runtime` finalizer registry) rather than handling deletion as a special case inline
-- **Status via conditions** - use `metav1.Condition` and `apimeta.SetStatusCondition` (a `Ready` condition plus resource-specific ones), not a single status enum
-- **Idempotent, requeue-driven reconciliation** - Get → check → Create/Update, and requeue transient failures with `ctrl.Result{RequeueAfter: ...}` instead of hand-rolled retry loops
-- **Cross-cluster watches when a resource depends on another cluster's state** - wire a `WatchesRawSource` against the other cluster's cache rather than polling
+- **Finalizers for cleanup** - cleanup-before-delete logic is registered as a finalizer, not handled as a special case inline
+- **Status via conditions** - resources report state through a set of conditions (a `Ready` condition plus resource-specific ones), not a single status enum
+- **Idempotent, requeue-driven reconciliation** - check current state, then create/update as needed, and requeue transient failures rather than hand-rolling retry loops
+- **Watch dependencies directly** - when a resource depends on state in another cluster or service, wire a watch against it instead of polling
 
-`milo/internal/controllers/resourcemanager/project_controller.go` is the clearest example of all four conventions together (finalizer, cross-cluster reconcile via `sigs.k8s.io/multicluster-runtime`, status conditions, `SetupWithManager`), with its design documented at `milo/docs/architecture/controllers/project-controller/README.md`. `search/internal/controllers/policy/policy_controller.go` shows the same shape applied to a lighter-weight case — a policy reconciler that only manages lifecycle, while the actual work (indexing) runs as a separate NATS-driven worker rather than inside the reconcile loop. That split — a `controller-runtime` reconciler for lifecycle/policy, plus an event-driven worker for the hot path — is worth copying whenever the "real work" is too high-throughput to live comfortably inside a reconcile loop.
-
-Leader election is one place `milo` diverges from `search`/`activity`: `milo`'s controller-manager is a close fork of upstream `kube-controller-manager` and uses `client-go`'s leader election directly (`milo/cmd/milo/controller-manager/controllermanager.go`), while `search` and `activity` use the simpler `EnableLeaderElection` flag built into a plain `controller-runtime` manager. Default to the plain manager flag unless you have milo's reasons (multiple cooperating controller processes) to do otherwise.
+One pattern worth calling out: when the "real work" behind a resource is high-throughput (e.g. indexing, streaming), it's common to split it in two — a lightweight reconciler that only manages the resource's lifecycle and policy, plus a separate event-driven worker that does the actual work. Don't cram high-throughput processing into a reconcile loop.
 
 ## Aggregated API servers
 
-A CRD registered against the existing API server is the default — reach for it first. An aggregated API server (`k8s.io/apiserver`'s `genericapiserver`) is worth the extra machinery specifically when a resource **can't be modeled as etcd-backed CRUD**: `activity`'s `AuditLogQuery` is the clearest real example — it executes a query against ClickHouse and returns a computed, non-persisted result, which a CRD's create-and-store model can't express.
+A CRD registered against the existing API server is the default — reach for it first. A custom, aggregated API server is worth the extra machinery specifically when a resource **can't be modeled as etcd-backed CRUD** — for example, a resource that represents a live query against another data store and returns a computed, non-persisted result rather than something we create and store.
 
-When an aggregated API server is warranted, `search/internal/apiserver/apiserver.go` and `activity/internal/apiserver/apiserver.go` are the two reference implementations to copy from — both follow the standard `k8s.io/sample-apiserver` shape:
+Within an aggregated API server, only the resources that actually need custom behavior should get hand-written storage — anything that persists normally can still use conventional storage underneath. Going the aggregated route doesn't mean every resource inside it has to be special-cased.
 
-- A package-level `Scheme`/`Codecs`, with an `init()` that installs versioned and internal types
-- An `ExtraConfig` struct for service-specific dependencies (search's Meilisearch client, activity's ClickHouse/NATS config)
-- `Config{GenericConfig, ExtraConfig}` → `Complete()` → `CompletedConfig` (the "completed config" idiom, not a bare struct)
-- `New()` calling `GenericConfig.New(...)`, building `map[string]rest.Storage` per API group/version, and `InstallAPIGroup(...)`
-- Registration under a service-owned group (e.g. `search.miloapis.com/v1alpha1`), proxied in via an `APIService`
-
-Storage within an aggregated API server can still be conventional etcd-backed REST storage for resources that do persist (`activity`'s `ActivityPolicy`, `search`'s `ResourceIndexPolicy`) — going the aggregated-API-server route doesn't mean every resource inside it has to be custom. Only hand-write storage for the resources that actually need it.
-
-`milo` is the exception, not the model to start from: its API server chains `apiextensions-apiserver` (CRDs) → the vendored upstream `controlplane` apiserver → `kube-aggregator` (`milo/cmd/milo/apiserver/server.go`) — it's effectively a customized Kubernetes control-plane binary, built to host every other service's CRDs and aggregated APIs, not a pattern to re-derive for a new service.
-
-There's no shared Milo scaffold or code generator behind any of this — `search` and `activity` don't depend on `milo` or on each other; each hand-wires the same upstream idiom independently. If you're standing up a new control-plane service, start from whichever of `search` or `activity`'s `apiserver.go` is closer to your resource shape (persisted-but-custom vs. computed-and-ephemeral) rather than starting from scratch.
+If you're standing up a new control-plane service and think you need this, talk to the team first — it's a bigger commitment than a CRD, and there's precedent to build from rather than starting from scratch.

--- a/src/content/handbook/build/control-plane.md
+++ b/src/content/handbook/build/control-plane.md
@@ -24,6 +24,7 @@ Every controller we build follows the same reconciler shape: one handler per res
 - **Status via conditions** - resources report state through a set of conditions (a `Ready` condition plus resource-specific ones), not a single status enum
 - **Idempotent, requeue-driven reconciliation** - check current state, then create/update as needed, and requeue transient failures rather than hand-rolling retry loops
 - **Watch dependencies directly** - when a resource depends on state in another cluster or service, wire a watch against it instead of polling
+- **Owner references for cascading cleanup** - when one resource's lifecycle should be tied to another's (a child resource that shouldn't outlive its parent), express that with an owner reference rather than a bespoke delete hook the next engineer has to discover
 
 One pattern worth calling out: when the "real work" behind a resource is high-throughput (e.g. indexing, streaming), it's common to split it in two — a lightweight reconciler that only manages the resource's lifecycle and policy, plus a separate event-driven worker that does the actual work. Don't cram high-throughput processing into a reconcile loop.
 
@@ -32,6 +33,11 @@ One pattern worth calling out: when the "real work" behind a resource is high-th
 A CRD registered against the existing API server is the default — reach for it first. A custom, aggregated API server is worth the extra machinery specifically when a resource **can't be modeled as etcd-backed CRUD** — for example, a resource that represents a live query against another data store and returns a computed, non-persisted result rather than something we create and store.
 
 Within an aggregated API server, only the resources that actually need custom behavior should get hand-written storage — anything that persists normally can still use conventional storage underneath. Going the aggregated route doesn't mean every resource inside it has to be special-cased.
+
+A couple of API-serving conventions apply whether you're writing custom storage or not:
+
+- **Validate and default on the server, not the client** - every consumer (portal, CLI, SDK, another service) should get identical validation and defaulting behavior, which only holds if it lives in the API layer instead of being re-implemented per client
+- **Paginate large collections with a continue token, not an offset** - offsets get inconsistent under concurrent writes; a continue token doesn't
 
 ## What to expect once you build one
 

--- a/src/content/handbook/build/design.md
+++ b/src/content/handbook/build/design.md
@@ -16,14 +16,14 @@ Design is the second phase of our SDLC, sitting between [planning](/handbook/pro
 
 ## System design
 
-We keep design lightweight and proportional to blast radius. Not every enhancement needs a formal document — a comment thread on the GitHub issue is often enough. A design doc earns its keep when a change:
+We keep design lightweight and proportional to blast radius. Not every enhancement needs a formal document — a discussion on the GitHub issue from planning is often enough. A design doc earns its keep when a change:
 
 - Touches more than one [component](/handbook/build/components) (infrastructure, platform, backend, or software)
 - Introduces a new API, resource type, or external dependency
 - Has a [service tier](/handbook/build/service-tiers) of Tier 1 or higher
 - Is hard to reverse once shipped
 
-When a design doc is warranted, it lives as a comment or linked document on the GitHub issue from planning — not a separate system. At minimum it should cover the problem being solved, the approach, alternatives considered and why they were rejected, and the operational cost (what it takes to run and monitor once shipped — see [production readiness](/handbook/build/production-readiness)).
+When a design doc is warranted, it's a committed document — not a GitHub issue comment — so it stays reviewable, linkable, and versioned alongside the code it describes (see [where designs actually live](#where-designs-actually-live) below). The issue from planning just links to it. At minimum it should cover the problem being solved, the approach, alternatives considered and why they were rejected, and the operational cost (what it takes to run and monitor once shipped — see [production readiness](/handbook/build/production-readiness)).
 
 Get eyes on the design before writing code. It's much cheaper to argue about an approach on paper than to unwind it after a PR is half-merged.
 

--- a/src/content/handbook/build/design.md
+++ b/src/content/handbook/build/design.md
@@ -27,6 +27,15 @@ When a design doc is warranted, it lives as a comment or linked document on the 
 
 Get eyes on the design before writing code. It's much cheaper to argue about an approach on paper than to unwind it after a PR is half-merged.
 
+### Where designs actually live
+
+In practice we use two mechanisms, depending on scope:
+
+- **Cross-cutting concerns** — anything spanning multiple services or systems (a shared auth model, a new cross-cutting API convention, an infra-wide change) — go through [`datum-cloud/enhancements`](https://github.com/datum-cloud/enhancements). It uses a single, Kubernetes-KEP-inspired template (Summary, Motivation with Goals/Non-Goals, Proposal, Design Details, a Production Readiness Review questionnaire, Alternatives) for everything, from a scoped product feature up to an org-wide architectural pattern — the rigor and which sections get filled out scale with how far-reaching the change is, not a different template.
+- **Service-specific design** lives in that service's own repo, typically under a `docs/` directory, so it stays next to the code it describes and is versioned alongside it.
+
+For a concrete model of what a strong in-repo `docs/` looks like, `milo-os/search` and `milo-os/activity` are worth studying. `search`'s `docs/enhancements/` folder is a lightweight local version of the KEP pattern above, and `docs/components/resource-indexer.md` is a genuinely thorough component design (sequence diagrams for every event path, a decision table, an explicit error-handling taxonomy). `activity`'s `docs/architecture/` is the stronger model for the broader documentation *program*: a single `README.md` hub that cross-links every sub-doc, a `data-model.md` with real schema and rationale, and — notably for the [monitoring phase](/handbook/build/production-readiness#monitoring--observability) — dated incident write-ups under `docs/investigations/` and alert-driven runbooks under `docs/runbooks/` (see [incidents](/handbook/build/incidents)). Neither repo is "the" template to copy verbatim, but between them they show what good looks like: rigorous decision records from `search`, and a mature, cross-linked documentation program from `activity`.
+
 ## API design
 
 Datum's [backend](/handbook/build/components) and control plane are built around a declarative, resource-oriented model — closer to the Kubernetes API style than a traditional CRUD REST API. That shapes how we think about any new API surface, whether it's exposed by [Milo](/handbook/product/milo) or the broader platform:

--- a/src/content/handbook/build/design.md
+++ b/src/content/handbook/build/design.md
@@ -42,10 +42,25 @@ Datum's [backend](/handbook/build/components) and control plane are built around
 
 - **Resources, not actions** - Model the thing being managed (a connection, a quota, a domain) as a resource with a desired state, rather than a collection of imperative endpoints
 - **Design for intent, not mechanism** - A resource should capture *what* the consumer wants to achieve, not the specific steps we currently take to get there. "Give me a database with these characteristics" is an intent; "create this exact set of low-level primitives" is a mechanism leaking through the API. Intent-based resources are what let us change how something is implemented underneath without breaking everyone who built against it
-- **Backward compatibility by default** - Existing fields and behavior shouldn't break for existing customers; new capabilities are additive or versioned
+- **Backward compatibility by default** - Existing fields and behavior shouldn't break for existing customers; new capabilities are additive or versioned (see [deprecation policy](#deprecation-policy) below for what this means in practice)
 - **Consistent with what's already there** - A new resource type should look and feel like the ones customers already use, not introduce a one-off convention
 - **AX and DX before UX** - Per our [product values](/handbook/product/index#product-values), design the agent and developer surface (API, SDK, `datumctl`) first; the portal UI is a consumer of the same API, not a special case
 
 A good test for intent vs. mechanism: if the implementation underneath a resource changed completely, would consumers need to change anything about how they use it? If yes, some mechanism has leaked into the API and it's worth another look before it ships.
+
+### Status conventions
+
+Every resource's status should be reportable in a shape a consumer (or another service) can act on programmatically, not just read:
+
+- **A standard condition shape** - each condition carries a `type`, `status`, `reason`, `message`, and `lastTransitionTime`, so any consumer can parse any resource's health the same way instead of learning a bespoke status format per resource type
+- **`observedGeneration`** - status should report which version of the spec it was computed against, so a consumer can tell "the controller has processed my latest change" apart from "the controller just hasn't gotten to it yet" — without guessing from timestamps
+
+### Deprecation policy
+
+"Backward compatible by default" needs a concrete rule to actually hold up:
+
+- A field or API version being removed is marked deprecated first, with a clear replacement documented, before it's ever removed
+- Deprecated fields keep working for a stated minimum number of releases, not "eventually"
+- Callers still using a deprecated field or version get a visible warning back from the API, not just a line in a changelog they may never read
 
 As with system design, the level of rigor should match the size of the surface. A small internal endpoint doesn't need the same scrutiny as a customer-facing resource type that we'll be supporting for years.

--- a/src/content/handbook/build/design.md
+++ b/src/content/handbook/build/design.md
@@ -41,8 +41,11 @@ For a concrete model of what a strong in-repo `docs/` looks like, `milo-os/searc
 Datum's [backend](/handbook/build/components) and control plane are built around a declarative, resource-oriented model — closer to the Kubernetes API style than a traditional CRUD REST API. That shapes how we think about any new API surface, whether it's exposed by [Milo](/handbook/product/milo) or the broader platform:
 
 - **Resources, not actions** - Model the thing being managed (a connection, a quota, a domain) as a resource with a desired state, rather than a collection of imperative endpoints
+- **Design for intent, not mechanism** - A resource should capture *what* the consumer wants to achieve, not the specific steps we currently take to get there. "Give me a database with these characteristics" is an intent; "create this exact set of low-level primitives" is a mechanism leaking through the API. Intent-based resources are what let us change how something is implemented underneath without breaking everyone who built against it
 - **Backward compatibility by default** - Existing fields and behavior shouldn't break for existing customers; new capabilities are additive or versioned
 - **Consistent with what's already there** - A new resource type should look and feel like the ones customers already use, not introduce a one-off convention
 - **AX and DX before UX** - Per our [product values](/handbook/product/index#product-values), design the agent and developer surface (API, SDK, `datumctl`) first; the portal UI is a consumer of the same API, not a special case
+
+A good test for intent vs. mechanism: if the implementation underneath a resource changed completely, would consumers need to change anything about how they use it? If yes, some mechanism has leaked into the API and it's worth another look before it ships.
 
 As with system design, the level of rigor should match the size of the surface. A small internal endpoint doesn't need the same scrutiny as a customer-facing resource type that we'll be supporting for years.

--- a/src/content/handbook/build/design.md
+++ b/src/content/handbook/build/design.md
@@ -1,0 +1,39 @@
+---
+title: "Design"
+sidebar:
+  label: Design
+  order: 1.5
+updatedDate: Jul 24, 2026
+authors: jacob
+meta:
+  title: "System & API Design at Datum - Datum Handbook"
+  description: "How Datum approaches system design and API design once an enhancement is planned — lightweight design docs, and a declarative, control-plane-first approach to APIs."
+  og:
+    title: "Design"
+---
+
+Design is the second phase of our SDLC, sitting between [planning](/handbook/product/roadmap) and [implementation](/handbook/build/standards). An enhancement that's ready to be built still needs someone to work out *how* — what changes, what the interfaces look like, and what it costs us to run.
+
+## System design
+
+We keep design lightweight and proportional to blast radius. Not every enhancement needs a formal document — a comment thread on the GitHub issue is often enough. A design doc earns its keep when a change:
+
+- Touches more than one [component](/handbook/build/components) (infrastructure, platform, backend, or software)
+- Introduces a new API, resource type, or external dependency
+- Has a [service tier](/handbook/build/service-tiers) of Tier 1 or higher
+- Is hard to reverse once shipped
+
+When a design doc is warranted, it lives as a comment or linked document on the GitHub issue from planning — not a separate system. At minimum it should cover the problem being solved, the approach, alternatives considered and why they were rejected, and the operational cost (what it takes to run and monitor once shipped — see [production readiness](/handbook/build/production-readiness)).
+
+Get eyes on the design before writing code. It's much cheaper to argue about an approach on paper than to unwind it after a PR is half-merged.
+
+## API design
+
+Datum's [backend](/handbook/build/components) and control plane are built around a declarative, resource-oriented model — closer to the Kubernetes API style than a traditional CRUD REST API. That shapes how we think about any new API surface, whether it's exposed by [Milo](/handbook/product/milo) or the broader platform:
+
+- **Resources, not actions** - Model the thing being managed (a connection, a quota, a domain) as a resource with a desired state, rather than a collection of imperative endpoints
+- **Backward compatibility by default** - Existing fields and behavior shouldn't break for existing customers; new capabilities are additive or versioned
+- **Consistent with what's already there** - A new resource type should look and feel like the ones customers already use, not introduce a one-off convention
+- **AX and DX before UX** - Per our [product values](/handbook/product/index#product-values), design the agent and developer surface (API, SDK, `datumctl`) first; the portal UI is a consumer of the same API, not a special case
+
+As with system design, the level of rigor should match the size of the surface. A small internal endpoint doesn't need the same scrutiny as a customer-facing resource type that we'll be supporting for years.

--- a/src/content/handbook/build/design.md
+++ b/src/content/handbook/build/design.md
@@ -55,6 +55,16 @@ Every resource's status should be reportable in a shape a consumer (or another s
 - **A standard condition shape** - each condition carries a `type`, `status`, `reason`, `message`, and `lastTransitionTime`, so any consumer can parse any resource's health the same way instead of learning a bespoke status format per resource type
 - **`observedGeneration`** - status should report which version of the spec it was computed against, so a consumer can tell "the controller has processed my latest change" apart from "the controller just hasn't gotten to it yet" — without guessing from timestamps
 
+### Versioning scheme
+
+Every API version carries a stability stage in its name — `v1alpha1`, `v1beta1`, `v1` — and that stage is a promise about how much the shape can still change, not just a label:
+
+- **Alpha (`v1alphaN`)** - may be incomplete or change incompatibly at any time, including bumping straight from `v1alpha1` to `v1alpha2` with no conversion path between them. This is where every API we've shipped so far lives, and it's the right default for anything new — don't reach for beta just because a feature feels done.
+- **Beta (`v1betaN`)** - the shape is considered settled. Real usage is expected, so from here on a breaking change means a new version plus a conversion path between it and the previous one, not an in-place change. Moving something to beta is a deliberate call, not an automatic next step after alpha — treat it like the [design doc](#system-design) bar, since you're committing to support the shape going forward.
+- **Stable (`v1`)** - the [deprecation policy](#deprecation-policy) below applies in full; the shape is a long-term commitment to every consumer built against it.
+
+Since we're early, almost everything we run today is alpha, and that's the correct state for a platform this young — the scheme matters most as the thing that keeps "just add a beta label" from becoming a way to skip making an intentional decision.
+
 ### Deprecation policy
 
 "Backward compatible by default" needs a concrete rule to actually hold up:
@@ -62,5 +72,7 @@ Every resource's status should be reportable in a shape a consumer (or another s
 - A field or API version being removed is marked deprecated first, with a clear replacement documented, before it's ever removed
 - Deprecated fields keep working for a stated minimum number of releases, not "eventually"
 - Callers still using a deprecated field or version get a visible warning back from the API, not just a line in a changelog they may never read
+
+This policy fully applies from beta onward. Alpha versions are explicitly exempt — that's what makes alpha useful.
 
 As with system design, the level of rigor should match the size of the surface. A small internal endpoint doesn't need the same scrutiny as a customer-facing resource type that we'll be supporting for years.

--- a/src/content/handbook/build/incidents.md
+++ b/src/content/handbook/build/incidents.md
@@ -35,4 +35,6 @@ The other component is asynchronous: capturing knowledge. Like any investigation
 
 The analysis of an incident is just as important as mitigating the customer impact. Without good post-incident hygiene, a team is doomed to (a) repeat handling the incident in perpetuity and (b) continue to design systems with yesterday's understanding instead of today's.
 
+A good model for capturing this in-repo, next to the service it's about, is `milo-os/activity`: dated write-ups under `docs/investigations/` (e.g. `YYYY-MM-DD-request-spike.md`, with Severity/Status/Author metadata, a timeline, and root cause analysis), plus alert-driven runbooks under `docs/runbooks/` that pair each alert with symptoms, impact, and concrete investigation commands. Post-mortems and runbooks are a natural byproduct of the [monitoring phase](/handbook/build/production-readiness#monitoring--observability) — an alert or dashboard anomaly is usually what kicks off the investigation in the first place.
+
 By doing incidents well, a lot of good habits will form naturally around the team, which will lead to a stronger team, working on more interesting and business-critical problems, and having a better time working together.

--- a/src/content/handbook/build/index.md
+++ b/src/content/handbook/build/index.md
@@ -21,3 +21,12 @@ We’re not Frodo, we’re Gandalf (or maybe Samwise Gamgee). We’re not Luke, 
 This mindset informs a lot about what we do, and helps us know what we shouldn’t do. Ultimately, our north star is to be a foundational infrastructure partner to our customers, who we believe are building their value directly on top of that infrastructure. No pressure, right? 
 
 Ultimately, it comes down to things like trust, reliability, authenticity, transparency, responsiveness, and honesty. So as we build software, systems, and processes we work to balance the desire to finely craft every element to bullet-proof perfection, with a need to innovate at the speed of the market and our users.
+
+## Our SDLC
+
+Everything we ship moves through the same four phases, though the rigor applied to each scales with the size and blast radius of the change:
+
+1. **[Planning](/handbook/product/roadmap)** - turning an idea into a scoped, prioritized enhancement
+2. **[Design](/handbook/build/design)** - working out the system design and API design before code is written
+3. **[Implementation](/handbook/build/standards)** - version control, code review, and CI standards for turning a design into shipped code
+4. **Monitoring** - [production monitoring & observability](/handbook/build/production-readiness#monitoring--observability) to know a service is healthy, and [listening to customers](/handbook/product/customers#listening-to-customers) to know it's actually useful — both feed back into the next round of planning

--- a/src/content/handbook/build/index.md
+++ b/src/content/handbook/build/index.md
@@ -28,5 +28,5 @@ Everything we ship moves through the same four phases, though the rigor applied 
 
 1. **[Planning](/handbook/product/roadmap)** - turning an idea into a scoped, prioritized enhancement
 2. **[Design](/handbook/build/design)** - working out the system design and API design before code is written
-3. **[Implementation](/handbook/build/standards)** - version control, code review, and CI standards for turning a design into shipped code
+3. **[Implementation](/handbook/build/standards)** - version control, code review, and CI standards for turning a design into shipped code, including [control plane implementation](/handbook/build/control-plane) patterns for controllers and aggregated API servers
 4. **Monitoring** - [production monitoring & observability](/handbook/build/production-readiness#monitoring--observability) to know a service is healthy, and [listening to customers](/handbook/product/customers#listening-to-customers) to know it's actually useful — both feed back into the next round of planning

--- a/src/content/handbook/build/production-readiness.md
+++ b/src/content/handbook/build/production-readiness.md
@@ -46,6 +46,24 @@ We think about observability as five pillars, roughly in order of how early you 
 
 The same graduated scale applies here as everywhere else in this page: Minimum means basic alerting and no dashboard is required; Moderate adds structured logging and a working dashboard; High means full tracing and a public status page. Don't build out all five pillars for an internal tool nobody's paging on.
 
+### Dashboards are code
+
+Dashboards are generated from committed source (Jsonnet/Grafonnet), never hand-built by clicking around in the Grafana UI. That means:
+
+- A dashboard change is a pull request, reviewed like any other change, not a silent edit that only lives in Grafana's own history
+- CI regenerates dashboards from source and fails the build if the generated output has drifted from what's committed — the UI is a rendering of the source, not the source of truth
+- A dashboard is owned by the same team that owns the service it covers, and gets updated as part of any change that adds, removes, or renames what it monitors — a dashboard that still graphs a metric that no longer exists is worse than no dashboard, because it looks like signal
+
+We don't yet have a shared, reusable "golden signals" dashboard template — most dashboards today assemble their own latency/traffic/error panels from scratch. Building one and having every new service start from it, rather than writing its panels from first principles, would remove a lot of duplicated effort and inconsistency; that's an open gap worth closing rather than a solved problem.
+
+### Monitoring a rollout
+
+Shipping a change and watching a dashboard *afterward* is too late to catch most regressions cheaply. For anything that follows the [calendar event](/handbook/build/change) process, plan to actively watch the relevant dashboard during and immediately after the change — not just rely on alerts to page you if something goes wrong:
+
+- Know which panel you'd expect to move, and by roughly how much, before you make the change — "we'll watch p99 latency and error rate on this dashboard for the next 30 minutes" is a plan; "we'll keep an eye on things" is not
+- Prefer rolling a change out gradually (a canary, a percentage of traffic, one region first) over an all-at-once deploy whenever the blast radius justifies it, so a regression shows up against a small slice of traffic instead of all of it at once
+- Decide the rollback trigger *before* the rollout, not while it's happening — a specific threshold or condition that means "stop and roll back," agreed on ahead of time, is much easier to act on under pressure than a judgment call made live incident-style
+
 ## When you can't check every box
 
 Sometimes business needs require shipping before every box is checked. That's a real and acceptable decision. What matters is that the team has made it deliberately, documented the gaps, and committed to addressing them.

--- a/src/content/handbook/build/production-readiness.md
+++ b/src/content/handbook/build/production-readiness.md
@@ -32,6 +32,20 @@ It's tempting to treat operational concerns as the last 10% of a project — som
 
 Start a readiness review at the beginning of a project, not the end. Use it to surface constraints early, identify missing data, and make sure the team has considered the full lifecycle of the service — not just the happy path.
 
+## Monitoring & observability
+
+This is the operational half of the monitoring phase — the other half is [listening to customers](/handbook/product/customers#listening-to-customers). Both close the loop back into [planning](/handbook/product/roadmap).
+
+We think about observability as five pillars, roughly in order of how early you need them:
+
+- **Metrics** - Services export [OpenTelemetry](https://opentelemetry.io/) metrics to Grafana Cloud. This is the baseline: request rates, error rates, latency, and resource usage for anything running in production.
+- **Logs** - Structured, not free text, so they're queryable and correlate cleanly with the request or resource that produced them. Structured logging is a Moderate-tier expectation above.
+- **Traces** - Exported alongside metrics via OTel, giving us a request's path across services. Most valuable for anything that crosses the control plane / backend (Milo) boundary, where a single customer action touches multiple components.
+- **Alerts** - Defined against the metrics that matter for a service's tier, routed through PagerDuty. An alert without an on-call owner isn't an alert, it's noise — see [on-call](/handbook/build/oncall).
+- **Dashboards** - Built in Grafana from the same metrics and traces. A dashboard's job is to answer "is this healthy right now?" at a glance, not to be an archive of every number we could possibly graph.
+
+The same graduated scale applies here as everywhere else in this page: Minimum means basic alerting and no dashboard is required; Moderate adds structured logging and a working dashboard; High means full tracing and a public status page. Don't build out all five pillars for an internal tool nobody's paging on.
+
 ## When you can't check every box
 
 Sometimes business needs require shipping before every box is checked. That's a real and acceptable decision. What matters is that the team has made it deliberately, documented the gaps, and committed to addressing them.

--- a/src/content/handbook/build/standards.md
+++ b/src/content/handbook/build/standards.md
@@ -31,9 +31,16 @@ Every change to production code goes through a pull request and requires review 
 
 Reviewers are expected to respond promptly — an async, distributed team lives or dies on how quickly a PR gets unstuck.
 
-## Continuous integration
+## Continuous integration & testing
 
 Changes that alter product functionality are tested by CI before merging, not locally and not in production — see the [testing policy](/handbook/policy/testing) for the full policy, including the incident-response exception. At minimum, CI should run type checking, linting, and the relevant automated test suite before a PR is mergeable.
+
+A few guidelines on how we test in practice:
+
+- **Prefer a fake over a real dependency for unit-level tests** - test controller and API server logic against an in-memory fake client rather than spinning up a live cluster. It's faster, more hermetic, and keeps the unit-test stage fast enough to run on every push.
+- **Save real integration/end-to-end testing for the stage that needs it** - standing up an ephemeral cluster, deploying the built image, and running a true end-to-end suite is valuable, but it's a heavier, slower CI stage. Reserve it for the services where a fake client genuinely can't give you confidence, not as the default for every PR.
+- **A skip needs a reason, and the reason should be an environment gate, not flakiness** - it's fine to skip a test that needs a prerequisite the current environment doesn't have (a missing credential, a local-only tool). It's not fine to skip a test because it's unreliable — a flaky test gets fixed or deleted, not silenced.
+- **CI failures block merge, without exception carved out for "it's probably fine"** - if a check is unreliable enough that people routinely ignore it, that's a signal to fix or remove the check, not to develop a habit of overriding it.
 
 ## Control-plane services
 

--- a/src/content/handbook/build/standards.md
+++ b/src/content/handbook/build/standards.md
@@ -16,9 +16,23 @@ Implementation is the third phase of our SDLC — turning an agreed [design](/ha
 
 ## Version control
 
-- Work happens in a feature branch off the default branch; the [GitHub issue](/handbook/operate/using-github) it implements should already exist from planning
+- Work happens in a feature branch off the default branch; the [GitHub issue](/handbook/operate/using-github) it implements must already exist from planning, and the pull request must link it
 - Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, etc.) so history and changelogs stay generatable
 - Keep pull requests focused on one feature or fix — a bug fix doesn't need a drive-by refactor riding along with it
+
+### Why every pull request needs an issue
+
+A pull request says what changed. It cannot say what was wrong. Six months on, the diff is still there and the reason is gone — the reader sees a fix and has to guess the fault. The issue is where the fault lives, and it outlives the branch.
+
+An issue also puts the problem up for argument before anyone spends a day on the answer. Review a pull request and you are reviewing a solution someone has already built; by then, saying "wrong approach" costs a rewrite, so it mostly goes unsaid. The issue is cheap to disagree with. That is the point of it.
+
+Work with no issue is invisible work. It is not on the board, not in planning, and nobody knows it is in flight — so two people fix the same thing, or two branches touch the same file and collide at merge. Ten minutes filing beats a day untangling.
+
+And a fix is not done when the symptom clears. It is done when whatever let it happen is closed off. The pull request merges and takes its context with it; the issue is what holds the follow-up, the coverage gap, the thing we chose not to do yet.
+
+The rule is not paperwork. It is the difference between a repository that records decisions and one that records keystrokes.
+
+**This is binding.** A pull request opens with a linked issue, or it does not open. Repositories enforce it as a required pull request check; automated dependency updates are the only exemption.
 
 ## Code review
 

--- a/src/content/handbook/build/standards.md
+++ b/src/content/handbook/build/standards.md
@@ -1,0 +1,40 @@
+---
+title: "Implementation standards"
+sidebar:
+  label: Implementation standards
+  order: 2.5
+updatedDate: Jul 24, 2026
+authors: jacob
+meta:
+  title: "Engineering Implementation Standards - Datum Handbook"
+  description: "Common standards Datum engineers follow while building — version control, code review, CI, and testing — once a design is ready to become code."
+  og:
+    title: "Implementation standards"
+---
+
+Implementation is the third phase of our SDLC — turning an agreed [design](/handbook/build/design) into shipped code. These are the standards that hold across our repositories, regardless of which component you're working in.
+
+## Version control
+
+- Work happens in a feature branch off the default branch; the [GitHub issue](/handbook/operate/using-github) it implements should already exist from planning
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, etc.) so history and changelogs stay generatable
+- Keep pull requests focused on one feature or fix — a bug fix doesn't need a drive-by refactor riding along with it
+
+## Code review
+
+Every change to production code goes through a pull request and requires review before merging. A good review checks for:
+
+- Does the code match the design that was agreed on, and flag it in the PR if it diverges
+- Does it follow the [API design](/handbook/build/design#api-design) conventions for anything customer-facing
+- Is it tested per our [testing policy](/handbook/policy/testing)
+- Does documentation need to change alongside the code (this handbook, docs, or inline comments)
+
+Reviewers are expected to respond promptly — an async, distributed team lives or dies on how quickly a PR gets unstuck.
+
+## Continuous integration
+
+Changes that alter product functionality are tested by CI before merging, not locally and not in production — see the [testing policy](/handbook/policy/testing) for the full policy, including the incident-response exception. At minimum, CI should run type checking, linting, and the relevant automated test suite before a PR is mergeable.
+
+## Operational readiness
+
+Implementation isn't done when the code merges — see [production readiness](/handbook/build/production-readiness). Monitoring, secrets, and rollback procedures should be designed in during implementation, not bolted on afterward. If a change has a large enough blast radius, coordinate it as a [calendar event](/handbook/build/change), not just a merged PR.

--- a/src/content/handbook/build/standards.md
+++ b/src/content/handbook/build/standards.md
@@ -35,6 +35,10 @@ Reviewers are expected to respond promptly — an async, distributed team lives 
 
 Changes that alter product functionality are tested by CI before merging, not locally and not in production — see the [testing policy](/handbook/policy/testing) for the full policy, including the incident-response exception. At minimum, CI should run type checking, linting, and the relevant automated test suite before a PR is mergeable.
 
+## Control-plane services
+
+Building a controller or an aggregated API server for a control-plane service (`milo`, `search`, `activity`, and similar) has its own set of recurring conventions — reconciler shape, finalizers, when to reach for an aggregated API server instead of a CRD. See [control plane implementation](/handbook/build/control-plane) for the details.
+
 ## Operational readiness
 
 Implementation isn't done when the code merges — see [production readiness](/handbook/build/production-readiness). Monitoring, secrets, and rollback procedures should be designed in during implementation, not bolted on afterward. If a change has a large enough blast radius, coordinate it as a [calendar event](/handbook/build/change), not just a merged PR.

--- a/src/content/handbook/product/customers.md
+++ b/src/content/handbook/product/customers.md
@@ -35,3 +35,17 @@ In other words, how do we go about getting more customers:
 
 ## Our guarantee:
 Having a guarantee is a really important part of our strategy. Our “work in progress” version right now is based on delivering value: Try our highest tier for 90 days. If you don’t get the value you expect, don’t pay.
+
+## Listening to customers
+
+The last phase of our SDLC is monitoring — and half of that is product monitoring: making sure real customer reaction actually makes it back into [planning](/handbook/product/roadmap), not just operational health (see [monitoring & observability](/handbook/build/production-readiness#monitoring--observability)).
+
+We don't run a single formal feedback tool. Instead we lean on a few channels that are already part of how we work in the open:
+
+- **[GitHub Discussions](https://github.com/orgs/datum-cloud/discussions)** - where feature ideas, complaints, and support questions surface first, and where we close the loop when an enhancement ships
+- **[Discord](https://link.datum.net/discord)** - real-time chat with the community, good for catching friction and confusion as it happens
+- **Monthly newsletter** - a two-way moment; we tell customers what shipped, and replies and forwards are a reliable signal of what landed and what didn't
+- **Community Huddle** - our recurring virtual meetup (see [rhythms](/handbook/operate/rhythms)) where we show early demos and hear reactions live, before something is fully baked
+- **Direct conversations** - support threads, sales calls, and Slack Connect channels with design partners are often the fastest way to hear when something is actually broken
+
+None of this is worth much if it stays anecdotal. When a piece of feedback changes a decision, it should show up as a comment on the relevant GitHub issue or discussion — that's what turns a Slack aside into something the next planning cycle can act on.

--- a/src/content/handbook/product/roadmap.md
+++ b/src/content/handbook/product/roadmap.md
@@ -16,8 +16,21 @@ Working in the open is a core construct at Datum, but the area of transparency t
 
 Just like this company handbook, our roadmap and changelog are managed through GitHub and displayed on our website. 
 
-While it’s somewhat of a new practice, we try to ideate around potential features in [GitHub discussions](https://github.com/orgs/datum-cloud/discussions). If you’re a new user or community member, this is a great place to share your feedback and suggest approaches alongside real-time chat on our [Discord server](https://link.datum.net/discord).
+## Planning phase
+
+This is the first phase of our SDLC — turning fuzzy ideas into scoped, prioritized work before anyone touches [design](/handbook/build/design) or code.
+
+While it's somewhat of a new practice, we try to ideate around potential features in [GitHub discussions](https://github.com/orgs/datum-cloud/discussions). If you're a new user or community member, this is a great place to share your feedback and suggest approaches alongside real-time chat on our [Discord server](https://link.datum.net/discord).
 
 Once ideas are formalized we create [detailed enhancements](https://github.com/orgs/datum-cloud/projects/22) that prepare the work. Since this is where all active work on our various open source projects are tracked and progressed, this is how we generate our public roadmap for [datum.net](http://datum.net) and milo-os.com. 
 
-As the work on enhancements are completed, we publish notices to [GitHub Discussions](https://github.com/orgs/datum-cloud/discussions) and include a summary in our monthly newsletter.
+An enhancement is ready to move into design once it has:
+
+- A clear problem statement and named owner
+- A rough sense of customer or business impact (who's asking, and why now)
+- A target [monthly milestone](https://github.com/datum-cloud/enhancements/milestones) — even a tentative one
+- Enough scope definition that someone outside the discussion could understand what's in and out
+
+Prioritization leans on a few simple questions: Does it serve the customers we're building for (see [who we're building for](/handbook/product/customers))? Does it compound — does shipping it make the next thing easier? And is now the right time, given our [quarterly rocks](/handbook/eos/quarterly-rocks) and monthly milestone cadence?
+
+As the work on enhancements are completed, we publish notices to [GitHub Discussions](https://github.com/orgs/datum-cloud/discussions) and include a summary in our monthly newsletter — which feeds customer reaction straight back into the next round of planning (see [listening to customers](/handbook/product/customers#listening-to-customers)).


### PR DESCRIPTION
## Summary
- Ties the handbook's existing scattered process pages into one coherent SDLC: Planning → Design → Implementation → Monitoring
- Adds two new pages: `build/design.md` (system design + API design) and `build/standards.md` (version control, code review, CI, operational readiness)
- Expands `product/roadmap.md` (planning phase / definition of ready), `product/customers.md` (listening to customers / product feedback), and `build/production-readiness.md` (metrics, logs, traces, alerts, dashboards)
- Adds a short "Our SDLC" overview to `build/index.md` linking all four phases in order

## Test plan
- [x] `npm run lint:md` passes on all changed/new files
- [ ] Preview the handbook pages in a running dev server to check sidebar ordering and rendered links
- [ ] Confirm cross-links resolve (`/handbook/build/design`, `/handbook/build/standards`, anchor links like `#monitoring--observability` and `#listening-to-customers`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)