### PR TITLE
fix(nav): revert top nav CTA to start for free

### DIFF
--- a/src/components/MobileMenu.astro
+++ b/src/components/MobileMenu.astro
@@ -220,9 +220,15 @@ const mainNav = navData.main;
           Sign in
           <Icon name="log-in" size="sm" />
         </a>
-        <a href="/demo" class="mobile-cta-primary" x-on:click="closeMenu()">
-          Book a demo
-          <Icon name="calendar" size="sm" />
+        <a
+          href="https://auth.datum.net/ui/v2/login/register"
+          class="mobile-cta-primary"
+          target="_blank"
+          data-rybbit-event="Nav: Start for free"
+          x-on:click="closeMenu()"
+        >
+          Start for free
+          <Icon name="arrow-right" size="sm" />
         </a>
       </div>
       <div class="mobile-menu-social">

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -29,10 +29,15 @@ import NavMenu from '@components/NavMenu.astro';
         <Icon name="log-in" size="md" class="text-canyon-clay hidden lg:inline-flex" />
       </a>
 
-      <a href="/demo" class="nav-cta-demo" data-rybbit-event="Nav: Book a demo">
-        <span class="hidden lg:inline-flex">Book a demo</span>
-        <span class="inline-flex lg:hidden">Demo</span>
-        <Icon name="calendar" size="md" class="hidden lg:inline-flex" />
+      <a
+        href="https://auth.datum.net/ui/v2/login/register"
+        class="nav-cta-demo"
+        target="_blank"
+        data-rybbit-event="Nav: Start for free"
+      >
+        <span class="hidden lg:inline-flex">Start for free</span>
+        <span class="inline-flex lg:hidden">Start</span>
+        <Icon name="arrow-right" size="md" class="hidden lg:inline-flex" />
       </a>
     </div>
 

--- a/src/components/forms/DedicatedCloudForm.astro
+++ b/src/components/forms/DedicatedCloudForm.astro
@@ -202,6 +202,7 @@ const labelClass = 'datum-text-xs text-midnight-fjord/80 font-semibold';
           if (result.error) {
             this.showStatus('Something went wrong. Please try again in a minute or two.', false);
           } else {
+            if (window.rybbit) window.rybbit.event('Dedicated: Send request');
             this.showStatus("Thanks — we'll be in touch shortly.", true);
             this.form.reset();
             this.sizingOutput.textContent = this.sizingInput.defaultValue;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -4,6 +4,9 @@ declare module '@alpinejs/collapse';
 
 interface Window {
   Alpine: import('alpinejs').Alpine;
+  rybbit?: {
+    event: (name: string) => void;
+  };
 }
 
 declare namespace App {

--- a/src/pages/dedicated-cloud.astro
+++ b/src/pages/dedicated-cloud.astro
@@ -82,7 +82,11 @@ const jsonLd = {
           <p class="datum-text-lg text-app---dark---utility-3 max-w-2xl">{hero.description}</p>
         </div>
 
-        <a href={hero.ctaHref} class="btn btn--midnight-fjord btn--sm w-fit">
+        <a
+          href={hero.ctaHref}
+          class="btn btn--midnight-fjord btn--sm w-fit"
+          data-rybbit-event="Dedicated: Schedule a conversation"
+        >
           {hero.ctaText}
           <Icon name="calendar" size="sm" />
         </a>

--- a/src/static/styles/components-nav.css
+++ b/src/static/styles/components-nav.css
@@ -102,7 +102,7 @@
     }
   }
 
-  /* Desktop Actions: Sign in + Book a demo */
+  /* Desktop Actions: Sign in + Start for free */
   .nav-cta-signin {
     @apply border-silver-mist text-midnight-fjord datum-text-base flex h-full items-center justify-center gap-3 border-x px-4 whitespace-nowrap transition-colors duration-150;
     @apply hover:bg-glacier-mist-800 md:px-7;


### PR DESCRIPTION
Restore the nav primary CTA to "Start for free" with auth register link and Nav: Start for free Rybbit event. Add Dedicated page tracking for schedule a conversation and send request form submission.

Ref #1579