### PR TITLE
feat(scripts): add single-person Strapi headshot upload script

### DIFF
--- a/scripts/add-team-avatar.mjs
+++ b/scripts/add-team-avatar.mjs
@@ -1,0 +1,116 @@
+// Uploads a single team member's headshot to Strapi and links it to their
+// `avatar` field. Use this for onboarding a new hire's avatar, or replacing
+// one person's headshot without touching anyone else.
+//
+// Prerequisites:
+//   1. The person must already exist as an Author entry in Strapi
+//      (Content Manager -> Author -> create, isTeam: true) — this script
+//      does not create people, only avatars.
+//   2. You have their 3 pre-rendered variants (<slug>-canyon-clay.png,
+//      <slug>-glacier-mist.png, <slug>-pine-forge.png), transparent bg,
+//      2100x2100 — generated externally, not by this script.
+//
+// The upload-time ref/refId/field auto-link 500s on this Strapi instance,
+// so this does the proven two-step dance instead: upload with
+// fileInfo.folder, then PUT /api/authors/:documentId to set the relation.
+// The old avatar stays valid until the PUT succeeds — no blank-avatar gap.
+//
+// Usage:
+//   STRAPI_TOKEN=... npx tsx scripts/add-team-avatar.mjs <slug> <color> <path-to-png>
+//   npx tsx scripts/add-team-avatar.mjs jon-wick canyon-clay ~/Downloads/jon-wick-canyon-clay.png
+//
+// Pass --confirm to actually write; omit it to dry-run (looks up the
+// person, validates the file, makes zero Strapi writes).
+
+import { getStrapiTeamMembers } from '../src/libs/strapi/authors.ts';
+import fs from 'node:fs';
+
+const STRAPI_URL = process.env.STRAPI_URL || 'https://grateful-excitement-dfe9d47bad.strapiapp.com';
+const STRAPI_TOKEN = process.env.STRAPI_TOKEN;
+const FOLDER_ID = 2; // "Team Headshots" folder in Strapi Media Library
+const VALID_COLORS = ['canyon-clay', 'glacier-mist', 'pine-forge'];
+
+const [, , slug, color, filePath, ...rest] = process.argv;
+const LIVE = rest.includes('--confirm');
+
+async function main() {
+  if (!slug || !color || !filePath) {
+    console.error('Usage: npx tsx scripts/add-team-avatar.mjs <slug> <color> <path-to-png> [--confirm]');
+    process.exit(1);
+  }
+  if (!VALID_COLORS.includes(color)) {
+    console.error(`Color must be one of: ${VALID_COLORS.join(', ')}`);
+    process.exit(1);
+  }
+  if (!STRAPI_TOKEN) {
+    console.error('STRAPI_TOKEN not set in env — aborting.');
+    process.exit(1);
+  }
+  if (!fs.existsSync(filePath)) {
+    console.error(`File not found: ${filePath}`);
+    process.exit(1);
+  }
+
+  const members = await getStrapiTeamMembers();
+  const person = members.find((m) => m.slug === slug);
+  if (!person) {
+    console.error(
+      `No team member with slug "${slug}" found. Create their Author entry in Strapi first (isTeam: true), then re-run.`
+    );
+    process.exit(1);
+  }
+
+  console.log(`Found ${person.name} (documentId=${person.documentId})`);
+  console.log(`Current avatar: ${person.avatar?.url ?? '(none)'}`);
+  console.log(`New file: ${filePath} (${color})`);
+
+  if (!LIVE) {
+    console.log('\nDRY RUN — no Strapi writes performed. Re-run with --confirm to execute.');
+    return;
+  }
+
+  const form = new FormData();
+  const fileBuffer = fs.readFileSync(filePath);
+  const blob = new Blob([fileBuffer], { type: 'image/png' });
+  form.append('files', blob, `${slug}-${color}.png`);
+  form.append('fileInfo', JSON.stringify({ folder: FOLDER_ID }));
+
+  const uploadRes = await fetch(`${STRAPI_URL}/api/upload`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${STRAPI_TOKEN}` },
+    body: form,
+  });
+  if (!uploadRes.ok) {
+    console.error(`Upload failed: ${uploadRes.status} ${await uploadRes.text()}`);
+    process.exit(1);
+  }
+  const uploaded = await uploadRes.json();
+  const fileId = uploaded?.[0]?.id;
+  console.log(`Uploaded -> file id=${fileId}`);
+
+  const relinkRes = await fetch(`${STRAPI_URL}/api/authors/${person.documentId}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${STRAPI_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ data: { avatar: fileId } }),
+  });
+  if (!relinkRes.ok) {
+    console.error(
+      `Relink failed: ${relinkRes.status} ${await relinkRes.text()} (uploaded orphan file id=${fileId} — safe to delete manually)`
+    );
+    process.exit(1);
+  }
+
+  console.log(`Done — ${person.name}'s avatar now points to file id=${fileId}.`);
+  console.log(
+    'Local dev: clear .cache/strapi-authors* and .cache/strapi-team-members* to see the change on localhost.'
+  );
+  console.log('Production: Strapi\'s own webhook auto-invalidates the site cache on this content update.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds `scripts/add-team-avatar.mjs`, a reusable script for uploading a single team member's headshot to Strapi and linking it to their author record — for onboarding new hires or replacing one person's avatar without touching anyone else.

This is a follow-up to a live content fix (not in this repo — done directly against production Strapi): all 25 current team members' headshots were replaced with the 3-color illustrated variant set (`canyon-clay` / `glacier-mist` / `pine-forge`), matching each person's existing background-color cycle from `getTeamBgColor(index)`. That work is already live; this PR just captures the reusable tooling that came out of it so future onboarding doesn't require re-deriving the upload flow from scratch.

## Why the two-step upload

Strapi's upload-time `ref`/`refId`/`field` auto-link (attach a file to an entry's relation in the same request as the upload) returns a `500` on this Strapi Cloud instance regardless of payload — confirmed via a differential test (bad token → clean `401`; valid token with the auto-link params, with or without a file → `500`). The script instead does the well-supported two-step version:

1. `POST /api/upload` with `fileInfo.folder` to land the file in the "Team Headshots" media folder
2. `PUT /api/authors/:documentId` to set `avatar` to the new file's id

The old avatar stays linked and valid until step 2 succeeds, so there's no blank-avatar window even though it's two requests.

## Usage

```bash
# dry run — resolves the person via getStrapiTeamMembers(), validates the file, writes nothing
npx tsx scripts/add-team-avatar.mjs jon-wick canyon-clay ~/Downloads/jon-wick-canyon-clay.png

# writes for real
npx tsx scripts/add-team-avatar.mjs jon-wick canyon-clay ~/Downloads/jon-wick-canyon-clay.png --confirm
```

Prerequisite: the person must already exist as an Author entry in Strapi (`isTeam: true`) — this script only attaches an avatar, it doesn't create people.

## Test plan

- [x] Dry run against a nonexistent file → fails with a clear "File not found" error, no writes
- [x] Dry run against a nonexistent slug → fails with a clear "no team member found" error, no writes
- [x] Dry run against a real person (`felix-widjaja`) → correctly resolves name, documentId, and current avatar URL, makes zero write calls
- [x] The underlying two-step upload+relink flow was validated live against production for all 25 current team members before this script was written
