### PR TITLE
fix(dedicated-cloud): design/copy review + Figma hero and Why Datum updates

### DIFF
--- a/src/components/dedicated-cloud/BuiltForYou.astro
+++ b/src/components/dedicated-cloud/BuiltForYou.astro
@@ -23,7 +23,7 @@ import { builtForYou } from '@data/dedicatedCloud';
         </div>
 
         <div
-          class="border-silver-mist bg-silver-mist col-span-6 grid grid-cols-1 gap-px border sm:grid-cols-2 md:col-span-4 xl:grid-cols-3 xl:[&>*:last-child]:col-span-2"
+          class="border-silver-mist bg-silver-mist col-span-6 grid grid-cols-1 gap-px border sm:grid-cols-2 md:col-span-4"
         >
           {
             builtForYou.items.map((item) => (
@@ -32,7 +32,7 @@ import { builtForYou } from '@data/dedicatedCloud';
                   <Icon name={item.icon} size="sm" class="text-pine-forge---links" />
                 </div>
                 <div class="flex flex-col gap-1">
-                  <p class="datum-text-lg text-midnight-fjord font-semibold">{item.title}</p>
+                  <p class="datum-text-xl text-midnight-fjord font-semibold">{item.title}</p>
                   <p class="datum-text-base text-app---dark---utility-3">{item.description}</p>
                 </div>
               </div>

--- a/src/components/dedicated-cloud/Operators.astro
+++ b/src/components/dedicated-cloud/Operators.astro
@@ -39,7 +39,11 @@ const people = await Promise.all(
 
 <section class="section--block section--block--x-pad bg-midnight-fjord relative overflow-hidden">
   <div class="max-width-nav large-pad relative">
-    <SectionEyebrow variant="app" position="left-top">
+    <SectionEyebrow
+      variant="app"
+      position="left-top"
+      class="text-aurora-moss [&_.section-eyebrow-cursor]:bg-aurora-moss"
+    >
       {operators.eyebrow}
     </SectionEyebrow>
 
@@ -96,9 +100,7 @@ const people = await Promise.all(
       </ul>
     </div>
     <div class="max-width-nopad relative">
-      <p
-        class="border-app---dark---utility-2 text-app---dark---utility-4 datum-text-sm mt-14 border-t pt-6 text-center md:mt-20"
-      >
+      <p class="text-app---dark---utility-4 datum-text-sm mt-14 text-center md:mt-20">
         {whyDatum.tagline}
       </p>
     </div>

--- a/src/components/dedicated-cloud/WhyDatum.astro
+++ b/src/components/dedicated-cloud/WhyDatum.astro
@@ -4,6 +4,9 @@ import SectionLine from '@components/SectionLine.astro';
 import Icon from '@components/Icon.astro';
 import { whyDatum } from '@data/dedicatedCloud';
 import ModuleConnector from '@components/home/ModuleConnector.astro';
+
+const WHY_DATUM_TITLE_HIGHLIGHT = '25 years';
+const whyDatumTitleRest = whyDatum.title.slice(WHY_DATUM_TITLE_HIGHLIGHT.length);
 ---
 
 <section
@@ -16,26 +19,31 @@ import ModuleConnector from '@components/home/ModuleConnector.astro';
 
     <div class="max-width-nopad flex flex-col gap-10 md:gap-16">
       <div class="flex flex-col gap-4">
-        <h2 class="section-title--sm text-midnight-fjord">{whyDatum.title}</h2>
+        <h2 class="section-title--sm text-midnight-fjord">
+          <span
+            class="text-pine-forge---links text-highlight bg-[linear-gradient(to_bottom,transparent_42%,var(--color-aurora-moss)_42%,var(--color-aurora-moss)_92%,transparent_92%)] box-decoration-clone px-1"
+            >{WHY_DATUM_TITLE_HIGHLIGHT}</span
+          >{whyDatumTitleRest}
+        </h2>
       </div>
 
-      <ul class="grid grid-cols-1 gap-x-16 gap-y-10 md:grid-cols-2">
+      <div
+        class="border-silver-mist bg-silver-mist grid grid-cols-1 gap-px border sm:grid-cols-2 lg:grid-cols-4"
+      >
         {
           whyDatum.items.map((item) => (
-            <li class="flex items-start gap-3">
-              <Icon
-                name="check"
-                size="sm"
-                class="text-pine-forge---links stroke-2.5 mt-1 shrink-0"
-              />
-              <div class="flex flex-col gap-1">
-                <p class="datum-text-lg text-midnight-fjord font-semibold">{item.title}</p>
-                <p class="datum-text-base text-app---dark---utility-3">{item.description}</p>
+            <div class="bg-platinum flex flex-col items-start gap-7 p-8">
+              <div class="bg-aurora-moss flex size-10 shrink-0 items-center justify-center rounded-sm">
+                <Icon name="check" size="sm" class="text-pine-forge---links stroke-2.5" />
               </div>
-            </li>
+              <div class="flex flex-col gap-2.5">
+                <p class="datum-text-lg text-midnight-fjord font-semibold">{item.title}</p>
+                <p class="datum-text-base text-midnight-fjord/80">{item.description}</p>
+              </div>
+            </div>
           ))
         }
-      </ul>
+      </div>
     </div>
   </div>
 

--- a/src/components/forms/DedicatedCloudForm.astro
+++ b/src/components/forms/DedicatedCloudForm.astro
@@ -118,7 +118,7 @@ const labelClass = 'datum-text-xs text-midnight-fjord/80 font-semibold';
         <span class={labelClass}>Anything else we should know?</span>
         <textarea
           name="message"
-          placeholder="Tell us more about your requirements, timeline, connectivity, and anything else we should know."
+          placeholder="Tell us more about your requirements, timeline, etc. This is a good place to share about storage, fleet management, connectivity, and location needs!"
           class:list={[inputClass, 'placeholder:text-midnight-fjord/40 h-[106px] resize-none']}
         ></textarea>
       </label>

--- a/src/content/faq/dedicated-1-gpu-generations.mdx
+++ b/src/content/faq/dedicated-1-gpu-generations.mdx
@@ -1,5 +1,5 @@
 ---
-question: 'What NVIDIA GPU generations can I deploy through Datum?'
+question: 'What NVIDIA GPU generations can I deploy with Datum?'
 order: 1
 category: 'dedicated-cloud'
 ---

--- a/src/data/dedicatedCloud.ts
+++ b/src/data/dedicatedCloud.ts
@@ -10,7 +10,7 @@ export const meta = {
 
 export const hero = {
   eyebrow: 'Dedicated cloud',
-  title: 'GPU clusters, built and operated by folks you can trust.',
+  title: 'GPU clusters, built and operated by folks you can trust',
   description:
     'Leverage our decades of experience, deep industry relationships, flexible platform, and operational muscle to accelerate your business.',
   ctaText: 'Schedule a conversation',
@@ -29,7 +29,7 @@ export interface BuiltForYouItem extends ChecklistItem {
 
 export const builtForYou = {
   eyebrow: 'Built for you',
-  title: 'Like wealth managers, but for AI companies.',
+  title: 'Like wealth managers, but for AI companies',
   intro: [
     'It’s no easy task to assemble all the pieces of the digital infrastructure puzzle, and each situation at scale is unique.',
     "That's why we don't try to pretend it's easy. Instead, we show up with a simple promise: we'll put the work in, we'll be honest with you, and we'll do our best to help you win.",
@@ -41,7 +41,7 @@ export const builtForYou = {
       icon: 'waypoints',
     },
     {
-      title: 'Supply chain management',
+      title: 'Supply chain',
       description: 'Sourcing GPUs, servers, and networking gear from vetted hardware partners.',
       icon: 'package',
     },
@@ -71,7 +71,7 @@ export const builtForYou = {
 
 export const whyDatum = {
   eyebrow: 'Why Datum',
-  title: '25 years in bare metal, global networks, and datacenters.',
+  title: '25 years in bare metal, global networks, and datacenters',
   items: [
     {
       title: "Built by people who've done this before",
@@ -112,7 +112,7 @@ export const operators = {
     {
       name: 'Zac Smith',
       role: 'Co-Founder, CEO',
-      bio: "Founded Packet (acquired by Equinix) and led Equinix Metal. Twenty years building bare metal and interconnected infrastructure for the world's most demanding operators.",
+      bio: "Twenty years building bare metal and interconnected infrastructure for the world's most demanding operators.",
       slug: 'zachary-smith',
     },
     {
@@ -141,7 +141,7 @@ export const operators = {
 
 export const contact = {
   eyebrow: 'Contact',
-  title: 'Talk to our team.',
+  title: 'Talk to our team',
   description:
     "Tell us what you're building. We'll come back within one business day with a scoping call and the specialists relevant to your workload.",
   reassurance: [

--- a/src/pages/dedicated-cloud.astro
+++ b/src/pages/dedicated-cloud.astro
@@ -58,7 +58,7 @@ const jsonLd = {
             <p class="datum-text-lg text-app---dark---utility-3 max-w-2xl">{hero.description}</p>
           </div>
 
-          <a href={hero.ctaHref} class="btn btn--midnight-fjord btn--glow-aurora w-fit">
+          <a href={hero.ctaHref} class="btn btn--midnight-fjord w-fit">
             {hero.ctaText}
             <Icon name="arrow-right" size="sm" />
           </a>
@@ -122,7 +122,7 @@ const jsonLd = {
 
             <div class="max-width-nopad grid grid-cols-12 gap-8" x-data="{ expandedFaq: null }">
               <div class="col-span-12 flex flex-col gap-4 md:col-span-5">
-                <h2 class="section-title--sm text-midnight-fjord">Questions we hear most often.</h2>
+                <h2 class="section-title--sm text-midnight-fjord">Questions we hear most often</h2>
               </div>
               <div class="col-span-12 md:col-span-7">
                 <div class="faq-list">

--- a/src/pages/dedicated-cloud.astro
+++ b/src/pages/dedicated-cloud.astro
@@ -17,10 +17,15 @@ import WhyDatum from '@components/dedicated-cloud/WhyDatum.astro';
 import Operators from '@components/dedicated-cloud/Operators.astro';
 import { meta, hero, contact } from '@data/dedicatedCloud';
 import ModuleConnector from '@components/home/ModuleConnector.astro';
+import HeroBlocksLeft from '@assets/svgs/dedicated-hero-blocks-left.svg';
+import HeroBlocksRight from '@assets/svgs/dedicated-hero-blocks-right.svg';
 
 const faqs = (await getCollection('faq'))
   .filter((faq) => !faq.data.draft && faq.data.category === 'dedicated-cloud')
   .sort((a, b) => (a.data.order ?? 0) - (b.data.order ?? 0));
+
+const HERO_TITLE_HIGHLIGHT = 'trust';
+const heroTitleLead = hero.title.slice(0, hero.title.lastIndexOf(HERO_TITLE_HIGHLIGHT));
 
 const jsonLd = {
   '@context': 'https://schema.org',
@@ -50,17 +55,29 @@ const jsonLd = {
 
     <div class="section--block section--block--x-pad relative overflow-hidden bg-white">
       <div class="max-width-nav large-pad relative">
-        <SectionLine left top />
+        <HeroBlocksLeft
+          class="line-draw pointer-events-none absolute top-0 left-0 hidden lg:block"
+          aria-hidden="true"
+        />
+        <HeroBlocksRight
+          class="line-draw pointer-events-none absolute top-0 right-0 hidden lg:block"
+          aria-hidden="true"
+        />
 
         <div class="max-width-nopad flex flex-col items-center gap-8 text-center">
           <div class="mx-auto flex max-w-3xl flex-col items-center gap-6">
-            <h1 class="datum-text-9xl text-midnight-fjord">{hero.title}</h1>
+            <h1 class="datum-text-9xl text-midnight-fjord">
+              {heroTitleLead}<span
+                class="text-pine-forge---links text-highlight bg-[linear-gradient(to_bottom,transparent_42%,var(--color-aurora-moss)_42%,var(--color-aurora-moss)_92%,transparent_92%)] box-decoration-clone px-1"
+                >{HERO_TITLE_HIGHLIGHT}</span
+              >
+            </h1>
             <p class="datum-text-lg text-app---dark---utility-3 max-w-2xl">{hero.description}</p>
           </div>
 
-          <a href={hero.ctaHref} class="btn btn--midnight-fjord w-fit">
+          <a href={hero.ctaHref} class="btn btn--midnight-fjord btn--sm w-fit">
             {hero.ctaText}
-            <Icon name="arrow-right" size="sm" />
+            <Icon name="calendar" size="sm" />
           </a>
         </div>
       </div>

--- a/src/static/assets/svgs/dedicated-hero-blocks-left.svg
+++ b/src/static/assets/svgs/dedicated-hero-blocks-left.svg
@@ -1,0 +1,10 @@
+<svg width="240" height="280" viewBox="0 0 240 280" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect data-line-draw x="120" y="160" width="80" height="80" fill="#E6F59F" />
+  <rect data-line-draw x="80" y="80" width="40" height="40" fill="#E6F59F" />
+  <rect data-line-draw y="120" width="40" height="40" fill="#E6F59F" />
+  <path data-line-draw pathLength="1" d="M40 0L40 160" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M120 80L120 200" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M200 120L200 280" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M0 80H160" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M120 160H240" stroke="#C3C6C9" />
+</svg>

--- a/src/static/assets/svgs/dedicated-hero-blocks-right.svg
+++ b/src/static/assets/svgs/dedicated-hero-blocks-right.svg
@@ -1,0 +1,11 @@
+<svg width="255" height="281" viewBox="0 0 255 281" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect data-line-draw x="135" y="81" width="80" height="80" fill="#E6F59F" />
+  <rect data-line-draw x="16" y="121" width="40" height="40" fill="#E6F59F" />
+  <rect data-line-draw x="136" y="241" width="40" height="40" fill="#E6F59F" />
+  <path data-line-draw pathLength="1" d="M215 0L215 120" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M136 41L136 280" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M56 121L56 160" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M96 240H176" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M0 160H176" stroke="#C3C6C9" />
+  <path data-line-draw pathLength="1" d="M96 80H255" stroke="#C3C6C9" />
+</svg>


### PR DESCRIPTION
## Summary

Ref #1538

- Design/copy review pass on `/dedicated-cloud`: removed trailing full stops from headlines, resized the hero CTA, fixed "Built for you" card title sizing and grid layout, recolored the operators eyebrow, trimmed Zac's bio, and closed a handful of copy gaps against the approved content doc (storage/fleet-management placeholder text, FAQ wording, "Supply chain" label)
- Matched the hero and "Why Datum" row to the Figma design:
  - Hero: added mirrored decorative glass-block SVGs in the top corners (reusing the site's existing `line-draw` scroll-reveal system), highlighted "trust" with the standard marker-style text highlight, resized the CTA to `btn--sm` with a calendar icon
  - Why Datum: highlighted "25 years", replaced the two-column checklist with a bordered four-column card row (same hairline-grid technique as "Built for you")

## Test plan

- [x] `astro check` — 0 errors
- [x] `eslint` — clean
- [x] Verified visually against the dev server with Playwright screenshots (hero, Built for you, Why Datum, Operators, form)
- [ ] Manual review against staging/Figma before merge
