### PR TITLE
fix(seo): rewrite page titles, meta descriptions, and H1s per audit sheet

### DIFF
--- a/src/content/about/index.mdx
+++ b/src/content/about/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "We're on a mission to help the next 1k clouds thrive in the AI era"
+title: "Run workloads at the network edge, an alternative solution for AI companies"
 subtitle: About
 iconName: datum
 contents:
@@ -10,8 +10,8 @@ contents:
   - team
   - we-value
 meta:
-  title: "About Datum: Building the Open Network Cloud for AI"
-  description: "The Neutral, open source networking cloud Datum was founded by industry veterans from Voxel, Packet, Equinix, Fastly, and StackPath. Datum is on a mission to help the next 1,000 clouds thrive."
+  title: "About Datum - The Network Layer for Alternative Clouds"
+  description: "Founded by infrastructure veterans from Packet, Equinix, Fastly and StackPath, Datum is a modern edge cloud platform, backed by open source."
   og:
     title: We’re on a mission to help the next 1k clouds thrive
     description: We are infrastructure, open source software, and design nerds who love building for the future.

--- a/src/content/about/our-mission.mdx
+++ b/src/content/about/our-mission.mdx
@@ -1,5 +1,5 @@
 ---
-title: We’re on a mission to help the next 1k clouds thrive in the AI era
+title: Run workloads at the network edge, an alternative solution for AI companies
 ---
 
 Datum is unlocking the internet superpowers that all the big guys use – global edges, private networks, deterministic routing, direct interconnection – for the next generation of builders.

--- a/src/content/download/datumctl.mdx
+++ b/src/content/download/datumctl.mdx
@@ -5,8 +5,8 @@ description: "Quickly and safely expose local environments to the internet, for 
 icon: "terminal"
 order: 1
 meta:
-  title: "Developer tools and desktop apps - Datum Cloud"
-  description: "Install the datumctl CLI - Datum AI Network Cloud"
+  title: "Install datumctl - Datum CLI for the Network Cloud"
+  description: "Install datumctl, the command-line interface for Datum's open network cloud. Manage DNS, tunnels and network services from your terminal - free."
   og:
     title: "Install the datumctl CLI - Datum AI Network Cloud"
     description: "Quickly and safely expose local environments to the internet, for free."

--- a/src/content/download/mac-os.mdx
+++ b/src/content/download/mac-os.mdx
@@ -5,8 +5,8 @@ description: "Quickly and safely expose local environments to the internet, for 
 icon: "apple"
 order: 1
 meta:
-  title: "Developer tools and desktop apps - Datum Cloud"
-  description: "Quickly and safely expose local environments to the internet, for free with Datum's Rust-based desktop macOS app."
+  title: "Datum for macOS - Free Tunnels & Desktop App"
+  description: "Download the free Datum desktop app for macOS. Safely expose local environments to the internet with fast, secure QUIC tunnels - no network team needed."
   og:
     title: "Try Datum's Desktop app for free"
     description: "Quickly and safely expose local environments to the internet, for free."

--- a/src/content/handbook/build/components.md
+++ b/src/content/handbook/build/components.md
@@ -1,5 +1,5 @@
 ---
-title: "Components"
+title: "System components & architecture"
 sidebar:
   label: Components
   order: 1

--- a/src/content/pages/contact.mdx
+++ b/src/content/pages/contact.mdx
@@ -1,11 +1,11 @@
 ---
-title: "We're all about connecting, so how about a chat?"
+title: "Join the community"
 iconName: messages-square
 description: "Join us and our ecosystem in one place to share ideas, support, and continue building the future."
 slug: contact
 meta:
-  title: "Schedule a Meeting - Contact Datum"
-  description: "Ways to contact Datum to help grow your skills, your revenue, and your ecosystem advantage with our open network cloud platform and community."
+  title: "Contact Datum - Ways to get involved with Datum's open network cloud."
+  description: "Get in touch with Datum. Talk to the team about network cloud infrastructure for AI and alternative cloud providers, partnerships, or support."
   og:
     title: Book a chat with our founders
     description: Ways to contact Datum to help grow your skills, your revenue, and your ecosystem advantage with our open network cloud platform and community.

