### PR TITLE
fix(nav): use log-in icon for Sign in instead of a bare arrow

### DIFF
--- a/src/components/MobileMenu.astro
+++ b/src/components/MobileMenu.astro
@@ -218,7 +218,7 @@ const mainNav = navData.main;
       <div class="mobile-menu-ctas">
         <a href="https://cloud.datum.net/" class="mobile-cta-secondary" x-on:click="closeMenu()">
           Sign in
-          <Icon name="arrow-right" size="sm" />
+          <Icon name="log-in" size="sm" />
         </a>
         <a href="/demo" class="mobile-cta-primary" x-on:click="closeMenu()">
           Book a demo

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -26,7 +26,7 @@ import NavMenu from '@components/NavMenu.astro';
     <div class="nav-actions">
       <a href="https://cloud.datum.net/" class="nav-cta-signin" data-rybbit-event="Nav: Sign in">
         Sign in
-        <Icon name="arrow-right-to-line" size="md" class="text-canyon-clay hidden lg:inline-flex" />
+        <Icon name="log-in" size="md" class="text-canyon-clay hidden lg:inline-flex" />
       </a>
 
       <a href="/demo" class="nav-cta-demo" data-rybbit-event="Nav: Book a demo">


### PR DESCRIPTION
## Summary

- The "Sign in" link's icon read as ambiguous: desktop used `arrow-right-to-line` (an arrow hitting a plain vertical line), mobile used `arrow-right` (no door metaphor at all) — neither clearly reads as "sign in"
- Swapped both to the `log-in` icon (arrow entering an open door), which was already imported and mapped in `src/utils/iconMap.ts` but never actually used anywhere in the codebase
- `src/components/Nav.astro` (desktop) and `src/components/MobileMenu.astro` (mobile) now both use the same, clearer icon

## Test plan

- [x] `npx astro check` — 0 errors/warnings/hints
- [x] Verified visually via Playwright screenshots — desktop nav and mobile menu both render the door+arrow icon correctly at existing size/color
- [ ] Preview deploy sanity check on desktop + mobile nav
