### PR TITLE
fix(cta): update Start for free links to auth signup URL

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -64,7 +64,7 @@ const [platformSection, resourcesSection, companySection] = navData.footer;
                 iconPosition="right"
                 iconClass="stroke-1.5"
                 target="_blank"
-                href="https://auth.datum.net/ui/v2/login/register"
+                href="https://auth.datum.net/id/signup"
                 data-rybbit-event="Pre-footer: Start for free"
               />
               <Button

--- a/src/components/MobileMenu.astro
+++ b/src/components/MobileMenu.astro
@@ -221,7 +221,7 @@ const mainNav = navData.main;
           <Icon name="log-in" size="sm" />
         </a>
         <a
-          href="https://auth.datum.net/ui/v2/login/register"
+          href="https://auth.datum.net/id/signup"
           class="mobile-cta-primary"
           target="_blank"
           data-rybbit-event="Nav: Start for free"

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -30,7 +30,7 @@ import NavMenu from '@components/NavMenu.astro';
       </a>
 
       <a
-        href="https://auth.datum.net/ui/v2/login/register"
+        href="https://auth.datum.net/id/signup"
         class="nav-cta-demo"
         target="_blank"
         data-rybbit-event="Nav: Start for free"

--- a/src/content/pricing/free.json
+++ b/src/content/pricing/free.json
@@ -10,7 +10,7 @@
   "cta": {
     "label": "Start for free",
     "class": "btn btn--pine-forge",
-    "href": "https://auth.datum.net/ui/v2/login/register",
+    "href": "https://auth.datum.net/id/signup",
     "isExternal": true,
     "rybbitEvent": "Pricing-Waitlist-Subscribe"
   },

--- a/src/data/dns.ts
+++ b/src/data/dns.ts
@@ -19,7 +19,7 @@ export const hero = {
   title: 'Authoritative DNS without the upsell',
   description:
     'Fast and resilient DNS that is easily managed via our portal or CLI. The first 500k requests each month are free.',
-  primaryCta: { text: 'Start for free', href: 'https://auth.datum.net/ui/v2/login/register' },
+  primaryCta: { text: 'Start for free', href: 'https://auth.datum.net/id/signup' },
   secondaryCta: {
     text: 'View documentation',
     href: 'https://www.datum.net/docs/domain-dns/dns',

--- a/src/data/navigation.json
+++ b/src/data/navigation.json
@@ -94,7 +94,7 @@
   "right": [
     {
       "text": "Request Access",
-      "href": "https://auth.datum.net/ui/v2/login/register",
+      "href": "https://auth.datum.net/id/signup",
       "isExternal": true
     }
   ],

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -244,7 +244,7 @@ Datum operates at major internet peering points (IXPs) globally. Region naming f
 
 ## How to Sign Up
 
-1. **Go to:** \`https://cloud.datum.net\` (or \`https://auth.datum.net/ui/v2/login/register\`)
+1. **Go to:** \`https://cloud.datum.net\` (or \`https://auth.datum.net/id/signup\`)
 2. **Authenticate** using Google or GitHub OAuth — no email/password registration
 3. **Your account** is automatically associated with the primary email on your OAuth account
 4. A **Personal Org** is created for you automatically as a sandbox

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -63,7 +63,7 @@ const jsonLd = {
             unitText: 'MONTH',
           },
           availability: 'https://schema.org/InStock',
-          url: 'https://auth.datum.net/ui/v2/login/register',
+          url: 'https://auth.datum.net/id/signup',
           seller: { '@id': 'https://www.datum.net/#organization' },
         },
         {


### PR DESCRIPTION
Point signup CTAs from /ui/v2/login/register to /id/signup across nav, footer, pricing, DNS, and llms docs.