### PR TITLE
fix(dns): hide page in prod and polish copy

### DIFF
--- a/src/data/dns.ts
+++ b/src/data/dns.ts
@@ -97,7 +97,7 @@ export const operations = {
       icon: 'bot',
       title: 'MCP support',
       description:
-        'MCP support lets AI agents query and manage DNS zones under the same permissions as a human operator — not a bolted-on integration.',
+        'MCP support lets AI agents query and manage DNS zones with the same permissions as a human operator — not a bolted-on integration.',
     },
   ] satisfies IconItem[],
 };
@@ -149,7 +149,7 @@ export const domains = {
     {
       title: 'Add a domain',
       description:
-        'One at a time, in bulk via CSV/TXT import, or automatically when you attach a custom hostname to an AI Edge.',
+        'One at a time, in bulk via CSV/TXT import, or automatically when attaching a custom hostname to a Proxy.',
     },
     {
       title: 'Verify ownership',

--- a/src/data/navigation.json
+++ b/src/data/navigation.json
@@ -16,7 +16,7 @@
           "title": "Deliver",
           "href": "/platform/deliver",
           "items": [
-            { "text": "DNS", "href": "/platform/dns" },
+            { "text": "DNS", "href": "/platform/deliver" },
             {
               "text": "Application Load Balancer",
               "href": "/platform/deliver#application-load-balancer"

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,7 @@ import { stargazerCount } from '@libs/datum';
 import { sequence } from 'astro:middleware';
 import type { MiddlewareHandler } from 'astro';
 
-const PROTECTED_ROUTES = [/^\/dev($|\/.*)/];
+const PROTECTED_ROUTES = [/^\/dev($|\/.*)/, /^\/platform\/dns(\.md)?\/?$/];
 
 const HELLO_PROFILE_PATH = /^\/hello\/([^/]+)$/;
 
@@ -34,7 +34,7 @@ const routeGuard: MiddlewareHandler = async ({ url, redirect }, next) => {
   if (isProtected(pathName)) {
     // only for development mode, to ease testing
     if (mode == 'production') {
-      return redirect(`/`);
+      return redirect(`/`, 302);
     }
   }
 

--- a/src/pages/dev/info.astro
+++ b/src/pages/dev/info.astro
@@ -7,7 +7,7 @@ const mode = process.env.MODE || import.meta.env.MODE;
 
 // only for development mode, to ease testing
 if (mode == 'production') {
-  return Astro.redirect('/');
+  return Astro.redirect('/', 302);
 }
 
 /**

--- a/src/pages/platform/dns.astro
+++ b/src/pages/platform/dns.astro
@@ -1,6 +1,8 @@
 ---
 // src/pages/platform/dns.astro
 // DNS product detail page — Figma node 15755:114768.
+export const prerender = false;
+
 import '@styles/page-dns.css';
 
 import Layout from '@layouts/Layout.astro';

--- a/src/pages/platform/dns.md.ts
+++ b/src/pages/platform/dns.md.ts
@@ -1,6 +1,8 @@
 // Dynamic markdown export of /platform/dns. Reads the same source the rendered
 // page consumes: src/data/dns.ts. Shared with platform/dns.astro so the two
 // can't drift out of sync.
+export const prerender = false;
+
 import type { APIRoute } from 'astro';
 import { hero, capabilities, operations, comparison, domains } from '@data/dns';
 import { toAsciiMarkdown } from '@utils/markdownExport';

--- a/src/static/styles/components-dns.css
+++ b/src/static/styles/components-dns.css
@@ -76,7 +76,7 @@
   }
 
   .dns-operations-description {
-    @apply datum-text-base text-midnight-fjord/80 lg:flex-1;
+    @apply datum-text-base text-midnight-fjord/80 text-pretty lg:flex-1;
   }
 
   /* Datum vs Cloudflare table — Figma node 15755:115034.
@@ -161,6 +161,6 @@
   }
 
   .dns-step-description {
-    @apply datum-text-base text-midnight-fjord/80;
+    @apply datum-text-base text-midnight-fjord/80 text-pretty;
   }
 }


### PR DESCRIPTION
Gate /platform/dns behind middleware in production with a 302 redirect, SSR the page and markdown export so the guard applies, and point nav DNS at deliver until launch. Update MCP and domain step copy and tighten description line breaks.