### PR TITLE
fix(about): remove empty hero gap above the mission heading

### DIFF
--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -106,7 +106,7 @@ const jsonLd = {
 
 <Layout title={title} description={description} bodyClass="page-about" meta={meta} jsonLd={jsonLd}>
   <section class="datum-container">
-    <Hero class="light bg-white" />
+    <Hero class="light bg-white" hideHero />
 
     <OurMission content={contentData[0]} />
 


### PR DESCRIPTION
## Summary

- `/about` had a large empty gap between the nav and the "We're on a mission..." heading — `<Hero class="light bg-white" />` was called with no `title`/`description`/`image`, so it still rendered an empty, padded `hero--main-content` wrapper with nothing inside it.
- Added `hideHero`, matching the pattern `careers.astro` already uses: when a page's own component renders the actual hero-like content directly below `Nav` (`Mission.astro` there, `OurMission.astro` here), `Hero` should skip its own content block entirely rather than leave an empty spacer.

## Test plan

- [x] `npx astro check` — 0 errors/warnings/hints
- [x] Verified visually via Playwright — gap is gone, content sits directly below nav, matching `/careers`' layout
