### PR TITLE
feat(legal): collapsible On This Page TOC, wider column spacing

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -7,26 +7,98 @@ const {
   class: className,
   showTitle = true,
   sticky = true,
+  collapsible = false,
 } = Astro.props;
 
 // Filter headings if needed (e.g., only show h2 and h3)
 const filteredHeadings = headings.filter((heading: MarkdownHeading) => heading.depth <= 3);
+
+// When collapsible, group h3s under their preceding h2 so long docs can hide
+// sub-sections behind a toggle instead of listing every heading at once.
+interface TocGroup {
+  heading: MarkdownHeading;
+  children: MarkdownHeading[];
+}
+
+const groups: TocGroup[] = [];
+if (collapsible) {
+  for (const heading of filteredHeadings) {
+    if (heading.depth === 2 || groups.length === 0) {
+      groups.push({ heading, children: [] });
+    } else {
+      groups[groups.length - 1].children.push(heading);
+    }
+  }
+}
 ---
 
 {
   filteredHeadings.length > 0 && (
     <aside class={`toc-container ${className || ''} ${sticky ? 'sticky top-0' : ''}`}>
       {showTitle && <h3 class="toc-title">{title}</h3>}
-      <nav class={`toc-nav`}>
-        <ul class="toc-list">
-          {filteredHeadings.map((heading: MarkdownHeading) => (
-            <li class={`toc-item toc-item--level-${heading.depth}`}>
-              <a href={`#${heading.slug}`} class="toc-link" data-toc-level={heading.depth}>
-                {heading.text}
-              </a>
-            </li>
-          ))}
-        </ul>
+      <nav class="toc-nav">
+        {collapsible ? (
+          <ul class="toc-list">
+            {groups.map((group, index) => (
+              <li
+                class:list={['toc-group', { 'is-open': index === 0 }]}
+                data-toc-group={group.heading.slug}
+              >
+                <div class="toc-group-header">
+                  <a href={`#${group.heading.slug}`} class="toc-link" data-toc-level={2}>
+                    {group.heading.text}
+                  </a>
+                  {group.children.length > 0 && (
+                    <button
+                      type="button"
+                      class="toc-group-toggle"
+                      aria-expanded={index === 0 ? 'true' : 'false'}
+                      aria-label={`Toggle ${group.heading.text} sub-sections`}
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        class="toc-group-chevron"
+                        aria-hidden="true"
+                      >
+                        <path d="m9 18 6-6-6-6" />
+                      </svg>
+                    </button>
+                  )}
+                </div>
+
+                {group.children.length > 0 && (
+                  <ul class="toc-sublist">
+                    {group.children.map((child) => (
+                      <li class="toc-item toc-item--level-3">
+                        <a href={`#${child.slug}`} class="toc-link" data-toc-level={3}>
+                          {child.text}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <ul class="toc-list">
+            {filteredHeadings.map((heading: MarkdownHeading) => (
+              <li class={`toc-item toc-item--level-${heading.depth}`}>
+                <a href={`#${heading.slug}`} class="toc-link" data-toc-level={heading.depth}>
+                  {heading.text}
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
       </nav>
     </aside>
   )
@@ -37,12 +109,39 @@ const filteredHeadings = headings.filter((heading: MarkdownHeading) => heading.d
     const tocLinks = document.querySelectorAll<HTMLAnchorElement>('.toc-link');
     if (tocLinks.length === 0) return;
 
+    const groupEls = document.querySelectorAll<HTMLElement>('.toc-group');
+
+    function setGroupOpen(groupEl: HTMLElement, open: boolean) {
+      groupEl.classList.toggle('is-open', open);
+      groupEl.querySelector('.toc-group-toggle')?.setAttribute('aria-expanded', String(open));
+    }
+
+    // Expand the group containing the active heading (as top-level or child),
+    // collapse the rest — keeps only the relevant sub-sections visible.
+    function openGroupForSlug(slug: string | null) {
+      if (groupEls.length === 0) return;
+      groupEls.forEach((groupEl) => {
+        const isOwnHeading = !!slug && groupEl.getAttribute('data-toc-group') === slug;
+        const hasActiveChild = !!slug && !!groupEl.querySelector(`.toc-sublist a[href="#${slug}"]`);
+        setGroupOpen(groupEl, isOwnHeading || hasActiveChild);
+      });
+    }
+
     function setActiveLink(slug: string | null) {
       tocLinks.forEach((link) => {
         const href = link.getAttribute('href');
         link.classList.toggle('active', !!slug && href === `#${slug}`);
       });
+      openGroupForSlug(slug);
     }
+
+    // Manual expand/collapse via the chevron button, independent of scroll
+    groupEls.forEach((groupEl) => {
+      const toggle = groupEl.querySelector<HTMLButtonElement>('.toc-group-toggle');
+      toggle?.addEventListener('click', () => {
+        setGroupOpen(groupEl, !groupEl.classList.contains('is-open'));
+      });
+    });
 
     // Collect all heading elements referenced by TOC links
     const headingElements: HTMLElement[] = [];
@@ -87,7 +186,7 @@ const filteredHeadings = headings.filter((heading: MarkdownHeading) => heading.d
       if (hash) setActiveLink(hash);
     });
 
-    // Seed from current hash on load
+    // Seed from current hash on load (the first group is already open by default)
     const initialHash = window.location.hash.slice(1);
     if (initialHash) setActiveLink(initialHash);
   });

--- a/src/pages/legal/[slug].astro
+++ b/src/pages/legal/[slug].astro
@@ -69,6 +69,7 @@ const navItems: LegalNavItem[] = sortedLegal.map((entry) => ({
               title="On This Page"
               showTitle={true}
               sticky={true}
+              collapsible={true}
             />
           </aside>
         </div>

--- a/src/static/styles/components.css
+++ b/src/static/styles/components.css
@@ -706,6 +706,41 @@
     left: calc(-1rem - 1px);
   }
 
+  /* Collapsible TOC groups (opt-in via the `collapsible` prop) — an h2 with its
+     h3 sub-headings collapsed behind a toggle instead of always listed out. */
+  .toc-group {
+    @apply datum-text-sm text-midnight-fjord/60 relative list-none;
+  }
+
+  .toc-group-header {
+    @apply relative flex w-full items-start justify-between gap-2;
+  }
+
+  .toc-group-header:has(.toc-link.active)::before {
+    @apply bg-blush-quartz absolute top-1/2 h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full content-[''];
+    left: calc(-1rem - 1px);
+  }
+
+  .toc-group-toggle {
+    @apply text-midnight-fjord/40 hover:text-midnight-fjord mt-0.5 flex shrink-0 items-center justify-center rounded p-0.5 transition-colors duration-150;
+  }
+
+  .toc-group-chevron {
+    @apply h-3.5 w-3.5 transition-transform duration-200 ease-out;
+  }
+
+  .toc-group.is-open .toc-group-chevron {
+    @apply rotate-90;
+  }
+
+  .toc-sublist {
+    @apply flex max-h-0 flex-col gap-2 overflow-hidden pt-2 transition-[max-height] duration-300 ease-in-out;
+  }
+
+  .toc-group.is-open .toc-sublist {
+    @apply max-h-[600px];
+  }
+
   /* figure */
   figure {
     .figure-image-wrapper {

--- a/src/static/styles/page-legal.css
+++ b/src/static/styles/page-legal.css
@@ -68,11 +68,21 @@
   }
 
   .legal-toc .toc-container {
-    @apply top-9! max-h-[calc(100vh-5rem)] overflow-y-auto;
+    /* pl-2 keeps the active-dot indicator (which intentionally bleeds left onto
+       the dashed guide line) inside the padding box — overflow-y: auto forces
+       overflow-x to clip too, and without this the dot gets cut off. */
+    @apply top-9! max-h-[calc(100vh-5rem)] overflow-y-auto pl-2;
+  }
+
+  /* Sub-headings read smaller than their parent section, and the smaller
+     line-height widens the gap between separate items relative to a
+     wrapped line within one item. */
+  .legal-toc .toc-item--level-3 {
+    @apply datum-text-xs;
   }
 
   .legal-content {
-    @apply flex-1 px-0 pt-9 pb-0 md:pt-12 lg:pt-16;
+    @apply flex-1 px-0 pt-9 pb-0 md:px-10 md:pt-12 lg:px-16 lg:pt-16;
 
     table {
       @apply my-6 w-full border-separate;


### PR DESCRIPTION
## Summary

Follow-up to #1621 — makes the `/legal/*` "On This Page" TOC collapsible for long docs, and fixes the column spacing plus a few regressions found while testing it live.

## Changes

- **Collapsible TOC** — added an opt-in `collapsible` prop to `TableOfContents.astro`. H3 sub-headings are grouped under their parent H2 behind a chevron toggle instead of always being listed out. The group containing the currently active heading auto-expands on scroll (via the existing `IntersectionObserver`) and the rest collapse; the chevron also lets you manually peek at another group. The handbook's usage is untouched (`collapsible` defaults to `false`).
- **Column spacing** — `.legal-content` had `px-0`, which read as squished against both the sidenav and the TOC. Gave it `md:px-10 lg:px-16`, the same values `.handbook-content` already uses.
- **Font-size regression fix** — the new H2 group wrapper (`.toc-group`) had dropped the `datum-text-sm` sizing that `.toc-item` used to provide via inheritance, so grouped H2 entries were rendering at an unstyled, larger size than the H3 sub-items.
- **Active-dot indicator fix** — `overflow-y: auto` (added previously so a long TOC scrolls internally) forces `overflow-x` to clip too, per the CSS Overflow spec. That was clipping the active-dot's intentional negative-`left` bleed onto the dashed guide line, leaving a "broken circle." Added `pl-2` as safe clearance.
- **Sub-item spacing fix** — `.toc-sublist` had no `gap` between its `<li>` items, so a wrapped line within one heading and the gap to the next heading looked identical. Added `flex flex-col gap-2`, and sized legal's H3 sub-items down to `datum-text-xs` for clearer hierarchy (handbook's H3 sizing is untouched).

## Test plan

- [x] `npx astro check` — 0 errors
- [x] Confirmed handbook's TOC markup is unchanged (still flat `.toc-item`, no `.toc-group`) — the new grouping only renders when `collapsible` is passed
- [x] Confirmed the MSA's TOC renders 16 groups, only leaf sections (no children) omit the toggle button, and only the first group is open by default
- [ ] Manual visual QA on `/legal/master-services-agreement` (long doc, multiple multi-child groups) and `/handbook/eos/vto` (regression check) across breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)
