### PR TITLE
docs: Point AI Edge docs links at /docs/alb

### DIFF
--- a/public/.well-known/agent-skills/datum-docs/SKILL.md
+++ b/public/.well-known/agent-skills/datum-docs/SKILL.md
@@ -18,7 +18,7 @@ Navigate to `https://www.datum.net/docs/` to browse documentation, or append `?q
 - **Quickstart:** https://www.datum.net/docs/quickstart/
 - **API Reference:** https://www.datum.net/docs/api/reference/
 - **datumctl CLI:** https://www.datum.net/docs/datumctl/
-- **AI Edge Runtime:** https://www.datum.net/docs/runtime/ai-edge/
+- **AI Edge Runtime:** https://www.datum.net/docs/alb/overview
 
 ## Authentication
 

--- a/public/.well-known/agent-skills/datum-docs/SKILL.md
+++ b/public/.well-known/agent-skills/datum-docs/SKILL.md
@@ -18,7 +18,7 @@ Navigate to `https://www.datum.net/docs/` to browse documentation, or append `?q
 - **Quickstart:** https://www.datum.net/docs/quickstart/
 - **API Reference:** https://www.datum.net/docs/api/reference/
 - **datumctl CLI:** https://www.datum.net/docs/datumctl/
-- **AI Edge Runtime:** https://www.datum.net/docs/alb/overview
+- **Application Load Balancer:** https://www.datum.net/docs/alb/overview
 
 ## Authentication
 

--- a/src/data/ai-prompt.md
+++ b/src/data/ai-prompt.md
@@ -20,7 +20,7 @@ https://datum.net/docs
 https://datum.net/docs/overview
 https://datum.net/docs/platform/setup
 https://datum.net/docs/desktop-apps
-https://datum.net/docs/ai-edge/overview
+https://datum.net/docs/alb/overview
 https://datum.net/docs/connectors/tunnels
 https://datum.net/docs/galactic-vpc/overview
 https://datum.net/docs/datumctl/overview

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -325,7 +325,7 @@ npx skills add https://github.com/datum-cloud/skills
 
 | Skill | Purpose |
 |-------|---------|
-| \`ai-edge\` | Application Load Balancer: manage WAF, authentication, authorization, rate limiting, and traffic policies (TrafficProtectionPolicy, SecurityPolicy, BackendTrafficPolicy) attached to Gateways and HTTPRoutes |
+| \`alb\` | Application Load Balancer: manage WAF, authentication, authorization, rate limiting, and traffic policies (TrafficProtectionPolicy, SecurityPolicy, BackendTrafficPolicy) attached to Gateways and HTTPRoutes |
 | \`client-traffic\` | Configure how edge gateways accept client connections — TLS termination, mTLS, HTTP/2, HTTP/3, timeouts, connection limits, real IP detection |
 | \`dns\` | Manage DNS zones and record sets (A, AAAA, CNAME, MX, TXT, ALIAS, CAA, SRV, SVCB, HTTPS, TLSA, etc.) |
 | \`domains\` | Attach and verify domain resources within a project |

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -70,7 +70,7 @@ Datum uses a standard cloud hierarchy:
 \`\`\`
 Organization
   └── Project
-        └── Resources (AI Edge, Tunnels, DNS Zones, Domains, Secrets, etc.)
+        └── Resources (Application Load Balancer, Tunnels, DNS Zones, Domains, Secrets, etc.)
 \`\`\`
 
 - **Personal Org** — created automatically per user; no collaboration; personal sandbox
@@ -115,18 +115,19 @@ Organization (admin) → Project (admin, inherited) → Service Resources (admin
 
 ## Current Platform Features
 
-### 1. AI Edge (Generally Available — Free)
+### 1. Application Load Balancer (Generally Available — Free)
 
-An intelligent HTTP proxy and edge layer built on **Envoy Proxy** and powered by **Tetrate**.
+An intelligent HTTP proxy and edge layer built on **Envoy Proxy** and powered by **Tetrate**. In the portal nav this appears as **ALB**.
 
 - **Protocols supported:** HTTP/1.1, HTTP/2, gRPC, WebSockets, HTTPS
 - **WAF:** Coraza-based Web Application Firewall covering top OWASP threats; runs in \`observe\` mode by default, can be set to \`enforced\` (Level 1 Relaxed or Level 2 Balanced)
 - **Custom Hostnames:** Verify and attach custom domains; HTTPS enforced by default
-- **Basic Auth:** Username/password protection for any AI Edge endpoint
+- **Basic Auth:** Username/password protection for any Application Load Balancer endpoint
 - **Global reach:** 17+ regions across all major internet peering points (see Regions below)
-- **Default hostname:** Each AI Edge gets a generated HTTPS hostname automatically
+- **Default hostname:** Each Application Load Balancer gets a generated HTTPS hostname automatically
 - **Resource kinds:** \`HTTPProxy\`, \`HTTPRoute\`, \`Gateway\`, \`TrafficProtectionPolicy\`
 - **Observability:** Portal metrics include upstream latency percentiles (p90, p99), RPS by region, response codes; filter by region
+- **Docs:** https://www.datum.net/docs/alb/overview
 
 **Use case for agents:** Give any agent or app a global edge to absorb attacks, interact with the broader internet, and safely route traffic to backend services.
 
@@ -226,7 +227,7 @@ Datum operates at major internet peering points (IXPs) globally. Region naming f
 | **Provider** | Custom             | Alt cloud providers; become a design partner                     |
 
 **Builder tier includes (forever free):**
-- AI Edge (Envoy Proxy + Coraza WAF)
+- Application Load Balancer (Envoy Proxy + Coraza WAF)
 - Connectors (QUIC Tunnels)
 - DNS and Domains
 - OTel Metrics Export
@@ -259,7 +260,7 @@ Datum operates at major internet peering points (IXPs) globally. Region naming f
 
 1. Sign up at \`https://cloud.datum.net\`
 2. Create a project inside your Personal Org (or a new Standard Org)
-3. Create an AI Edge: navigate to AI Edge → New → configure upstream URL → get your generated HTTPS hostname
+3. Create an Application Load Balancer: navigate to ALB → New → configure upstream URL → get your generated HTTPS hostname
 4. (Optional) Add and verify a custom domain
 5. (Optional) Set up a Tunnel via the Desktop App to expose localhost
 
@@ -324,7 +325,7 @@ npx skills add https://github.com/datum-cloud/skills
 
 | Skill | Purpose |
 |-------|---------|
-| \`ai-edge\` | Manage WAF, authentication, authorization, rate limiting, and traffic policies (TrafficProtectionPolicy, SecurityPolicy, BackendTrafficPolicy) attached to Gateways and HTTPRoutes |
+| \`ai-edge\` | Application Load Balancer: manage WAF, authentication, authorization, rate limiting, and traffic policies (TrafficProtectionPolicy, SecurityPolicy, BackendTrafficPolicy) attached to Gateways and HTTPRoutes |
 | \`client-traffic\` | Configure how edge gateways accept client connections — TLS termination, mTLS, HTTP/2, HTTP/3, timeouts, connection limits, real IP detection |
 | \`dns\` | Manage DNS zones and record sets (A, AAAA, CNAME, MX, TXT, ALIAS, CAA, SRV, SVCB, HTTPS, TLSA, etc.) |
 | \`domains\` | Attach and verify domain resources within a project |

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -36,7 +36,7 @@ export const GET: APIRoute = async () => {
     // Base structure for llms.txt
     let llmsContent = `# Datum\n\n`;
     llmsContent += `## About\n\n`;
