### PR TITLE
fix(legal): correct terms/privacy inconsistencies and update privacy policy

### DIFF
--- a/src/content/legal/privacy.mdx
+++ b/src/content/legal/privacy.mdx
@@ -12,9 +12,16 @@ import Container from '@components/Container.astro';
 
 <Container tag="article" class="datum-prose-article max-w-4xl pb-1 flow-root *:first:mt-0">
 
-<small class="mb-8 block italic">Effective as of December 1, 2024</small>
+<small class="mb-8 block italic">Effective as of September 8, 2025</small>
 
-This Privacy Policy describes how Datum Technology, Inc. ("**Datum**," "**we**", "**us**" or "**our**") handles personal information that we collect through our website and other digital properties that link to this Privacy Policy (collectively, the "**Service**"), as well as through social media, our marketing activities, and other activities described in this Privacy Policy.
+This Privacy Policy describes how Datum Technology, Inc. ("**Datum**," "**we**", "**us**" or "**our**") handles personal information that we collect through our website and connectivity infrastructure platform that link to this Privacy Policy (collectively, the "**Service**"), as well as through social media, our marketing activities, and other activities described in this Privacy Policy.
+
+## **Our Commitments**
+
+- We do not sell your personal information to third parties
+- We do not use your data for advertising or marketing analytics beyond our own services
+- We process data only as necessary to provide our connectivity infrastructure services
+- We give you control over your information and are transparent about our practices
 
 ## **Personal information we collect**
 
