### PR TITLE
Add temporary redirect for /pricing to homepage

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -72,6 +72,8 @@ const WELL_KNOWN_CONTENT_TYPES = {
 // Redirect configuration with Cache-Control: no-cache
 const AUTH_TARGET = 'https://auth.datum.net';
 const REDIRECTS = {
+  '/pricing': { destination: '/', status: 307 },
+  '/pricing/': { destination: '/', status: 307 },
   '/product': { destination: '/platform/deliver', status: 302 },
   '/feature/': { destination: '/platform/deliver', status: 302 },
   '/product/overview/overview': { destination: '/platform/deliver', status: 302 },


### PR DESCRIPTION
## Summary
- Adds a temporary (307) redirect from `/pricing` and `/pricing/` to `/` in `server.mjs`
- Existing `pricing.astro` page is left in place; the redirect map is checked before static file serving, so it takes priority

Related to #1539

## Test plan
- [ ] `npm run build && node server.mjs`, confirm `curl -I http://localhost:4321/pricing` returns 307 with `Location: /`