### PR TITLE
fix(dedicated-cloud): restore operator card size and remove orphaned corner lines

### DIFF
--- a/src/components/dedicated-cloud/Operators.astro
+++ b/src/components/dedicated-cloud/Operators.astro
@@ -63,15 +63,10 @@ const people = await Promise.all(
     <SectionLine left bottom class="bg-app---dark---utility-2" />
 
     <div class="max-width-nopad relative py-4 md:py-6">
-      <SectionLine left top class="bg-app---dark---utility-2" />
-      <SectionLine right top class="bg-app---dark---utility-2" />
-      <SectionLine left bottom class="bg-app---dark---utility-2" />
-      <SectionLine right bottom class="bg-app---dark---utility-2" />
-
-      <ul class="grid grid-cols-1 gap-6 sm:grid-cols-3 md:gap-8">
+      <ul class="flex flex-wrap justify-center gap-6 md:gap-8">
         {
           people.map((person) => (
-            <li class="border-app---dark---utility-2 flex flex-col gap-4 border p-3">
+            <li class="border-app---dark---utility-2 flex w-[calc(50%-0.75rem)] flex-col gap-4 border p-3 md:w-[calc(25%-1.5rem)]">
               {person.avatarUrl ? (
                 <img
                   src={person.avatarUrl}


### PR DESCRIPTION
## Summary
Fixes the operator card grid on `/dedicated-cloud` after trimming the roster to 3 people (#1559):

- Switched from a stretching 3-column grid back to fixed-width cards (same size as the original 4-column layout) laid out with flexbox, centered as a row
- Removed the 4 corner `SectionLine` decorations around the card row — they were anchored to the full container width and floated disconnected from the cards now that the row is centered and narrower than the container

## Test plan
- [x] `astro check` passes with 0 errors
- [x] Verified locally via Playwright screenshot on desktop (centered row, normal card/photo size) and mobile (2-up then 1 centered)
- [ ] Visual review on preview deployment