@@ -22,6 +29,7 @@ This Privacy Policy describes how Datum Technology, Inc. ("**Datum**," "**we**",
 
 - **Contact data**, such as your first and last name, professional title, organizational affiliation, email address, and phone number.
 - **Profile data**, such as the username and password that you may set to establish an online account on the Service, and any other information that you add to your account profile.
+- **Network configuration data**, such as connectivity requirements, infrastructure details, and service configurations.
 - **User-generated content**, such as comments, questions, feedback, messages, images, photos, videos and other content or information that you submit to, or use with, the Services.
 - **Communications** that we exchange with you, including when you contact us through the Service, social media, or otherwise.
 - **Marketing data**, such as your preferences for receiving our marketing communications and details about your engagement with them.
@@ -34,12 +42,12 @@ This Privacy Policy describes how Datum Technology, Inc. ("**Datum**," "**we**",
 - **Marketing partners**, such as joint marketing partners and event co-sponsors.
 - **Third party services**, such as social media services, that you use to log into, or otherwise link to, your Service account. This data may include your username, profile picture and other information associated with your account on that third party service that is made available to us based on your account settings on that service.
 
-Automatic data collection. We, our service providers, and our business partners may automatically log information about you, your computer or mobile device, and your interaction over time with the Service, our communications and other online services, such as:
+**Automatic data collection.** We, our service providers, and our business partners may automatically log information about you, your computer or mobile device, and your interaction over time with the Service, our communications and other online services, such as:
 
 - **Device data**, such as your computer's or mobile device's operating system type and version, manufacturer and model, browser type, screen resolution, RAM and disk size, CPU usage, device type (e.g., phone, tablet), IP address, unique identifiers (including identifiers used for advertising purposes), language settings, and general location information such as city, state or geographic area.
 - **Online activity data**, such as pages you viewed, how long you spent on a page, the website you visited before browsing to the Service, navigation paths between pages, information about your activity on a page, access times and duration of access, and whether you have opened our emails or clicked links within them.
 
-Cookies and similar technologies. Some of the automatic collection described above is facilitated by the following technologies:
+**Cookies and similar technologies.** Some of the automatic collection described above is facilitated by the following technologies:
 
 - **Cookies**, which are small text files that websites store on user devices and that allow web servers to record users' web browsing activities and remember their submissions, preferences and login status as they navigate a site. Cookies used on our sites include both "session cookies" that are deleted when a session ends, "persistent cookies" that remain longer, "first party" cookies that we place and "third party" cookies that our third party business partners and service providers place.
 - **Web beacons**, also known as pixel tags or clear GIFs, which are clear images placed in web content or HTML emails to record when a user visits a web page or views an email.
@@ -59,7 +67,7 @@ We may use your personal information for the following purposes or as otherwise 
 
 **Service delivery.** We may use your personal information to:
 
-- provide, operate and improve the Service and our business;
+- provide, operate and improve our connectivity infrastructure platform and related services;
 - facilitate your invitations to friends who you want to invite to join the Service;
 - communicate with you about the Service, including by sending announcements, updates, security alerts, and support and administrative messages;
 - understand your needs and interests, and personalize your experience with the Service and our communications; and
@@ -67,7 +75,7 @@ We may use your personal information for the following purposes or as otherwise 
 
 **Research and development.** We may use your personal information for research and development purposes, including to analyze and improve the Service and our business. As part of these activities, we may create aggregated, de-identified or other anonymous data from personal information we collect. We make personal information into anonymous data by removing information that makes the data personally identifiable to you. We may use this anonymous data and share it with third parties for our lawful business purposes, including to analyze, improve and promote the Service and our business.
 
-**Marketing and advertising.** We may collect and use your personal information to send you direct marketing communications. You may opt-out of our marketing communications as described in the **Opt-out of marketing** section below.
+**Marketing and advertising.** We may collect and use your personal information to send you direct marketing communications about our connectivity infrastructure services. You may opt-out of our marketing communications as described in the **Opt-out of marketing** section below.
 
 **Compliance and protection.** We may use your personal information to:
 
@@ -91,9 +99,55 @@ We may share your personal information with the following parties and as otherwi
 
 **Authorities and others.** Law enforcement, government authorities, and private parties, as we believe in good faith to be necessary or appropriate for the **compliance and protection purposes** described above.
 
-**Business transferees.** Acquirers and other relevant participants in business transactions (or negotiations of or due diligence for such transactions) involving a corporate divestiture, merger, consolidation, acquisition, reorganization, sale or other disposition of all or any portion of the business or assets of, or equity interests in, Common Paper or our affiliates (including in connection with a bankruptcy or similar proceedings).
+**Business transferees.** Acquirers and other relevant participants in business transactions (or negotiations of or due diligence for such transactions) involving a corporate divestiture, merger, consolidation, acquisition, reorganization, sale or other disposition of all or any portion of the business or assets of, or equity interests in, Datum Technology, Inc. or our affiliates (including in connection with a bankruptcy or similar proceedings).
 
 **Other users and the public.** Your profile and other user-generated content may be visible to other users of the Service and the public. For example, if you post a comment or other content on the Service, it can be seen, collected and used by others, including being cached, copied, screen captured or stored elsewhere by others (e.g., search engines), and we are not responsible for any such use of this information.
+
+## **Data Retention**
+
+We retain your personal information for as long as necessary to provide our services and for the following periods:
+
+- **Active accounts:** Duration of your account plus 90 days for transition
+- **Financial records:** 7 years as required by law
+- **Marketing data:** Until you opt out plus 30 days for processing
+- **Security logs:** Up to 3 years for security monitoring
+- **Technical logs:** 12 months for service optimization
+- **Anonymized analytics:** Indefinitely in anonymized form
+
+## **International Data Transfer**
+
+We are headquartered in the United States and may transfer your personal information to the United States or other countries where privacy laws may not be as protective as those in your state, province, or country.
+
+For EU residents, we ensure adequate protection for international transfers through:
+
+- Standard Contractual Clauses approved by the European Commission
+- Adequacy decisions where available
+- Additional technical and organizational safeguards to protect transferred data
+
+## **Security**
+
+We implement comprehensive technical, administrative, and physical safeguards to protect your information, including:
+
+**Technical safeguards:**
+
+- Encryption of data in transit (TLS 1.3) and at rest (AES-256)
+- Multi-factor authentication for account access
+- Regular security assessments and penetration testing
+- Network security monitoring and intrusion detection
+
+**Administrative safeguards:**
+
+- Employee training on data protection practices
+- Limited access controls based on job responsibilities and need-to-know basis
+- Background checks for employees with data access
+- Incident response procedures and breach notification protocols
+
+**Physical safeguards:**
+
+- Secure data centers with physical access controls
+- Environmental monitoring and backup systems
+
+However, no method of transmission over the internet or electronic storage is 100% secure. In the event of a data breach, we will notify affected users and relevant authorities as required by applicable law.
 
 ## **Your choices**
 
@@ -105,17 +159,29 @@ We may share your personal information with the following parties and as otherwi
 
 **Linked third party platforms.** If you choose to connect to the Service through your social media account or other third party platform, you may be able to use your settings in your account with that platform to limit the information we receive from it. If you revoke our ability to access information from a third party platform, that choice will not apply to information that we have already received from that third party.
 
+## **European Union Residents (GDPR)**
+
+If you're located in the EU/EEA, you have additional rights under the General Data Protection Regulation (GDPR):
+
+**Your Rights:**
+
+- **Access:** Request information about the personal data we hold about you
+- **Correction:** Request correction of inaccurate or incomplete information
+- **Deletion:** Request deletion of your personal information (subject to legal limitations)
+- **Portability:** Request a copy of your data in a portable format
+- **Restriction:** Request limitation of processing in certain circumstances
+- **Objection:** Object to processing based on legitimate interests or for marketing purposes
+- **Withdraw consent:** Withdraw consent at any time without affecting prior lawful processing
+
+**Response Time:** We will respond to requests within 30 days (extendable to 90 days for complex requests with notification).
+
+**Supervisory Authority:** You have the right to lodge a complaint with your local supervisory authority if you believe your data protection rights have been violated.
+
+To exercise these rights, contact our Data Protection Officer at: [**dpo@datum.net**](mailto:dpo@datum.net)
+
 ## **Other sites and services**
 
 The Service may contain links to websites, mobile applications, and other online services operated by third parties. In addition, our content may be integrated into other online services that are not associated with us. These links and integrations are not an endorsement of, or representation that we are affiliated with, any third party. We do not control any online services operated by third parties, and we are not responsible for their actions. We encourage you to read the privacy policies of the other online services you use.
-
-## **Security**
-
-We employ a number of technical, organizational and physical safeguards designed to protect the personal information we collect. However, security risk is inherent in all internet and information technologies and we cannot guarantee the security of your personal information.
-
-## **International data transfer**
-
-We are headquartered in the United States and may use service providers that operate in the United States and other countries. Your personal information may be transferred to the United States or other locations where privacy laws may not be as protective as those in your state, province, or country.
 
 ## **Children**
 
@@ -123,11 +189,20 @@ The Service is not intended for use by anyone under 18 years of age. If you are 
 
 ## **Changes to this Privacy Policy**
 
-We reserve the right to modify this Privacy Policy at any time. If we make material changes to this Privacy Policy, we will notify you by updating the date of this Privacy Policy and posting it on the Service or other appropriate means. Any modifications to this Privacy Policy will be effective upon our posting the modified version (or as otherwise indicated at the time of posting). In all cases, your use of the Service after the effective date of any modified Privacy Policy indicates your acceptance of the modified Privacy Policy.
+We reserve the right to modify this Privacy Policy at any time. If we make material changes to this Privacy Policy, we will notify you by updating the date of this Privacy Policy and posting it on the Service or other appropriate means. For EU residents, we will provide at least 30 days' notice of material changes affecting your rights.
+
+Any modifications to this Privacy Policy will be effective upon our posting the modified version (or as otherwise indicated at the time of posting). In all cases, your use of the Service after the effective date of any modified Privacy Policy indicates your acceptance of the modified Privacy Policy.
 
 ## **How to contact us**
 
-**Email**: [**support@datum.net**](mailto:support@datum.net)
+**General inquiries:** Datum Technology, Inc.<br />
+29 Broadway, 31st Floor<br />
+New York, NY 10006<br />
+Email: [**support@datum.net**](mailto:support@datum.net)
+
+**Data Protection Officer:** Email: [**dpo@datum.net**](mailto:dpo@datum.net)
+
+For privacy-specific inquiries, please include "Privacy Policy" or "GDPR Request" in your subject line.
 
 ## **California privacy rights notice**
 
@@ -156,5 +231,3 @@ Your authorized agent may make a request on your behalf upon our verification of
 We do not sell your personal information and have not sold it during the 12 months preceding the effective date of this Privacy Policy.
 
 </Container>
-
-

--- a/src/content/legal/terms.mdx
+++ b/src/content/legal/terms.mdx
@@ -32,7 +32,7 @@ This Order Form incorporates and is governed by the Framework Terms that are mad
 
 **Order Date**: The Effective Date
 
-**Subscription Period**: 1 month(s) Certain parts of the Product have different pricing plans, which are available at Provider's [pricing page](/pricing). Customer will pay Provider the applicable Fees based on the Product tier and Customer's usage. Provider may update Product pricing by giving at least 30 days notice to Customer (including by email or notification within the Product), and the change will apply in the next Subscription Period.
+**Subscription Period**: 1 month(s). Certain parts of the Product have different pricing plans, which are available at Provider's [pricing page](/pricing). Customer will pay Provider the applicable Fees based on the Product tier and Customer's usage. Provider may update Product pricing by giving at least 30 days notice to Customer (including by email or notification within the Product), and the change will apply in the next Subscription Period.
 
 **Payment Process**: Automatic payment: Customer authorizes Provider to bill and charge Customer's payment method on file Monthly for immediate payment or deduction without further approval.
 
@@ -56,7 +56,7 @@ This Order Form incorporates and is governed by the Framework Terms that are mad
 
 **Customer Covered Claims**: Any action, proceeding, or claim that (1) the Customer Content, when used according to the terms of the Agreement, violates, misappropriates, or otherwise infringes upon anyone else's intellectual property or other proprietary rights; or (2) results from Customer's breach or alleged breach of Section 2.1 (Restrictions on Customer).
 
-**General Cap Amount**: The fees paid or payable by Customer to provider in the 12 month period immediately before the claim
+**General Cap Amount**: The fees paid or payable by Customer to Provider in the 12 month period immediately before the claim.
 
 **Notice Address**:
 


### PR DESCRIPTION
## Summary
- Fix inconsistent provider/Provider capitalization and a run-on sentence (missing punctuation after "month(s)") in terms.mdx
- Fix a leftover template reference to "Common Paper" (should be Datum) in the privacy.mdx business transferees clause
- Update privacy.mdx content to match the latest reviewed draft: new Our Commitments, Data Retention, and GDPR sections; expanded Security and International Data Transfer safeguards; added mailing address and DPO contact; bumped effective date to September 8, 2025

## Notes
- Kept "Rybbit" as the named analytics tool in privacy.mdx (not "Fathom" as in the reviewed draft) since that's what's actually integrated in `Layout.astro`
- The mailing address, DPO email, and data retention periods are taken directly from the reviewed draft doc — please have legal/ops confirm these are accurate before merging

## Test plan
- [ ] Confirm `/legal/terms` renders correctly and reads cleanly
- [ ] Confirm `/legal/privacy` renders correctly, including new sections (Our Commitments, Data Retention, GDPR, expanded Security/International Data Transfer, updated contact info)
- [ ] Legal/ops sign-off on the new privacy policy facts (address, DPO contact, retention periods, GDPR commitments)
