### PR TITLE
fix: remove trailing full stops from headlines

### DIFF
--- a/src/components/home/DedicatedCloud.astro
+++ b/src/components/home/DedicatedCloud.astro
@@ -37,7 +37,7 @@ const expertiseItems = [
             class="text-canyon-clay---links text-highlight bg-[linear-gradient(to_bottom,transparent_42%,var(--color-canyon-clay-pale)_42%,var(--color-canyon-clay-pale)_92%,transparent_92%)] box-decoration-clone px-1"
             >Single-tenant</span
           >{' '}
-          GPU, CPU, and network infrastructure.
+          GPU, CPU, and network infrastructure
         </h2>
       </div>
 

--- a/src/content/pages/features/build/index.mdx
+++ b/src/content/pages/features/build/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Bring intelligence to the <span class=\"text-canyon-clay---links\">network edge</span>."
+title: "Bring intelligence to the <span class=\"text-canyon-clay---links\">network edge</span>"
 slug: "features/build/index"
 description: "Millisecond cold-start compute and related primitives."
 meta:

--- a/src/content/pages/features/connect/index.mdx
+++ b/src/content/pages/features/connect/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Private networking, <span class=\"text-connect-slate\">reimagined</span>."
+title: "Private networking, <span class=\"text-connect-slate\">reimagined</span>"
 slug: "features/connect/index"
 description: "Land diverse connections on your own virtual \"meet me room\"."
 meta:

--- a/src/content/pages/features/deliver/index.mdx
+++ b/src/content/pages/features/deliver/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Protect, manage, and route <span class=\"text-pine-forge\">traffic</span>."
+title: "Protect, manage, and route <span class=\"text-pine-forge\">traffic</span>"
 slug: "features/deliver/index"
 description: "Route, filter, and accelerate traffic across every location without managing a separate CDN, WAF, or inference proxy."
 meta:

--- a/src/content/pages/home.mdx
+++ b/src/content/pages/home.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Connected <br>infrastructure <br><span class=\"text-highlight\">for AI companies.</span>"
+title: "Connected <br>infrastructure <br><span class=\"text-highlight\">for AI companies</span>"
 description: "Datum is a modern alternative to legacy CDN's, complex networks, and colocation. For alt clouds and tech-forward enterprises looking to scale, we provide \"hyperscale-style\" edge networking and connected CPU / GPU capacity."
 publishDate: 2025-03-04
 slug: "/"


### PR DESCRIPTION
## Summary
- Removes trailing full stops from headline copy for consistency (question marks are unaffected)
- Updates homepage hero, dedicated cloud section, and deliver/build/connect product page headlines
- Essentials headline already had no full stop, so no change was needed there

Fixes #1540

## Test plan
- [ ] Visually confirm homepage hero headline renders without a trailing period
- [ ] Visually confirm dedicated cloud section headline renders without a trailing period
- [ ] Visually confirm /platform/deliver, /platform/build, /platform/connect headlines render without trailing periods

🤖 Generated with [Claude Code](https://claude.com/claude-code)