### PR TITLE
fix: llms.txt dedicated-cloud entry and partner logo sizing

### DIFF
--- a/src/components/dedicated-cloud/Operators.astro
+++ b/src/components/dedicated-cloud/Operators.astro
@@ -12,11 +12,11 @@ import SabeyLogo from '@assets/logos/dc-partners/sabey.svg';
 import QtsLogo from '@assets/logos/dc-partners/qts.svg';
 
 const DC_PARTNER_LOGOS = [
-  { name: 'Digital Realty', Logo: DigitalRealtyLogo, class: 'h-12' },
+  { name: 'Digital Realty', Logo: DigitalRealtyLogo, class: 'h-14' },
   { name: 'Equinix', Logo: EquinixLogo, class: 'h-7' },
   { name: 'DataBank', Logo: DatabankLogo, class: 'h-7' },
-  { name: 'Sabey Data Centers', Logo: SabeyLogo, class: 'h-9' },
-  { name: 'QTS', Logo: QtsLogo, class: 'h-8' },
+  { name: 'Sabey Data Centers', Logo: SabeyLogo, class: 'h-8' },
+  { name: 'QTS', Logo: QtsLogo, class: 'h-6' },
 ];
 
 const AVATAR_BG = [
@@ -119,7 +119,7 @@ const people = await Promise.all(
         {whyDatum.tagline}
       </p>
       <span class="bg-app---dark---utility-3 hidden h-14 w-0.5 md:block" aria-hidden="true"></span>
-      <ul class="flex flex-wrap items-center justify-center gap-x-8 gap-y-4">
+      <ul class="flex flex-wrap items-center justify-center gap-x-12 gap-y-6">
         {
           DC_PARTNER_LOGOS.map(({ name, Logo, class: heightClass }) => (
             <li class="flex items-center opacity-80">

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
 import { site } from 'astro:config/client';
 import { extractDescription, buildUrl, stripHtml } from '@utils/llmsUtils';
+import { meta as dedicatedCloudMeta } from '@data/dedicatedCloud';
 
 // Note: handbook entries intentionally excluded — internal company ops content
 // is not relevant to AI agents consuming platform documentation.
@@ -56,6 +57,10 @@ export const GET: APIRoute = async () => {
       const pageTitle = stripHtml(page.data.title);
       llmsContent += `- [${pageTitle}](${pageUrl}) - ${description}\n`;
     }
+
+    // /dedicated-cloud is data-driven (src/data/dedicatedCloud.ts), not a `pages`
+    // collection entry, so the loop above never sees it — add it explicitly.
+    llmsContent += `- [${dedicatedCloudMeta.title}](${(site || '').replace(/\/+$/, '')}/dedicated-cloud) - ${dedicatedCloudMeta.description}\n`;
 
     llmsContent += `\n## Docs\n\n`;
     llmsContent += `- Full documentation index at ${siteUrl}/docs/llms.txt\n`;


### PR DESCRIPTION
## Summary
- `/dedicated-cloud` is data-driven (`src/data/dedicatedCloud.ts`) rather than a `pages` collection entry, so it was invisible to the collection loop that builds `llms.txt` even though its own `.md` export already worked — now listed explicitly using the same `meta` source the page and `.md.ts` endpoint share.
- Rebalanced the datacenter partner logo strip on `/dedicated-cloud`: Digital Realty was too small next to the others, Sabey and QTS were oversized and dominated the row. Also widened the gaps between logos for better separation.

## Test plan
- [x] `npx astro check` — 0 errors
- [x] `npx eslint` on changed files — clean
- [x] Verified `llms.txt` output locally includes the Dedicated Cloud entry with correct title/description/URL
- [x] Verified logo sizing/spacing visually via local screenshot of the operators section
