### PR TITLE
fix(dedicated-cloud): fix late-triggering hero animation

### DIFF
--- a/src/pages/dedicated-cloud.astro
+++ b/src/pages/dedicated-cloud.astro
@@ -57,17 +57,26 @@ const jsonLd = {
       <div class="max-width-nav large-pad relative flex flex-col items-center gap-8 text-center">
         <SectionLine left top />
         <div class="absolute top-0 -left-10 hidden lg:block">
-          <HeroBlocksLeft class="line-draw pointer-events-none" aria-hidden="true" />
+          <HeroBlocksLeft
+            class="line-draw pointer-events-none"
+            data-line-draw-eager
+            aria-hidden="true"
+          />
         </div>
 
         <div class="absolute -right-9.75 bottom-0 hidden lg:block">
-          <HeroBlocksRight class="line-draw pointer-events-none" aria-hidden="true" />
+          <HeroBlocksRight
+            class="line-draw pointer-events-none"
+            data-line-draw-eager
+            data-line-draw-delay="500"
+            aria-hidden="true"
+          />
         </div>
         <div class="mx-auto flex max-w-3xl flex-col items-center gap-6">
           <h1 class="datum-text-9xl text-midnight-fjord">
             {heroTitleLead}<span
               class="text-pine-forge---links text-highlight bg-[linear-gradient(to_bottom,transparent_42%,var(--color-aurora-moss)_42%,var(--color-aurora-moss)_92%,transparent_92%)] box-decoration-clone px-1"
-              >{HERO_TITLE_HIGHLIGHT}</span
+              data-highlight-delay="1000">{HERO_TITLE_HIGHLIGHT}</span
             >
           </h1>
           <p class="datum-text-lg text-app---dark---utility-3 max-w-2xl">{hero.description}</p>

--- a/src/static/scripts/module-animate.js
+++ b/src/static/scripts/module-animate.js
@@ -33,10 +33,21 @@ function touchRootMargin() {
 function initSectionLabels() {
   const labels = document.querySelectorAll('.section-label, .mission-label, .text-highlight');
   for (const label of Array.from(labels)) {
+    // Opt-in via [data-highlight-delay="<ms>"] — e.g. a hero title highlight
+    // that should animate in a beat after load rather than the instant the
+    // (already-visible) element is observed.
+    const delayMs = parseInt(label.dataset.highlightDelay, 10) || 0;
+    let timeoutId = null;
+
     const obs = trackObserver(
       new IntersectionObserver(
         (entries) => {
-          label.classList.toggle('highlight-animate', entries[0].isIntersecting);
+          clearTimeout(timeoutId);
+          if (entries[0].isIntersecting) {
+            timeoutId = setTimeout(() => label.classList.add('highlight-animate'), delayMs);
+          } else {
+            label.classList.remove('highlight-animate');
+          }
         },
         { threshold: 0.3 }
       )
@@ -128,13 +139,32 @@ function initSectionLines() {
 // Blueprint-grid "glass" graphics (hero, next-row, pre-footer) — lines draw
 // in, accent squares pop, then any content panel fades in, cued by the same
 // touch-lead as the module border wipe. Reverses on scroll-up.
+//
+// Graphics marked [data-line-draw-eager] (e.g. the page Hero) sit fully inside
+// the initial viewport with no scroll to cue against, so the touch-lead
+// rootMargin and the leisurely scroll-paced stagger below both read as a
+// stuck/late animation rather than a reveal — they get a real viewport
+// rootMargin and a compressed timeline that finishes almost immediately.
 function initLineDrawGraphics() {
   const PATH_STEP_MS = 55;
   const NODE_STEP_MS = 70;
   const GROUP_GAP_MS = 120;
 
+  const EAGER_PATH_STEP_MS = 12;
+  const EAGER_NODE_STEP_MS = 18;
+  const EAGER_GROUP_GAP_MS = 40;
+
   const graphics = document.querySelectorAll('.line-draw');
   for (const graphic of Array.from(graphics)) {
+    const eager = graphic.hasAttribute('data-line-draw-eager');
+    const pathStepMs = eager ? EAGER_PATH_STEP_MS : PATH_STEP_MS;
+    const nodeStepMs = eager ? EAGER_NODE_STEP_MS : NODE_STEP_MS;
+    const groupGapMs = eager ? EAGER_GROUP_GAP_MS : GROUP_GAP_MS;
+    // Lets one graphic's reveal start after a sibling's (e.g. the Hero's
+    // second corner graphic following the first) instead of both firing the
+    // instant they're intersecting.
+    const startDelayMs = parseInt(graphic.dataset.lineDrawDelay, 10) || 0;
+
     const paths = Array.from(graphic.querySelectorAll('path[data-line-draw]'));
     const nodes = Array.from(graphic.querySelectorAll('rect[data-line-draw]'));
     const panel = graphic.querySelector('[data-line-draw-panel]');
@@ -148,18 +178,20 @@ function initLineDrawGraphics() {
 
           if (entries[0].isIntersecting) {
             paths.forEach((el, i) =>
-              timeoutIds.push(setTimeout(() => el.classList.add('is-inview'), i * PATH_STEP_MS))
+              timeoutIds.push(
+                setTimeout(() => el.classList.add('is-inview'), startDelayMs + i * pathStepMs)
+              )
             );
 
-            const nodesStart = paths.length * PATH_STEP_MS + GROUP_GAP_MS;
+            const nodesStart = startDelayMs + paths.length * pathStepMs + groupGapMs;
             nodes.forEach((el, i) =>
               timeoutIds.push(
-                setTimeout(() => el.classList.add('is-inview'), nodesStart + i * NODE_STEP_MS)
+                setTimeout(() => el.classList.add('is-inview'), nodesStart + i * nodeStepMs)
               )
             );
 
             if (panel) {
-              const panelStart = nodesStart + nodes.length * NODE_STEP_MS + GROUP_GAP_MS;
+              const panelStart = nodesStart + nodes.length * nodeStepMs + groupGapMs;
               timeoutIds.push(setTimeout(() => panel.classList.add('is-inview'), panelStart));
             }
           } else {
@@ -168,7 +200,7 @@ function initLineDrawGraphics() {
             if (panel) panel.classList.remove('is-inview');
           }
         },
-        { threshold: 0, rootMargin: touchRootMargin() }
+        { threshold: 0, rootMargin: eager ? '0px' : touchRootMargin() }
       )
     );
     obs.observe(graphic);


### PR DESCRIPTION
## Summary
- The hero's corner "glass" graphics (top-left, bottom-right) reused the touch-lead scroll cue and ~500ms scroll-paced choreography built for below-the-fold module reveals. Since the hero is fully visible on load with no scroll to mask the delay, this read as the animation firing late/stuck rather than as a reveal.
- Added an opt-in `data-line-draw-eager` mode to `initLineDrawGraphics()` (`module-animate.js`): eager graphics use a real viewport `rootMargin` and a compressed timeline instead of the touch-lead band, so they trigger immediately on load. Other `.line-draw` usages (homepage hero, footer, WhatIsDatum) are unaffected.
- Added a `data-line-draw-delay` attribute so the bottom-right corner graphic starts 0.5s after the top-left one, instead of both firing simultaneously.
- Added a `data-highlight-delay` attribute to `initSectionLabels()` so the hero title's "trust" highlight animates in 1s after load, as a deliberate beat rather than firing the instant it's observed.

## Test plan
- [x] `npx astro check` — 0 errors
- [x] `npx eslint` on changed files — clean
- [x] Verified via headless browser timing probes: top-left graphic fires ~immediately, bottom-right follows ~0.5s later, "trust" highlight fires ~1s after load
- [x] Verified homepage hero grid (non-eager `.line-draw` usage) timing is unchanged
