### PR TITLE
fix: point liveness/readiness probes to /livez and /readyz

### DIFF
--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -61,7 +61,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 10
             httpGet:
-              path: /
+              path: /livez
               port: 4321
               scheme: HTTP
           readinessProbe:
@@ -70,7 +70,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 10
             httpGet:
-              path: /
+              path: /readyz
               port: 4321
               scheme: HTTP
       dnsPolicy: ClusterFirst


### PR DESCRIPTION
## Summary
- Update the deployment's liveness and readiness probes to hit `/livez` and `/readyz` instead of `/`, matching the dedicated health check endpoints served by `server.mjs` in production.

## Test plan
- [ ] Deploy and confirm pods pass liveness/readiness checks