### PR TITLE
fix: wire up SectionEyebrow variants left dead by an earlier commit

### DIFF
--- a/src/components/SectionEyebrow.astro
+++ b/src/components/SectionEyebrow.astro
@@ -15,7 +15,9 @@ const variantClass =
           ? 'section-eyebrow--iris'
           : variant === 'aurora-moss'
             ? 'section-eyebrow--aurora-moss'
-            : '';
+            : variant === 'app'
+              ? 'section-eyebrow--app'
+              : '';
 
 const positionClass =
   position === 'left-top'

--- a/src/components/SectionEyebrow.astro
+++ b/src/components/SectionEyebrow.astro
@@ -13,7 +13,9 @@ const variantClass =
         ? 'section-eyebrow--connect'
         : variant === 'iris'
           ? 'section-eyebrow--iris'
-          : '';
+          : variant === 'aurora-moss'
+            ? 'section-eyebrow--aurora-moss'
+            : '';
 
 const positionClass =
   position === 'left-top'

--- a/src/components/SectionGroup.astro
+++ b/src/components/SectionGroup.astro
@@ -8,7 +8,7 @@ import type { SectionEyebrowProps, SectionLineProps } from '@/src/types/common';
 
 interface SectionGroupProps {
   label?: string;
-  eyebrowVariant?: 'pine' | 'canyon' | 'connect' | 'iris';
+  eyebrowVariant?: 'pine' | 'canyon' | 'connect' | 'iris' | 'app';
   showSectionLines?: boolean;
   sectionLines?: Pick<SectionLineProps, 'left' | 'right' | 'top' | 'bottom' | 'overlap'>;
   listClass?: string;

--- a/src/components/dedicated-cloud/Operators.astro
+++ b/src/components/dedicated-cloud/Operators.astro
@@ -52,11 +52,7 @@ const people = await Promise.all(
 
 <section class="section--block section--block--x-pad bg-midnight-fjord relative overflow-hidden">
   <div class="max-width-nav large-pad relative">
-    <SectionEyebrow
-      variant="app"
-      position="left-top"
-      class="text-aurora-moss [&_.section-eyebrow-cursor]:bg-aurora-moss"
-    >
+    <SectionEyebrow variant="aurora-moss" position="left-top">
       {operators.eyebrow}
     </SectionEyebrow>
 

--- a/src/pages/download/[slug].astro
+++ b/src/pages/download/[slug].astro
@@ -326,8 +326,6 @@ const jsonLd = appSchema
       class="light linear-gradient-light"
       title={pageFm.title}
       description={pageFm.description}
-      bodyClass={`page-brand page-brand--${page.id}`}
-      meta={meta}
     />
 
     <div class="section--block section--block--small-pad">

--- a/src/static/styles/components-module-animate.css
+++ b/src/static/styles/components-module-animate.css
@@ -54,6 +54,10 @@
     @apply bg-aurora-moss;
   }
 
+  .section-eyebrow--app .section-eyebrow-cursor {
+    @apply bg-app---dark---utility-3;
+  }
+
   /* Text stays in the DOM at full size (no layout shift) but is clipped
      until typed — the monospace eyebrow font keeps clip-path steps evenly
      spaced per character. */

--- a/src/static/styles/components-module-animate.css
+++ b/src/static/styles/components-module-animate.css
@@ -50,6 +50,10 @@
     @apply bg-iris;
   }
 
+  .section-eyebrow--aurora-moss .section-eyebrow-cursor {
+    @apply bg-aurora-moss;
+  }
+
   /* Text stays in the DOM at full size (no layout shift) but is clipped
      until typed — the monospace eyebrow font keeps clip-path steps evenly
      spaced per character. */

--- a/src/static/styles/components.css
+++ b/src/static/styles/components.css
@@ -83,6 +83,10 @@
     @apply text-midnight-fjord;
   }
 
+  .section-eyebrow--aurora-moss {
+    @apply text-aurora-moss;
+  }
+
   .section-eyebrow--left-top {
     @apply absolute left-4 md:left-7;
     @apply top-5 md:top-6 lg:top-8;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -209,7 +209,7 @@ export interface SecondaryTabNavProps {
 export interface SectionEyebrowProps {
   class?: string;
   /** Text colour + cursor colour. Defaults to canyon-clay. */
-  variant?: 'pine' | 'midnight-fjord' | 'connect' | 'iris';
+  variant?: 'pine' | 'midnight-fjord' | 'connect' | 'iris' | 'aurora-moss';
   /** Absolute positioning against the nearest `relative` ancestor. */
   position?: 'left-top' | 'left-top-keyline';
 }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -209,7 +209,7 @@ export interface SecondaryTabNavProps {
 export interface SectionEyebrowProps {
   class?: string;
   /** Text colour + cursor colour. Defaults to canyon-clay. */
-  variant?: 'pine' | 'midnight-fjord' | 'connect' | 'iris' | 'aurora-moss';
+  variant?: 'pine' | 'midnight-fjord' | 'connect' | 'iris' | 'aurora-moss' | 'app';
   /** Absolute positioning against the nearest `relative` ancestor. */
   position?: 'left-top' | 'left-top-keyline';
 }


### PR DESCRIPTION
## Summary

Audited `/dedicated-cloud` and the site's most-recently-touched pages for design-token usage, inline styles, and reinvented patterns. Found and fixed three real bugs, all the same root cause: props silently ignored because they weren't in a shared component's type union, so the AI-authored call site compensated with an ad-hoc override or the intended styling never applied at all.

- **`Operators.astro`** passed `variant="app"` to `SectionEyebrow`, invalid per `SectionEyebrowProps`, so it did nothing — the actual `aurora-moss` color was forced via an ad-hoc arbitrary-selector class override instead. Added a proper `aurora-moss` variant end-to-end (type union, `SectionEyebrow.astro` ternary, CSS in `components.css` + `components-module-animate.css`) matching the existing `pine`/`midnight-fjord`/`connect`/`iris` pattern, and switched `Operators.astro` to use it.
- **`locations.astro`** passes `eyebrowVariant="app"` to `SectionGroup` for its "MAP" label — same invalid-prop bug, same root commit as the one above, but this time the intended `.section-eyebrow--app` CSS (muted `app---dark---utility-3` gray) already existed in `components.css` and was simply never wired into the type unions or `SectionEyebrow`'s ternary. Wired it up (plus the missing matching cursor-color rule) so the eyebrow now renders in its intended muted gray instead of falling back to the default canyon-clay color.
- **`download/[slug].astro`** passed `bodyClass`/`meta` props to `<Hero>`, which doesn't destructure or use either — dead copy-paste from `brand/[...slug].astro`, where the same values are (correctly) applied to `<Layout>`. Removed the dead props.

No inline styles or raw hex/rgb colors were found on any of the 14 pages scanned (dedicated-cloud + the 13 next-most-recently-touched pages: demo, roadmap, download, locations, platform/connect, platform/deliver, platform/index, platform/build, pricing, essentials, contact, careers). One flex+`calc()` layout in `career/Benefits.astro` initially looked like a "should be grid" candidate but `git log -p` confirmed it was a deliberate, intentional fix (same reasoning as the `Operators.astro` roster-centering layout) — left as-is.

## Test plan

- [x] `npx astro check` — 0 errors/warnings/hints
- [x] Verified visually via Playwright screenshots: `/dedicated-cloud` operators eyebrow (aurora-moss, unchanged appearance, now via real variant) and `/locations` "MAP" eyebrow (now muted gray instead of default pink/canyon-clay)
- [ ] Preview deploy sanity check on `/dedicated-cloud`, `/locations`, and `/downloads/*`
