### PR TITLE
fix(demo): required-field indicators and checklist alignment

### DIFF
--- a/src/components/forms/BookDemo.astro
+++ b/src/components/forms/BookDemo.astro
@@ -29,7 +29,9 @@ const recaptchaSiteKey = import.meta.env.PUBLIC_RECAPTCHA_SITE_KEY;
       </label>
 
       <label class="flex flex-col gap-2">
-        <span class="datum-text-xs text-midnight-fjord/80 font-semibold">Name</span>
+        <span class="datum-text-xs text-midnight-fjord/80 font-semibold">
+          Name <span class="text-red-600">*</span>
+        </span>
         <input
           type="text"
           name="name"
@@ -40,7 +42,9 @@ const recaptchaSiteKey = import.meta.env.PUBLIC_RECAPTCHA_SITE_KEY;
       </label>
 
       <label class="flex flex-col gap-2">
-        <span class="datum-text-xs text-midnight-fjord/80 font-semibold">Work email</span>
+        <span class="datum-text-xs text-midnight-fjord/80 font-semibold">
+          Work email <span class="text-red-600">*</span>
+        </span>
         <input
           type="email"
           name="email"
@@ -51,7 +55,9 @@ const recaptchaSiteKey = import.meta.env.PUBLIC_RECAPTCHA_SITE_KEY;
       </label>
 
       <label class="flex flex-col gap-2">
-        <span class="datum-text-xs text-midnight-fjord/80 font-semibold">Company</span>
+        <span class="datum-text-xs text-midnight-fjord/80 font-semibold">
+          Company <span class="text-red-600">*</span>
+        </span>
         <input
           type="text"
           name="company"
@@ -62,7 +68,9 @@ const recaptchaSiteKey = import.meta.env.PUBLIC_RECAPTCHA_SITE_KEY;
       </label>
 
       <label class="flex flex-col gap-2">
-        <span class="datum-text-xs text-midnight-fjord/80 font-semibold">Workload type</span>
+        <span class="datum-text-xs text-midnight-fjord/80 font-semibold">
+          Workload type <span class="text-red-600">*</span>
+        </span>
         <input
           type="text"
           name="workloadType"

--- a/src/pages/demo.astro
+++ b/src/pages/demo.astro
@@ -48,7 +48,7 @@ const checklist = [
               <ul class="flex flex-col gap-7">
                 {
                   checklist.map((item) => (
-                    <li class="flex items-start gap-4">
+                    <li class="flex items-center gap-4">
                       <div class="bg-aurora-moss flex size-10 shrink-0 items-center justify-center">
                         <Icon name="check" size="md" class="text-app---dark---utility-3 stroke-1" />
                       </div>


### PR DESCRIPTION
## Summary
- Add visual `*` indicators to the already-required fields (Name, Work email, Company, Workload type) on the `/demo` Book a Demo form, matching the pattern used on `DedicatedCloudForm`
- Fix vertical misalignment between the checkmark icon and label text in the `/demo` checklist (`items-start` → `items-center`)

## Test plan
- [x] `astro check` passes with 0 errors
- [x] Verified locally via Playwright screenshot that required-field asterisks render correctly and only on Name, Work email, Company, and Workload type
- [x] Verified locally via Playwright screenshot that checklist icons are now vertically centered with their text
- [ ] Visual review on preview deployment