--- a/src/content/pages/essentials.mdx
+++ b/src/content/pages/essentials.mdx
@@ -1,9 +1,9 @@
 ---
-title: Batteries included
+title: "Open source networking primitives, all the essentials included"
 description: "We think core cloud features are essential, not optional."
 meta:
-  title: "Datum Essentials — Free Enterprise Networking Primitives"
-  description: "Enterprise-grade networking primitives like Authoritative DNS, Domains, Metrics Export, RBAC, SSO and audit logs for free."
+  title: "Open Source Network Infrastructure - Datum Essentials"
+  description: "Open source network infrastructure primitives. Domains, metrics export, RBAC, SSO and audit logs. From solo developers to Enterprises."
   og:
     title: "Access enterprise-grade networking foundations at zero cost"
     description: "Enterprise-grade networking primitives like Authoritative DNS, Domains, Metrics Export, RBAC, SSO and audit logs — free to use."

--- a/src/content/pages/features/build/index.mdx
+++ b/src/content/pages/features/build/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: "Bring intelligence to the <span class=\"text-canyon-clay---links\">network edge</span>"
+title: "AI-Inference compute"
 slug: "features/build/index"
-description: "Millisecond cold-start compute and related primitives."
+description: "Deploy and scale applications instantly on fully isolated virtual machines across global infrastructure"
 meta:
-  title: "Edge Compute & Cold-Start Primitives — Datum Platform"
-  description: "Datum's Build tier delivers millisecond cold-start compute at the network edge — bring intelligence closer to your users with AI-native primitives."
+  title: "Millisecond Cold Start Compute Built for AI Inference At the Edge - Build, Datum Platform Features"
+  description: "Deploy and scale applications instantly on fully isolated virtual machines across global infrastructure"
   og:
-    title: "Edge Compute & Cold-Start Primitives — Datum Platform"
-    description: "Datum's Build tier delivers millisecond cold-start compute at the network edge — bring intelligence closer to your users with AI-native primitives."
+    title: "Millisecond Cold Start Compute Built for AI Inference At the Edge - Build, Datum Platform Features"
+    description: "Deploy and scale applications instantly on fully isolated virtual machines across global infrastructure"
 ---

--- a/src/content/pages/features/connect/index.mdx
+++ b/src/content/pages/features/connect/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: "Private networking, <span class=\"text-connect-slate\">reimagined</span>"
+title: "Private Networking"
 slug: "features/connect/index"
-description: "Land diverse connections on your own virtual \"meet me room\"."
+description: "Dedicated, high-speed private networking for AI and alt-cloud infrastructure - Galactic VPC, QUIC tunnels and interconnects to AWS, GCP and Azure. Land diverse connections in one virtual meet-me room."
 meta:
-  title: "Private Networking & Virtual Meet-Me Room — Datum Platform"
-  description: "Land diverse private connections on your own virtual meet-me room. Datum's Connect tier simplifies BGP peering, cloud on-ramps, and interconnection."
+  title: "Cloud Interconnect & Private Networking - Datum Connect Platform Features"
+  description: "Dedicated, high-speed private networking for AI and alt-cloud infrastructure - Galactic VPC, QUIC tunnels and interconnects to AWS, GCP and Azure. Land diverse connections in one virtual meet-me room."
   og:
-    title: "Private Networking & Virtual Meet-Me Room — Datum Platform"
-    description: "Land diverse private connections on your own virtual meet-me room. Datum's Connect tier simplifies BGP peering, cloud on-ramps, and interconnection."
+    title: "Cloud Interconnect & Private Networking - Datum Connect Platform Features"
+    description: "Dedicated, high-speed private networking for AI and alt-cloud infrastructure - Galactic VPC, QUIC tunnels and interconnects to AWS, GCP and Azure. Land diverse connections in one virtual meet-me room."
 ---

--- a/src/content/pages/features/deliver/index.mdx
+++ b/src/content/pages/features/deliver/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: "Protect, manage, and route <span class=\"text-pine-forge\">traffic</span>"
+title: "AI-native network infrastructure"
 slug: "features/deliver/index"
