### PR TITLE
fix(platform): restore hero title highlight and Deliver divider line

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -20,9 +20,34 @@ const {
   hideContent = false,
   hideHero = false,
   showSectionLines = false,
+  titleHighlightVariant,
+  titleHighlightWords = 1,
 } = Astro.props as HeroProps;
 
 const TitleTag = titleTag;
+
+const TITLE_HIGHLIGHT_CLASSES: Record<NonNullable<HeroProps['titleHighlightVariant']>, string> = {
+  pine: 'text-pine-forge',
+  canyon: 'text-canyon-clay---links',
+  connect: 'text-connect-slate',
+};
+
+function withTrailingHighlight(text: string, wordCount: number, className: string): string {
+  const words = text.trim().split(/\s+/);
+  if (wordCount < 1 || wordCount >= words.length) return text;
+
+  const lead = words.slice(0, -wordCount).join(' ');
+  const highlighted = words.slice(-wordCount).join(' ');
+  return `${lead} <span class="${className}">${highlighted}</span>`;
+}
+
+const renderedTitle = titleHighlightVariant
+  ? withTrailingHighlight(
+      title,
+      titleHighlightWords,
+      TITLE_HIGHLIGHT_CLASSES[titleHighlightVariant]
+    )
+  : title;
 ---
 
 <header class:list={['hero--main', className]}>
@@ -58,7 +83,7 @@ const TitleTag = titleTag;
                   {title && (
                     <TitleTag
                       class="hero--main-content-title"
-                      set:html={marked.parseInline(title)}
+                      set:html={marked.parseInline(renderedTitle)}
                     />
                   )}
                   {description && (

--- a/src/pages/platform/build.astro
+++ b/src/pages/platform/build.astro
@@ -54,6 +54,7 @@ const jsonLd = {
       title={title}
       description={fm.description}
       showSectionLines={true}
+      titleHighlightVariant="canyon"
     >
       <SecondaryTabNav
         slot="before-content"

--- a/src/pages/platform/connect.astro
+++ b/src/pages/platform/connect.astro
@@ -54,6 +54,7 @@ const jsonLd = {
       title={title}
       description={fm.description}
       showSectionLines={true}
+      titleHighlightVariant="connect"
     >
       <SecondaryTabNav
         slot="before-content"

--- a/src/pages/platform/deliver.astro
+++ b/src/pages/platform/deliver.astro
@@ -60,6 +60,7 @@ const jsonLd = {
       title={title}
       description={fm.description}
       showSectionLines={true}
+      titleHighlightVariant="pine"
     >
       <SecondaryTabNav
         slot="before-content"

--- a/src/pages/platform/deliver.astro
+++ b/src/pages/platform/deliver.astro
@@ -72,10 +72,8 @@ const jsonLd = {
 
     <section
       id="datum-platform"
-      class="section--block section--block--x-pad bg-platinum overflow-hidden"
-      data-module-wipe
+      class="section--block section--block--x-pad border-silver-mist bg-platinum overflow-hidden border-t"
     >
-      <span class="module-border-wipe" aria-hidden="true"></span>
       <FeatureSections label="Features">
         <FeatureSection
           id="dns"

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -53,6 +53,10 @@ export interface HeroProps {
   hideHero?: boolean;
   /** Renders decorative corner grid lines inside the hero container */
   showSectionLines?: boolean;
+  /** Colors the trailing word(s) of the title with a platform accent, so copy edits keep the highlight without hand-authored markup */
+  titleHighlightVariant?: 'pine' | 'canyon' | 'connect';
+  /** Number of trailing words to highlight when titleHighlightVariant is set (default 1) */
+  titleHighlightWords?: number;
 }
 
 export interface HomeHeroProps {


### PR DESCRIPTION
## Summary
- Restores the platform hero titles' colorful "punchline" treatment that PR #1577 lost when it rewrote the Deliver/Build/Connect titles as plain text (the old copy relied on a hand-authored `<span>` that got dropped). The highlight now derives from the title text itself via a `titleHighlightVariant` prop on `Hero.astro`, so it survives future copy edits without any markup.
- Fixes Deliver's hero-to-features divider line, which used a scroll-cued `data-module-wipe` animation meant to sync with a `ModuleConnector` bar that doesn't exist above that section on this page — it never showed until scrolling. Switched to the same static `border-t` used on Build, Connect, and Essentials.

## Test plan
- [x] Verified `/platform/deliver`, `/platform/build`, `/platform/connect` render the last word of the hero title in the correct accent color (pine/canyon/connect)
- [x] Verified the highlight is markup-independent by temporarily changing a title's text and confirming the new last word auto-colored
- [x] Verified `/platform/deliver`'s hero divider line now renders immediately, matching Build/Connect/Essentials
