### PR TITLE
feat(roadmap): auto-refresh roadmap cache via GitHub milestone webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ GITHUB_PROJECT_URL='http://github.com/datum-cloud/datum.net'
 APP_ID=
 APP_INSTALLATION_ID=
 APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nYOUR_PRIVATE_KEY_HERE\n-----END RSA PRIVATE KEY-----"
+# Secret configured on the datum-cloud/enhancements repo webhook (milestone events)
+GITHUB_WEBHOOK_SECRET=your-shared-secret
 
 MODE=development
 

--- a/src/libs/githubRoadmap.ts
+++ b/src/libs/githubRoadmap.ts
@@ -7,7 +7,9 @@
  * separately from static repo assets (see `getRoadmapCoverImage`).
  *
  * Cache strategy:
- *  - Redis (when REDIS_URL is set): key `${redisKeyPrefix}github:roadmaps`, TTL 30 min
+ *  - Redis (when REDIS_URL is set): key `${redisKeyPrefix}github:roadmaps`, TTL 1 day
+ *    (the github-milestone webhook invalidates this actively on status changes;
+ *    the TTL is just a fallback)
  *  - In-memory Map: fallback for local dev (single-instance, no persistence)
  *
  * Auth: uses existing APP_ID / APP_PRIVATE_KEY / APP_INSTALLATION_ID env vars
@@ -29,7 +31,10 @@ export interface RoadmapMilestone {
 
 const GITHUB_ORG = 'datum-cloud';
 const GITHUB_REPO = 'enhancements';
-const CACHE_TTL_SECONDS = 30 * 60; // 30 minutes
+// The github-milestone webhook actively invalidates this cache on status
+// changes, so the TTL is just a fallback safety net rather than the primary
+// refresh mechanism.
+const CACHE_TTL_SECONDS = 24 * 60 * 60; // 1 day
 
 const REDIS_CACHE_KEY = `${redisKeyPrefix}github:roadmaps`;
 

--- a/src/libs/githubWebhookAuth.ts
+++ b/src/libs/githubWebhookAuth.ts
@@ -1,0 +1,27 @@
+// src/libs/githubWebhookAuth.ts
+
+import crypto from 'node:crypto';
+
+/**
+ * Verifies the `X-Hub-Signature-256` header GitHub sends on webhook deliveries.
+ * GitHub signs the raw request body with HMAC-SHA256 using the configured
+ * webhook secret — unlike the plain shared-secret check in `cacheApiAuth.ts`,
+ * so it needs its own verifier.
+ */
+export function verifyGitHubWebhookSignature(request: Request, rawBody: string): boolean {
+  const webhookSecret = process.env.GITHUB_WEBHOOK_SECRET;
+  if (!webhookSecret) return false;
+
+  const signatureHeader = request.headers.get('X-Hub-Signature-256');
+  if (!signatureHeader) return false;
+
+  const expectedSignature =
+    'sha256=' + crypto.createHmac('sha256', webhookSecret).update(rawBody).digest('hex');
+
+  const expected = Buffer.from(expectedSignature);
+  const received = Buffer.from(signatureHeader);
+
+  if (expected.length !== received.length) return false;
+
+  return crypto.timingSafeEqual(expected, received);
+}

--- a/src/pages/api/webhooks/github-milestone.ts
+++ b/src/pages/api/webhooks/github-milestone.ts
@@ -1,0 +1,94 @@
+// src/pages/api/webhooks/github-milestone.ts
+/**
+ * GitHub → datum.net webhook endpoint.
+ *
+ * Listens for `milestone` events on datum-cloud/enhancements (configured as a
+ * repo webhook there) and force-regenerates the roadmap cache so status
+ * changes (e.g. closing a milestone) show up on /roadmap and /roadmap.md
+ * without waiting for the 30-min TTL.
+ */
+
+export const prerender = false;
+
+import type { APIRoute } from 'astro';
+import { verifyGitHubWebhookSignature } from '@libs/githubWebhookAuth';
+import { forceRegenerateGitHubRoadmaps } from '@libs/githubRoadmap';
+
+const EXPECTED_REPO = 'datum-cloud/enhancements';
+
+/** Milestone actions that change what's shown on the roadmap. */
+const RELEVANT_ACTIONS = new Set(['created', 'closed', 'opened', 'edited', 'deleted']);
+
+interface MilestoneWebhookPayload {
+  action?: string;
+  repository?: { full_name?: string };
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  // Fail closed: reject if the secret isn't configured, rather than silently
+  // skipping verification and leaving this cache-purge endpoint open.
+  if (!process.env.GITHUB_WEBHOOK_SECRET) {
+    console.error('[github-webhook] GITHUB_WEBHOOK_SECRET is not configured — rejecting request');
+    return new Response(JSON.stringify({ ok: false, error: 'Webhook secret not configured' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const rawBody = await request.text();
+
+  if (!verifyGitHubWebhookSignature(request, rawBody)) {
+    return new Response(JSON.stringify({ ok: false, error: 'Invalid signature' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (request.headers.get('X-GitHub-Event') !== 'milestone') {
+    return new Response(JSON.stringify({ ok: true, skipped: 'not a milestone event' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let payload: MilestoneWebhookPayload;
+  try {
+    payload = JSON.parse(rawBody) as MilestoneWebhookPayload;
+  } catch {
+    return new Response(JSON.stringify({ ok: false, error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (payload.repository?.full_name !== EXPECTED_REPO) {
+    return new Response(JSON.stringify({ ok: true, skipped: 'unexpected repository' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!payload.action || !RELEVANT_ACTIONS.has(payload.action)) {
+    return new Response(
+      JSON.stringify({ ok: true, skipped: `ignored action "${payload.action}"` }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  }
+
+  try {
+    const items = await forceRegenerateGitHubRoadmaps();
+    return new Response(JSON.stringify({ ok: true, regenerated: items.length }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('[github-webhook] Failed to regenerate roadmap cache:', err);
+    return new Response(JSON.stringify({ ok: false, error: 'Internal server error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- Add `POST /api/webhooks/github-milestone`, a webhook endpoint that listens for `milestone` events on `datum-cloud/enhancements` and calls `forceRegenerateGitHubRoadmaps()` so the roadmap cache refreshes immediately on milestone status changes, instead of waiting for the 30-min TTL.
- Signature verification via HMAC-SHA256 (`X-Hub-Signature-256`), the mechanism GitHub actually uses for webhook deliveries — separate from the existing shared-secret check used by `/api/cache/strapi`.
- Guards: rejects if `GITHUB_WEBHOOK_SECRET` isn't configured (fail closed), verifies event type, repo (`datum-cloud/enhancements`), and only regenerates for actions that affect roadmap output (`created`, `closed`, `opened`, `edited`, `deleted`).
- Adds `GITHUB_WEBHOOK_SECRET` to `.env.example`.

## Setup required (not part of this PR)
- Configure a webhook on `datum-cloud/enhancements`: Payload URL `https://<host>/api/webhooks/github-milestone`, content type `application/json`, secret = `GITHUB_WEBHOOK_SECRET` value, events: **Milestones** only.
- Set `GITHUB_WEBHOOK_SECRET` in the deployment environment.

## Test plan
- [ ] Configure webhook in a staging/test repo and verify delivery hits the endpoint with a 200
- [ ] Confirm invalid/missing signature returns 401
- [ ] Confirm missing `GITHUB_WEBHOOK_SECRET` returns 503
- [ ] Close a milestone on `datum-cloud/enhancements` and verify `/roadmap` and `/roadmap.md` reflect the change immediately (no 30-min wait)