### PR TITLE
chore: reuse STRAPI_WEBHOOK_SECRET for GitHub milestone webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,6 @@ GITHUB_PROJECT_URL='http://github.com/datum-cloud/datum.net'
 APP_ID=
 APP_INSTALLATION_ID=
 APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nYOUR_PRIVATE_KEY_HERE\n-----END RSA PRIVATE KEY-----"
-# Secret configured on the datum-cloud/enhancements repo webhook (milestone events)
-GITHUB_WEBHOOK_SECRET=your-shared-secret
 
 MODE=development
 
@@ -25,6 +23,7 @@ K8S_NAMESPACE=milo-system
 LUMA_API_KEY=""
 
 STRAPI_TOKEN=your-api-token
+# Also used to verify the GitHub milestone webhook (datum-cloud/enhancements)
 STRAPI_WEBHOOK_SECRET=your-shared-secret
 STRAPI_URL=https://your-project.strapiapp.com
 # Primary cache TTL in seconds (default 2592000 = 30 days)

--- a/src/libs/githubWebhookAuth.ts
+++ b/src/libs/githubWebhookAuth.ts
@@ -9,7 +9,7 @@ import crypto from 'node:crypto';
  * so it needs its own verifier.
  */
 export function verifyGitHubWebhookSignature(request: Request, rawBody: string): boolean {
-  const webhookSecret = process.env.GITHUB_WEBHOOK_SECRET;
+  const webhookSecret = process.env.STRAPI_WEBHOOK_SECRET;
   if (!webhookSecret) return false;
 
   const signatureHeader = request.headers.get('X-Hub-Signature-256');

--- a/src/pages/api/webhooks/github-milestone.ts
+++ b/src/pages/api/webhooks/github-milestone.ts
@@ -27,8 +27,8 @@ interface MilestoneWebhookPayload {
 export const POST: APIRoute = async ({ request }) => {
   // Fail closed: reject if the secret isn't configured, rather than silently
   // skipping verification and leaving this cache-purge endpoint open.
-  if (!process.env.GITHUB_WEBHOOK_SECRET) {
-    console.error('[github-webhook] GITHUB_WEBHOOK_SECRET is not configured — rejecting request');
+  if (!process.env.STRAPI_WEBHOOK_SECRET) {
+    console.error('[github-webhook] STRAPI_WEBHOOK_SECRET is not configured — rejecting request');
     return new Response(JSON.stringify({ ok: false, error: 'Webhook secret not configured' }), {
       status: 503,
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Replace `GITHUB_WEBHOOK_SECRET` with `STRAPI_WEBHOOK_SECRET` in the GitHub milestone webhook verifier and endpoint, so a single shared secret covers both the Strapi content webhook and the GitHub milestone webhook.
- Remove `GITHUB_WEBHOOK_SECRET` from `.env.example` and note the dual purpose of `STRAPI_WEBHOOK_SECRET`.

## Test plan
- [ ] Set `STRAPI_WEBHOOK_SECRET` to the same value configured on the datum-cloud/enhancements GitHub webhook and verify signature validation still passes on a milestone event delivery.
- [ ] Confirm the Strapi content webhook still authenticates correctly with the same secret.