-description: "Route, filter, and accelerate traffic across every location without managing a separate CDN, WAF, or inference proxy."
+description: "Route, filter and accelerate traffic across every location - authoritative DNS, Layer 7 load balancing and AI Edge WAF, without a separate CDN or proxy."
 meta:
-  title: "Traffic Delivery: CDN, WAF & Inference Proxy — Datum Platform"
-  description: "Route, filter, and accelerate traffic across every location without managing a separate CDN, WAF, or inference proxy."
+  title: "Deliver AI Infrastructure at the Networking Edge - Deliver, Datum Platform Features"
+  description: "Route, filter and accelerate traffic across every location - authoritative DNS, Layer 7 load balancing and AI Edge WAF, without a separate CDN or proxy."
   og:
-    title: "Traffic Delivery: CDN, WAF & Inference Proxy — Datum Platform"
-    description: "Route, filter, and accelerate traffic across every location without managing a separate CDN, WAF, or inference proxy."
+    title: "Deliver AI Infrastructure at the Networking Edge - Deliver, Datum Platform Features"
+    description: "Route, filter and accelerate traffic across every location - authoritative DNS, Layer 7 load balancing and AI Edge WAF, without a separate CDN or proxy."
 ---

--- a/src/content/pages/home.mdx
+++ b/src/content/pages/home.mdx
@@ -7,8 +7,8 @@ contents:
   - home/why-evolve
   - home/what-does-good-look-like
 meta:
-  title: "Datum - Open Source Network Cloud for AI"
-  description: "Datum is an open, neutral, global network cloud built for AI — giving alternative cloud providers critical network infrastructure to compete at scale."
+  title: "Datum - Modern Connected Infrastructure for AI Companies"
+  description: "Datum is the modern, cloud alternative to CDNs, complex networks and colocation for AI companies, giving alternative and neo cloud providers the connectivity to scale AI infrastructure."
   og:
     title: "Connected infrastructure for AI companies"
     description: "Hyperscale-style edge networking and connected CPU / GPU capacity for tech-forward enterprises."

--- a/src/content/pages/locations.mdx
+++ b/src/content/pages/locations.mdx
@@ -1,9 +1,9 @@
 ---
-title: Network Locations
+title: "Cloud interconnect at the world's peering points"
 description: "From Silicon Valley to Singapore, we've got you covered."
 meta:
-  title: "Datum Global Network - AI Edge Cloud Locations"
-  description: "Datum's network is deployed at major internet peering points for low-latency access to public clouds, AI clouds, and end users."
+  title: "Cloud Interconnect & AI Edge Locations - Datum Global Network"
+  description: "Datum deploys at major internet peering points for cloud interconnect and low-latency edge networking to public clouds, AI clouds and inference at the edge."
   og:
     title: "Located where it matters most – Datum Network Locations"
     description: "Datum's network is deployed at major internet peering points for low-latency access to public clouds, AI clouds, and end users."

--- a/src/content/pages/pricing.mdx
+++ b/src/content/pages/pricing.mdx
@@ -1,11 +1,11 @@
 ---
-title: Interact at scale, no network team required
+title: "Network cloud pricing — no network team required"
 subtitle: Pricing
 iconName: wallet
 description: "Our pricing is designed to create millions of connections between modern providers, their partners, and their customers."
 meta:
-  title: "Datum Pricing — Free Network Cloud Tier & Pro Plans"
-  description: "A low-friction plan for builders, developers, and agents — enterprise-grade network primitives free. Production tier from $20/month."
+  title: "Datum Pricing - Connected Infrastructure"
+  description: "Usage-based, transparent pricing for enterprise-grade network primitives."
   og:
     title: "Get Started for Free"
     description: "Set your developers or AI agents up to successfully interact with network primitives at scale, no network team required."

--- a/src/content/pages/resources/open-source.mdx
+++ b/src/content/pages/resources/open-source.mdx
@@ -1,12 +1,12 @@
 ---
