### PR TITLE
fix(compute): keep hero headline on one line across breakpoints

### DIFF
--- a/src/components/compute/Hero.astro
+++ b/src/components/compute/Hero.astro
@@ -15,6 +15,10 @@ import Breadcrumbs from '@components/Breadcrumbs.astro';
 import gridTexture from '@assets/images/compute-hero-grid.png';
 import { breadcrumbs, hero } from '@data/compute';
 
+const longestHeadlinePhrase = hero.titlePhrases.reduce((longest, phrase) =>
+  phrase.length > longest.length ? phrase : longest
+);
+
 // Cycles the clay-coloured fragment of the headline. Figma annotation on node
 // 15991:8580 is the source of the phrase list.
 const headlineCycler = `{
@@ -59,15 +63,25 @@ const headlineCycler = `{
           }
           <h1
             id="compute-hero-title"
-            class="datum-text-9xl text-midnight-fjord max-w-full text-pretty"
+            class="compute-hero-title datum-text-9xl text-midnight-fjord max-w-full"
             x-data={headlineCycler}
           >
-            {hero.titleLead}
-            <span
-              class="compute-headline-phrase"
-              x-text="phrases[index]"
-              :class="{ 'is-out': !visible }">{hero.titlePhrases[0]}</span
-            ><br />
+            <span class="compute-headline-lead">
+              {hero.titleLead}{' '}
+              <span class="compute-headline-phrase-slot">
+                <span
+                  class="compute-headline-phrase compute-headline-phrase--sizer"
+                  aria-hidden="true"
+                >
+                  {longestHeadlinePhrase}
+                </span>
+                <span
+                  class="compute-headline-phrase"
+                  x-text="phrases[index]"
+                  :class="{ 'is-out': !visible }">{hero.titlePhrases[0]}</span
+                >
+              </span>
+            </span>
             {hero.titleTail}
           </h1>
           <p class="datum-text-xl text-midnight-fjord/80 text-pretty">{hero.description}</p>

--- a/src/static/styles/components-compute.css
+++ b/src/static/styles/components-compute.css
@@ -71,26 +71,40 @@
     container-type: inline-size;
   }
 
+  /* Scale the headline down in narrow copy columns so "Build {phrase}" stays on
+     one line without clipping. ID beats the datum-text-9xl utility in the cascade. */
+  #compute-hero-title {
+    font-size: clamp(var(--32px), 9.5cqi, var(--text-9xl-canela-font-size));
+    line-height: clamp(var(--38px), 11.5cqi, var(--text-9xl-canela-line-height));
+  }
+
+  /* First headline row — "Build" plus the cycling phrase. */
+  .compute-headline-lead {
+    @apply block whitespace-nowrap;
+  }
+
+  /* Grid stack reserves the widest phrase width so cycling never shifts line two. */
+  .compute-headline-phrase-slot {
+    @apply inline-grid align-bottom;
+  }
+
+  .compute-headline-phrase-slot > .compute-headline-phrase {
+    grid-area: 1 / 1;
+  }
+
+  .compute-headline-phrase--sizer {
+    @apply pointer-events-none invisible;
+  }
+
   /* Cycling fragment of the hero headline — Figma annotation on node 15991:8580.
      Only this span animates. */
   .compute-headline-phrase {
-    @apply text-canyon-clay---links inline-block;
+    @apply text-canyon-clay---links inline-block whitespace-nowrap;
     @apply transition-[opacity,transform] duration-300 ease-out;
 
     &.is-out {
       @apply opacity-0;
       transform: translateY(-0.15em);
-    }
-  }
-
-  /* Hold each phrase on one line — but only while the column can actually take
-     it. The widest phrase measures 490px at the 54px headline size, and the
-     copy column is ~326px on a phone, so an unconditional `nowrap` overflows
-     and gets silently clipped by the section. Keyed to the column rather than
-     the viewport because the two-column layout narrows the column again at lg. */
-  @container (min-width: 500px) {
-    .compute-headline-phrase {
-      @apply whitespace-nowrap;
     }
   }
 

--- a/tests/e2e/platform-compute.spec.ts
+++ b/tests/e2e/platform-compute.spec.ts
@@ -48,7 +48,9 @@ test.describe('Compute product page', () => {
     await page.goto(PATH);
     await page.evaluate(() => document.fonts.ready);
 
-    const phrase = page.locator('.compute-headline-phrase');
+    const phrase = page.locator(
+      '.compute-headline-phrase-slot > .compute-headline-phrase:not(.compute-headline-phrase--sizer)'
+    );
     const first = await phrase.innerText();
 
     // A phrase must never break mid-way, so it always occupies one line box.


### PR DESCRIPTION
Reserve width for the longest cycling phrase and scale the headline with container units so "Build {phrase}" never wraps or shifts the second line.