### PR TITLE
Update banner announcement to public beta signup

### DIFF
--- a/src/data/announcement.json
+++ b/src/data/announcement.json
@@ -1,8 +1,8 @@
 {
   "show": true,
-  "label": "Free Download",
-  "text": "Use 'datumctl console' to access a full interactive terminal UI + built in AI skills",
-  "href": "https://www.datum.net/download/datumctl/",
+  "label": "Try for free",
+  "text": "Datum is currently free under public beta, sign up",
+  "href": "https://auth.datum.net/id/signup",
   "icon": {
     "name": "arrow-right",
     "size": "md"


### PR DESCRIPTION
## Summary
- Change banner notification label from "Free Download" to "Try for free"
- Update text and link to point to public beta signup instead of datumctl download

Closes #1541

## Test plan
- [x] Verify banner renders correctly with new copy and link
- [x] Verify link navigates to https://auth.datum.net/id/signup

🤖 Generated with [Claude Code](https://claude.com/claude-code)