-    llmsContent += `> Datum is an open source network cloud for AI, founded in 2024 and backed by $13.6M from Amplify Partners, CRV, Encoded Ventures, Cervin Ventures, Ex/Ante, Step Function, and Vine Ventures. Built for AI-native developers and alternative cloud providers, Datum provides an Envoy-based AI Edge across 17+ global regions, QUIC-based secure tunnels (Connectors), authoritative DNS, and programmatic domain management — all with a forever-free Builder tier. Core platform licensed AGPLv3. Founded by Zac Smith (ex-Equinix, Packet) and Jacob Smith.\n\n`;
+    llmsContent += `> Datum is an open source network cloud for AI, founded in 2024 and backed by $13.6M from Amplify Partners, CRV, Encoded Ventures, Cervin Ventures, Ex/Ante, Step Function, and Vine Ventures. Built for AI-native developers and alternative cloud providers, Datum provides an Envoy-based Application Load Balancer across 17+ global regions, QUIC-based secure tunnels (Connectors), authoritative DNS, and programmatic domain management — all with a forever-free Builder tier. Core platform licensed AGPLv3. Founded by Zac Smith (ex-Equinix, Packet) and Jacob Smith.\n\n`;
 
     // Get all pages sorted, excluding home/* pages
     const pages = await getCollection('pages');

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -69,7 +69,7 @@ export const GET: APIRoute = async () => {
     llmsContent += `- [Datum Docs MCP](${siteUrl}/docs/mcp) - MCP server for AI agents to search and read Datum documentation (JSON-RPC 2.0 over SSE). Tools: \`search_datum_cloud_docs\`, \`query_docs_filesystem_datum_cloud_docs\`.\n`;
 
     llmsContent += `\n## Skills\n\n`;
-    llmsContent += `- [Datum Cloud Skills](https://github.com/datum-cloud/skills) - Agent skills for working with Datum Cloud APIs and infrastructure primitives. Install via \`/plugin marketplace add datum-cloud/skills\` (Claude Code), \`npx skills add https://github.com/datum-cloud/skills\` (npx), or remote rule settings (Cursor). Available: ai-edge, client-traffic, dns, domains, httproute, metrics-export.\n`;
+    llmsContent += `- [Datum Cloud Skills](https://github.com/datum-cloud/skills) - Agent skills for working with Datum Cloud APIs and infrastructure primitives. Install via \`/plugin marketplace add datum-cloud/skills\` (Claude Code), \`npx skills add https://github.com/datum-cloud/skills\` (npx), or remote rule settings (Cursor). Available: alb, client-traffic, dns, domains, httproute, metrics-export.\n`;
 
     llmsContent += `\n## Optional\n\n`;
     llmsContent += `- Full site content at ${siteUrl}/llms-full.txt\n`;


### PR DESCRIPTION
## Summary

Mintlify docs for this product are moving from `/docs/ai-edge/...` to `/docs/alb/...`. datum.net still pointed at the old paths in crawl and agent skill surfaces, and the agent-facing llms briefs still called the product AI Edge.

This updates:

- Docs URLs in the ai-prompt crawl list and the datum-docs agent skill
- The well-known skill label from AI Edge Runtime to Application Load Balancer
- `/llms-full.txt` (same content as https://agents.datum.net/) to Application Load Balancer / ALB
- The `/llms.txt` about blurb and skills list (`alb` install id)

Marketing and handbook copy that still says AI Edge is left alone on purpose.

Related to [datum-cloud/enhancements#839](https://github.com/datum-cloud/enhancements/issues/839)