-title: Open is Our Strategy
+title: Open source is our strategy
 subtitle: Open Source
 iconName: code
 description: "Datum is an open source company, and we believe the best software is built in the open. In addition to the core projects that we lead and maintain, we lean into open source projects and companies wherever possible."
 slug: "open-source"
 meta:
-    title: "Building in the Open: Datum's Open Source Commitment"
-    description: "Learn how Datum leverages open-source projects including Milo, HickoryDNS, and the Envoy AI Gateway, along with Crossplane and SRv6."
+    title: "Open Source Networking - Datum's Open Source Projects"
+    description: "Datum is an open source networking company. Explore our projects - Milo, HickoryDNS, Envoy AI Gateway, Crossplane and SRv6."
     og:
       title: "Our open source commitment"
       description: "Datum is an open source company. We lead projects like Milo and the Envoy AI Gateway, and lean into Crossplane, SRv6, and HickoryDNS wherever possible."

--- a/src/data/dedicatedCloud.ts
+++ b/src/data/dedicatedCloud.ts
@@ -3,14 +3,14 @@
 // two can never drift out of sync.
 
 export const meta = {
-  title: 'Dedicated Cloud — GPU clusters built and operated by Datum',
+  title: 'Dedicated GPU Clusters - Datum Dedicated Cloud',
   description:
-    'Leverage our decades of experience, deep industry relationships, flexible platform, and operational muscle to accelerate your business.',
+    'Get white-glove support for enterprise networking needs – from architecture and design to fully managed connectivity and orchestration.',
 };
 
 export const hero = {
   eyebrow: 'Dedicated cloud',
-  title: 'GPU clusters, built and operated by folks you can trust',
+  title: 'Advanced cloud networking expertise',
   description:
     'Leverage our decades of experience, deep industry relationships, flexible platform, and operational muscle to accelerate your business.',
   ctaText: 'Schedule a conversation',

--- a/src/pages/dedicated-cloud.astro
+++ b/src/pages/dedicated-cloud.astro
@@ -24,7 +24,7 @@ const faqs = (await getCollection('faq'))
   .filter((faq) => !faq.data.draft && faq.data.category === 'dedicated-cloud')
   .sort((a, b) => (a.data.order ?? 0) - (b.data.order ?? 0));
 
-const HERO_TITLE_HIGHLIGHT = 'trust';
+const HERO_TITLE_HIGHLIGHT = 'expertise';
 const heroTitleLead = hero.title.slice(0, hero.title.lastIndexOf(HERO_TITLE_HIGHLIGHT));
 
 const jsonLd = {

--- a/src/pages/demo.astro
+++ b/src/pages/demo.astro
@@ -13,6 +13,9 @@ import SectionLine from '@components/SectionLine.astro';
 
 const title = 'Book a demo';
 const description = 'See our modern alternative to global cloud solutions in action.';
+const metaTitle = 'Book a Datum Demo - See the Network Cloud in Action';
+const metaDescription =
+  'Book a live Datum demo and see connected infrastructure for AI companies and alternative cloud providers in action. See how you can scale with no network team.';
 
 const checklist = [
   {
@@ -27,7 +30,7 @@ const checklist = [
 ];
 ---
 
-<Layout title={title} description={description} bodyClass="page-demo">
+<Layout title={metaTitle} description={metaDescription} bodyClass="page-demo">
   <section class="datum-container">
     <Hero class="light" hideContent={true} hideHero />
 

--- a/src/pages/essentials.astro
+++ b/src/pages/essentials.astro
@@ -17,7 +17,7 @@ const page = await getCollectionEntry('pages', 'essentials');
 // SEO
 const fm = page.data;
 const meta = fm.meta || {};
-const theTitle = 'Batteries included.';
+const theTitle = 'Open source networking primitives, all the essentials included';
 const jsonLd = {
   '@context': 'https://schema.org',
   '@graph': [
@@ -25,7 +25,7 @@ const jsonLd = {
       '@type': 'WebPage',
       '@id': 'https://www.datum.net/essentials',
       url: 'https://www.datum.net/essentials',
-      name: 'Batteries included – Enterprise-grade networking primitives',
+      name: 'Open Source Network Infrastructure - Datum Essentials',
       description: 'We think core cloud features are essential, not optional.',
       isPartOf: { '@id': 'https://www.datum.net/#organization' },
       inLanguage: 'en-US',

--- a/src/pages/handbook.astro
+++ b/src/pages/handbook.astro
@@ -28,7 +28,7 @@ const handbookMeta = {
 
 <Layout title={title} description={description} bodyClass="page-handbook" meta={handbookMeta}>
   <section class="datum-container">
-    <Hero class="light linear-gradient-light" title="Handbook" />
+    <Hero class="light linear-gradient-light" title="Company handbook" />
 
     <Article articleId="index" showTitle={false} />
 

--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -22,7 +22,7 @@ const fm = page.data;
 const meta = fm.meta || {};
 const description = fm.description;
 const heroYear = new Date().getFullYear();
-const heroTitle = `${heroYear} Roadmap`;
+const heroTitle = `${heroYear} Product Roadmap`;
 
 const roadmaps = await fetchGitHubRoadmaps();
 const hasUpcoming = roadmaps.some((roadmap) => !isRoadmapShipped(roadmap));

--- a/src/pages/roadmap/backlog.astro
+++ b/src/pages/roadmap/backlog.astro
@@ -21,8 +21,7 @@ const roadmapMeta = roadmapPage.data.meta || {};
 const backlogMeta = backlogPage.data.meta || {};
 const meta = { ...roadmapMeta, ...backlogMeta };
 
-const heroYear = new Date().getFullYear();
-const heroTitle = `${heroYear} Roadmap`;
+const heroTitle = 'Product backlog';
 const heroDescription = roadmapPage.data.description;
 
 const layoutTitle = backlogMeta.title ?? 'Datum Product Backlog';


### PR DESCRIPTION
Closes #1573

## Summary

Applies the metadata rewrite from the SEO audit across 18 pages: home, about, platform deliver/build/connect, locations, dedicated-cloud, essentials, pricing, roadmap + backlog, contact, demo, open-source, download mac-os/datumctl, and handbook + handbook/build/components.

- **Titles + meta descriptions** updated per the sheet's "UPDATED Title" / "UPDATED Meta Description" columns.
- **H1s** updated per the "RECOMMENDED H1" column, including two code-level changes needed to actually change the rendered heading:
  - `roadmap.astro` / `roadmap/backlog.astro` dropped the hardcoded `` `${year} Roadmap` `` template in favor of the sheet's H1 text.
  - `dedicated-cloud.astro`'s `HERO_TITLE_HIGHLIGHT` constant (`'trust'`) updated to `'expertise'` to match the new hero title; `demo.astro`'s shared title/description consts split into separate SEO vs. display values so the H1 could stay "Book a demo" while the tab title changed.
- Fixed two typos found in the sheet itself: "Milisecond" → "Millisecond" (`/platform/build`), and a duplicated "private networking **private** for" on `/platform/connect`.
- Corrected the actual H1 source for `/about` (it's `about/our-mission.mdx`, not `about/index.mdx`'s own `title` field, which is unused for display) and `/essentials` (a hardcoded constant in `essentials.astro`, independent of the content collection) — found by verifying rendered output against the sheet rather than trusting frontmatter alone.

**Out of scope:** `/docs*`, `/blog/*`, and `/authors/*` rows from the sheet aren't editable in this repo — docs are reverse-proxied to Mintlify (`server.mjs`) and blog/authors are Strapi-backed with no local content collection.

**Note:** `/contact`'s H1 changes from a question ("We're all about connecting, so how about a chat?") to "Join the community" — a real tone/content shift, not just SEO wording. Applied as specified in the sheet.

## Test plan

- [x] `npm run typecheck` — 0 errors, 251 files
- [x] `npm run lint:md` — clean
- [x] Verified rendered `<title>`, meta description, and `<h1>` for all 18 pages against the sheet via local dev server
- [ ] Manual review of copy against the sheet, especially the `/contact` H1 tone change
