### PR TITLE
fix(nav): keep mobile Start CTA descriptive for SEO

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -122,6 +122,7 @@ export default defineConfig({
     mermaid({
       theme: 'forest',
       autoTheme: true,
+      enableLog: false,
     }),
     playformCompress({
       // CSS minification disabled: csso@5 (bundled by @playform/compress) drops

--- a/docs/UNUSED_CODE_AUDIT.md
+++ b/docs/UNUSED_CODE_AUDIT.md
@@ -1,0 +1,49 @@
+# Unused Code Audit (Manual Review)
+
+Generated: 2026-08-12
+
+Static heuristic scan of **datum.net** for unused CSS classes and unused JS/TS (modules, exports, Astro components, client scripts).
+
+**Do not delete from these lists blindly.** Confirm with `rg` / typecheck / page smoke tests.
+
+## Reports
+
+| Report      | Path                                         | Focus                                                                 |
+| ----------- | -------------------------------------------- | --------------------------------------------------------------------- |
+| CSS classes | [UNUSED_CSS_AUDIT.md](./UNUSED_CSS_AUDIT.md) | Custom selectors in `src/static/styles/` with no markup/TS hit        |
+| JS / TS     | [UNUSED_JS_AUDIT.md](./UNUSED_JS_AUDIT.md)   | Modules, Astro components, named exports, inline `<script>` inventory |
+
+## Snapshot
+
+| Area                               | Candidates |
+| ---------------------------------- | ---------: |
+| Unused CSS classes                 |        128 |
+| Likely-dynamic CSS (probably keep) |         20 |
+| Orphan CSS files                   |          0 |
+| Unused modules                     |          0 |
+| Unused Astro components            |          0 |
+| Unused value exports               |         28 |
+| Unused type/interface exports      |         41 |
+
+## How this was produced
+
+Scanner: `scripts/audit/scan-unused.mjs`
+
+```bash
+node scripts/audit/scan-unused.mjs
+```
+
+## Suggested review order
+
+1. **CSS skeletons / old variants** in [UNUSED_CSS_AUDIT.md](./UNUSED_CSS_AUDIT.md) (blog/events skeletons, unused button variants) — highest chance of real dead CSS.
+2. **Value exports** in [UNUSED_JS_AUDIT.md](./UNUSED_JS_AUDIT.md) (`getUnique*`, `clearSession`, `stripTags`, etc.) — run `rg` then `npm run typecheck` after removals.
+3. **Type exports** last — many are intentional public types / inference-only.
+4. Skip or keep items under **Likely dynamic classes** unless you remove the corresponding template literal builders.
+5. Client scripts under `src/static/scripts/` are all wired (Layouts / 404); use the inline `<script>` inventory only as a map of JS surfaces.
+
+## Limits
+
+- Does not execute the site or analyze the built CSS bundle / Tailwind purge.
+- Misses Alpine/`class:list` concatenation that never contains a full literal class name.
+- Import detection can miss string-built dynamic `import()`.
+- Astro framework convention files (e.g. `src/actions/index.ts`) are excluded when known.

--- a/docs/UNUSED_CSS_AUDIT.md
+++ b/docs/UNUSED_CSS_AUDIT.md
@@ -1,0 +1,288 @@
+# Unused CSS Classes Audit
+
+Generated: 2026-08-12T03:30:38.852Z
+
+## How to read this
+
+Static heuristic scan of `src/static/styles/**/*.css`. **Review before deleting.**
+
+- A class is “unused” if its name never appears outside CSS (Astro/TS/JS/MD/MDX/HTML).
+- Dynamically built classes (`compute-meter-fill--${tone}`) are listed separately.
+- Animation-step / CSS-orchestrated modifiers may still be live even if unused in markup.
+- False positives: Alpine `x-bind:class`, server-injected HTML, content not in repo.
+
+## Summary
+
+| Metric                 |   Count |
+| ---------------------- | ------: |
+| CSS files scanned      |      57 |
+| Custom class selectors |    1084 |
+| With non-CSS usage     |     936 |
+| **Candidate unused**   | **128** |
+| Likely dynamic (keep)  |      20 |
+| Orphan CSS files       |       0 |
+
+## Detected dynamic class prefixes
+
+Found template/string patterns like `` `prefix${...}` `` in non-CSS sources:
+
+- `changelog-entry-card-tag--`
+- `compute-meter-fill--`
+- `dns-anim-checkbox--`
+- `dns-anim-status--`
+- `figure--`
+- `foo--`
+- `nav-dropdown-parent--`
+- `note--`
+- `page-author--`
+- `page-brand--`
+- `page-handbook--`
+- `page-legal--`
+
+## Possibly orphan CSS files
+
+_None detected._
+
+## Likely dynamic classes (probably keep)
+
+No literal usage, but matches a dynamic prefix — usually still live.
+
+| Class                                | Defined in                                            | Dynamic prefix               | Review |
+| ------------------------------------ | ----------------------------------------------------- | ---------------------------- | ------ |
+| `.changelog-entry-card-tag--changed` | `src/static/styles/components-changelog.css`          | `changelog-entry-card-tag--` | [ ]    |
+| `.changelog-entry-card-tag--fixed`   | `src/static/styles/components-changelog.css`          | `changelog-entry-card-tag--` | [ ]    |
+| `.changelog-entry-card-tag--new`     | `src/static/styles/components-changelog.css`          | `changelog-entry-card-tag--` | [ ]    |
+| `.compute-meter-fill--alert`         | `src/static/styles/components-compute.css`            | `compute-meter-fill--`       | [ ]    |
+| `.compute-meter-fill--moss`          | `src/static/styles/components-compute.css`            | `compute-meter-fill--`       | [ ]    |
+| `.dns-anim-checkbox--2`              | `src/static/styles/components-dns-hero-animation.css` | `dns-anim-checkbox--`        | [ ]    |
+| `.dns-anim-checkbox--3`              | `src/static/styles/components-dns-hero-animation.css` | `dns-anim-checkbox--`        | [ ]    |
+| `.dns-anim-checkbox--4`              | `src/static/styles/components-dns-hero-animation.css` | `dns-anim-checkbox--`        | [ ]    |
+| `.dns-anim-checkbox--5`              | `src/static/styles/components-dns-hero-animation.css` | `dns-anim-checkbox--`        | [ ]    |
+| `.dns-anim-checkbox--6`              | `src/static/styles/components-dns-hero-animation.css` | `dns-anim-checkbox--`        | [ ]    |
+| `.dns-anim-checkbox--7`              | `src/static/styles/components-dns-hero-animation.css` | `dns-anim-checkbox--`        | [ ]    |
+| `.dns-anim-status--1`                | `src/static/styles/components-dns-hero-animation.css` | `dns-anim-status--`          | [ ]    |
+| `.dns-anim-status--2`                | `src/static/styles/components-dns-hero-animation.css` | `dns-anim-status--`          | [ ]    |
+| `.dns-anim-status--4`                | `src/static/styles/components-dns-hero-animation.css` | `dns-anim-status--`          | [ ]    |
+| `.dns-anim-status--5`                | `src/static/styles/components-dns-hero-animation.css` | `dns-anim-status--`          | [ ]    |
+| `.dns-anim-status--6`                | `src/static/styles/components-dns-hero-animation.css` | `dns-anim-status--`          | [ ]    |
+| `.dns-anim-status--7`                | `src/static/styles/components-dns-hero-animation.css` | `dns-anim-status--`          | [ ]    |
+| `.note--caution`                     | `src/static/styles/components-download.css`           | `note--`                     | [ ]    |
+| `.note--note`                        | `src/static/styles/components-download.css`           | `note--`                     | [ ]    |
+| `.note--tip`                         | `src/static/styles/components-download.css`           | `note--`                     | [ ]    |
+
+## Candidate unused classes (by file)
+
+### `src/static/styles/components-blog.css`
+
+| Class                      | Lines | Review | Notes |
+| -------------------------- | ----- | ------ | ----- |
+| `.blog-strapi-skeleton`    | 125   | [ ]    |       |
+| `.skeleton-date`           | 147   | [ ]    |       |
+| `.skeleton-excerpt`        | 139   | [ ]    |       |
+| `.skeleton-excerpt--short` | 143   | [ ]    |       |
+| `.skeleton-image`          | 131   | [ ]    |       |
+| `.skeleton-list-date`      | 155   | [ ]    |       |
+| `.skeleton-list-title`     | 151   | [ ]    |       |
+
+### `src/static/styles/components-buttons.css`
+
+| Class                        | Lines | Review | Notes |
+| ---------------------------- | ----- | ------ | ----- |
+| `.btn--midnight-fjord-alpha` | 54    | [ ]    |       |
+
+### `src/static/styles/components-download.css`
+
+| Class                   | Lines  | Review | Notes |
+| ----------------------- | ------ | ------ | ----- |
+| `.download-nav-divider` | 77, 81 | [ ]    |       |
+
+### `src/static/styles/components-events.css`
+
+| Class                                          | Lines | Review | Notes |
+| ---------------------------------------------- | ----- | ------ | ----- |
+| `.event-calendar-list__zoom-link`              | 432   | [ ]    |       |
+| `.event-series-card__zoom-link`                | 528   | [ ]    |       |
+| `.events-overview-skeleton`                    | 87    | [ ]    |       |
+| `.events-overview-skeleton__calendar-day`      | 179   | [ ]    |       |
+| `.events-overview-skeleton__calendar-dow`      | 167   | [ ]    |       |
+| `.events-overview-skeleton__calendar-dow-cell` | 171   | [ ]    |       |
+| `.events-overview-skeleton__calendar-grid`     | 175   | [ ]    |       |
+| `.events-overview-skeleton__calendar-header`   | 147   | [ ]    |       |
+| `.events-overview-skeleton__calendar-layout`   | 139   | [ ]    |       |
+| `.events-overview-skeleton__calendar-month`    | 163   | [ ]    |       |
+| `.events-overview-skeleton__calendar-nav`      | 151   | [ ]    |       |
+| `.events-overview-skeleton__calendar-section`  | 135   | [ ]    |       |
+| `.events-overview-skeleton__calendar-widget`   | 143   | [ ]    |       |
+| `.events-overview-skeleton__category-arrow`    | 119   | [ ]    |       |
+| `.events-overview-skeleton__category-badge`    | 115   | [ ]    |       |
+| `.events-overview-skeleton__category-card`     | 99    | [ ]    |       |
+| `.events-overview-skeleton__category-cards`    | 95    | [ ]    |       |
+| `.events-overview-skeleton__category-content`  | 103   | [ ]    |       |
+| `.events-overview-skeleton__category-image`    | 123   | [ ]    |       |
+| `.events-overview-skeleton__category-text`     | 107   | [ ]    |       |
+| `.events-overview-skeleton__category-title`    | 111   | [ ]    |       |
+| `.events-overview-skeleton__heading`           | 131   | [ ]    |       |
+| `.events-overview-skeleton__heading-wrap`      | 127   | [ ]    |       |
+| `.events-overview-skeleton__list`              | 183   | [ ]    |       |
+| `.events-overview-skeleton__list-badge`        | 203   | [ ]    |       |
+| `.events-overview-skeleton__list-badges`       | 199   | [ ]    |       |
+| `.events-overview-skeleton__list-header`       | 191   | [ ]    |       |
+| `.events-overview-skeleton__list-item`         | 187   | [ ]    |       |
+| `.events-overview-skeleton__list-meta`         | 211   | [ ]    |       |
+| `.events-overview-skeleton__list-meta-chunk`   | 215   | [ ]    |       |
+| `.events-overview-skeleton__list-title`        | 195   | [ ]    |       |
+| `.events-overview-skeleton__pulse`             | 91    | [ ]    |       |
+| `.featured-event__description`                 | 4     | [ ]    |       |
+
+### `src/static/styles/components-features-hub.css`
+
+| Class                          | Lines | Review | Notes |
+| ------------------------------ | ----- | ------ | ----- |
+| `.feature-sections`            | 2     | [ ]    |       |
+| `.feature-sections-header`     | 7     | [ ]    |       |
+| `.feature-sections-label`      | 11    | [ ]    |       |
+| `.feature-sections-label-mark` | 16    | [ ]    |       |
+
+### `src/static/styles/components-features.css`
+
+| Class                               | Lines | Review | Notes |
+| ----------------------------------- | ----- | ------ | ----- |
+| `.features-cta-badge`               | 182   | [ ]    |       |
+| `.features-section-description--sm` | 51    | [ ]    |       |
+
+### `src/static/styles/components-form.css`
+
+| Class                       | Lines | Review | Notes |
+| --------------------------- | ----- | ------ | ----- |
+| `.form--actions`            | 58    | [ ]    |       |
+| `.form--checkbox`           | 46    | [ ]    |       |
+| `.form--checkbox-container` | 38    | [ ]    |       |
+| `.form--checkbox-label`     | 50    | [ ]    |       |
+| `.form--checkbox-wrapper`   | 42    | [ ]    |       |
+| `.form--content`            | 14    | [ ]    |       |
+| `.form--field`              | 22    | [ ]    |       |
+| `.form--fields`             | 18    | [ ]    |       |
+| `.form--header`             | 6     | [ ]    |       |
+| `.form--input`              | 30    | [ ]    |       |
+| `.form--label`              | 26    | [ ]    |       |
+| `.form--message`            | 54    | [ ]    |       |
+| `.form--textarea`           | 34    | [ ]    |       |
+| `.form--title`              | 10    | [ ]    |       |
+
+### `src/static/styles/components-handbook.css`
+
+| Class            | Lines | Review | Notes |
+| ---------------- | ----- | ------ | ----- |
+| `.article-aside` | 93    | [ ]    |       |
+
+### `src/static/styles/components-hero.css`
+
+| Class      | Lines | Review | Notes |
+| ---------- | ----- | ------ | ----- |
+| `.iconize` | 64    | [ ]    |       |
+
+### `src/static/styles/components-home.css`
+
+| Class                       | Lines | Review | Notes |
+| --------------------------- | ----- | ------ | ----- |
+| `.btn--home-hero-primary`   | 56    | [ ]    |       |
+| `.btn--home-hero-secondary` | 64    | [ ]    |       |
+| `.home-hero`                | 2     | [ ]    |       |
+| `.home-hero-grid`           | 7     | [ ]    |       |
+| `.home-hero-grid-lines`     | 15    | [ ]    |       |
+
+### `src/static/styles/components-list.css`
+
+| Class                         | Lines | Review | Notes |
+| ----------------------------- | ----- | ------ | ----- |
+| `.entry-list-item--meta-text` | 19    | [ ]    |       |
+
+### `src/static/styles/components-locations.css`
+
+| Class                         | Lines | Review | Notes |
+| ----------------------------- | ----- | ------ | ----- |
+| `.locations-map--description` | 25    | [ ]    |       |
+| `.locations-map--section`     | 2     | [ ]    |       |
+
+### `src/static/styles/components-mission.css`
+
+| Class                        | Lines | Review | Notes |
+| ---------------------------- | ----- | ------ | ----- |
+| `.mission-body`              | 33    | [ ]    |       |
+| `.mission-body-line`         | 38    | [ ]    |       |
+| `.mission-grid`              | 2     | [ ]    |       |
+| `.mission-paragraphs`        | 55    | [ ]    |       |
+| `.mission-reasons`           | 72    | [ ]    |       |
+| `.mission-reasons-item`      | 76    | [ ]    |       |
+| `.mission-reasons-number`    | 92    | [ ]    |       |
+| `.mission-reasons-text`      | 99    | [ ]    |       |
+| `.mission-reasons-text-wrap` | 88    | [ ]    |       |
+| `.mission-section`           | 7     | [ ]    |       |
+| `.mission-vision-check`      | 121   | [ ]    |       |
+| `.mission-vision-check-icon` | 134   | [ ]    |       |
+| `.mission-vision-check-text` | 138   | [ ]    |       |
+| `.mission-vision-checks`     | 117   | [ ]    |       |
+| `.mission-vision-closing`    | 146   | [ ]    |       |
+| `.mission-vision-cta-text`   | 151   | [ ]    |       |
+| `.mission-wrapper`           | 49    | [ ]    |       |
+| `.video-thumb`               | 160   | [ ]    |       |
+| `.video-thumb-blend`         | 164   | [ ]    |       |
+
+### `src/static/styles/components-roadmap.css`
+
+| Class                           | Lines    | Review | Notes |
+| ------------------------------- | -------- | ------ | ----- |
+| `.roadmap-backlog-badge`        | 147, 173 | [ ]    |       |
+| `.roadmap-backlog-labels`       | 143      | [ ]    |       |
+| `.roadmap-container`            | 242      | [ ]    |       |
+| `.roadmap-content`              | 279      | [ ]    |       |
+| `.roadmap-content--description` | 299      | [ ]    |       |
+| `.roadmap-content--summary`     | 303      | [ ]    |       |
+| `.roadmap-content--text`        | 283      | [ ]    |       |
+| `.roadmap-content--title`       | 287      | [ ]    |       |
+| `.roadmap-detail--attribution`  | 110      | [ ]    |       |
+| `.roadmap-detail--section`      | 85       | [ ]    |       |
+| `.roadmap-link`                 | 333      | [ ]    |       |
+| `.roadmap-link--icon`           | 345      | [ ]    |       |
+| `.roadmap-month`                | 263      | [ ]    |       |
+| `.roadmap-month--text`          | 275      | [ ]    |       |
+| `.roadmap-row`                  | 258      | [ ]    |       |
+| `.roadmap-section`              | 246      | [ ]    |       |
+| `.roadmap-section--title`       | 250      | [ ]    |       |
+| `.roadmap-strapi-skeleton`      | 349      | [ ]    |       |
+| `.roadmap-table`                | 254      | [ ]    |       |
+| `.skeleton-description`         | 369      | [ ]    |       |
+| `.skeleton-link`                | 373      | [ ]    |       |
+| `.skeleton-month`               | 361      | [ ]    |       |
+| `.skeleton-section-title`       | 357      | [ ]    |       |
+
+### `src/static/styles/components.css`
+
+| Class                     | Lines    | Review | Notes |
+| ------------------------- | -------- | ------ | ----- |
+| `.article-aside`          | 427      | [ ]    |       |
+| `.article-aside-close`    | 449, 458 | [ ]    |       |
+| `.article-aside-content`  | 446, 471 | [ ]    |       |
+| `.article-aside-header`   | 463      | [ ]    |       |
+| `.article-aside-title`    | 445, 467 | [ ]    |       |
+| `.footer-prefooter-label` | 261      | [ ]    |       |
+| `.toc-item--level-1`      | 667      | [ ]    |       |
+| `.toc-item--level-2`      | 671      | [ ]    |       |
+| `.toc-item--level-3`      | 675      | [ ]    |       |
+| `.toc-item--level-4`      | 679      | [ ]    |       |
+| `.toc-item--level-5`      | 683      | [ ]    |       |
+| `.toc-item--level-6`      | 687      | [ ]    |       |
+
+### `src/static/styles/page-hello.css`
+
+| Class                           | Lines | Review | Notes |
+| ------------------------------- | ----- | ------ | ----- |
+| `.hello-hero-newsletter-input`  | 46    | [ ]    |       |
+| `.hello-hero-newsletter-submit` | 50    | [ ]    |       |
+
+## Review checklist
+
+- [ ] `rg` the class name across `src/`
+- [ ] Check Alpine / `class:list` / string concatenation
+- [ ] Confirm parent CSS file is imported on live pages
+- [ ] Remove CSS + dead markup together

--- a/docs/UNUSED_JS_AUDIT.md
+++ b/docs/UNUSED_JS_AUDIT.md
@@ -1,0 +1,180 @@
+# Unused JavaScript / TypeScript Audit
+
+Generated: 2026-08-12T03:30:38.853Z
+
+## How to read this
+
+Static import/reference scan. **Review before deleting.**
+
+- Modules/components need an `import` / `from` / `import()` path hit (or Astro/MDX tag usage).
+- Pages under `src/pages` are routes and excluded from unused-module checks.
+- Type-only exports often look unused when only inferred — verify with `rg`.
+- Barrel-only Astro components (`@components/content`) are listed separately.
+
+## Summary
+
+| Metric                        | Count |
+| ----------------------------- | ----: |
+| Module candidates             |    65 |
+| Astro components              |   112 |
+| **Unused modules/scripts**    | **0** |
+| **Unused Astro components**   | **0** |
+| Barrel-only Astro             |     0 |
+| Unused value exports          |    28 |
+| Unused type/interface exports |    41 |
+| Unreferenced root scripts     |     0 |
+| Astro files with `<script>`   |    33 |
+
+## Candidate unused modules / client scripts
+
+_None detected._
+
+## Candidate unused Astro components
+
+_None detected._
+
+## Barrel-only Astro components
+
+Imported via folder `index` barrel (likely used from MDX). Confirm before removing.
+
+_None._
+
+## Candidate unused value exports (functions/const/class)
+
+| Export                              | File                                        | Review |
+| ----------------------------------- | ------------------------------------------- | ------ |
+| `getUniqueDepartments`              | `src/libs/ashby.ts`                         | [ ]    |
+| `getUniqueEmploymentTypes`          | `src/libs/ashby.ts`                         | [ ]    |
+| `getUniqueLocations`                | `src/libs/ashby.ts`                         | [ ]    |
+| `clearSession`                      | `src/libs/auth.ts`                          | [ ]    |
+| `getSession`                        | `src/libs/auth.ts`                          | [ ]    |
+| `filterEventsInNextUtcMonth`        | `src/libs/events.ts`                        | [ ]    |
+| `getEventSlug`                      | `src/libs/events.ts`                        | [ ]    |
+| `clearGitHubBacklogCache`           | `src/libs/githubBacklog.ts`                 | [ ]    |
+| `INCLUDED_BACKLOG_STATUSES`         | `src/libs/githubBacklog.ts`                 | [ ]    |
+| `clearGitHubRoadmapsCache`          | `src/libs/githubRoadmap.ts`                 | [ ]    |
+| `deletePrimaryCacheByPrefix`        | `src/libs/strapi/_runtime.ts`               | [ ]    |
+| `STRAPI_GRAPHQL_PAGE_SIZE`          | `src/libs/strapi/graphqlPagination.ts`      | [ ]    |
+| `STRAPI_FORCE_REGENERATE_KEYS`      | `src/libs/strapi/regenerateCache.ts`        | [ ]    |
+| `validateStrapiForceRegenerateName` | `src/libs/strapi/regenerateCache.ts`        | [ ]    |
+| `ResilientGraphQLStrapiClient`      | `src/libs/strapi/resilientGraphqlClient.ts` | [ ]    |
+| `removeHeaderTags`                  | `src/libs/string.ts`                        | [ ]    |
+| `stripTags`                         | `src/libs/string.ts`                        | [ ]    |
+| `getAuthorBgColor`                  | `src/utils/authorUtils.ts`                  | [ ]    |
+| `getStrapiTeamBgColor`              | `src/utils/authorUtils.ts`                  | [ ]    |
+| `getTeamMembers`                    | `src/utils/authorUtils.ts`                  | [ ]    |
+| `BLOG_LISTING_BASE`                 | `src/utils/blogPagination.ts`               | [ ]    |
+| `getBlogListingPagePath`            | `src/utils/blogPagination.ts`               | [ ]    |
+| `formatRelativeTime`                | `src/utils/dateUtils.ts`                    | [ ]    |
+| `extractFrontmatter`                | `src/utils/llmsUtils.ts`                    | [ ]    |
+| `containsFigureSyntax`              | `src/utils/markdownFigure.ts`               | [ ]    |
+| `makeEntryMarkdownRoute`            | `src/utils/pageMarkdown.ts`                 | [ ]    |
+| `findUrls`                          | `src/utils/string.ts`                       | [ ]    |
+| `hasUrl`                            | `src/utils/string.ts`                       | [ ]    |
+
+## Candidate unused type / interface exports
+
+Higher false-positive rate — types may only be used via inference or `import type` in ways the scanner missed.
+
+| Export                        | File                                   | Review |
+| ----------------------------- | -------------------------------------- | ------ |
+| `MeterBar`                    | `src/data/compute.ts`                  | [ ]    |
+| `TerminalBlock`               | `src/data/compute.ts`                  | [ ]    |
+| `TerminalContent`             | `src/data/compute.ts`                  | [ ]    |
+| `BuiltForYouItem`             | `src/data/dedicatedCloud.ts`           | [ ]    |
+| `ChecklistItem`               | `src/data/dedicatedCloud.ts`           | [ ]    |
+| `Operator`                    | `src/data/dedicatedCloud.ts`           | [ ]    |
+| `ComparisonRow`               | `src/data/dns.ts`                      | [ ]    |
+| `DomainStep`                  | `src/data/dns.ts`                      | [ ]    |
+| `IconItem`                    | `src/data/dns.ts`                      | [ ]    |
+| `AshbyCompensation`           | `src/libs/ashby.ts`                    | [ ]    |
+| `AshbyFetchResult`            | `src/libs/ashby.ts`                    | [ ]    |
+| `AshbyJobBoardResponse`       | `src/libs/ashby.ts`                    | [ ]    |
+| `AshbyLocation`               | `src/libs/ashby.ts`                    | [ ]    |
+| `GroupedJobs`                 | `src/libs/ashby.ts`                    | [ ]    |
+| `CacheEntry`                  | `src/libs/cacheViewer.ts`              | [ ]    |
+| `CacheEntryByName`            | `src/libs/cacheViewer.ts`              | [ ]    |
+| `CacheViewerData`             | `src/libs/cacheViewer.ts`              | [ ]    |
+| `GetCacheEntryResult`         | `src/libs/cacheViewer.ts`              | [ ]    |
+| `RoadmapProps`                | `src/libs/datum.ts`                    | [ ]    |
+| `EventHostsGuests`            | `src/libs/events.ts`                   | [ ]    |
+| `GeoAddress`                  | `src/libs/events.ts`                   | [ ]    |
+| `GroupedRoadmaps`             | `src/libs/githubRoadmap.ts`            | [ ]    |
+| `K8sClientConfig`             | `src/libs/k8s-client.ts`               | [ ]    |
+| `K8sMetadata`                 | `src/libs/k8s-client.ts`               | [ ]    |
+| `ResilientCacheDriverOptions` | `src/libs/strapi/drivers/resilient.ts` | [ ]    |
+| `RegenerateResult`            | `src/libs/strapi/regenerateCache.ts`   | [ ]    |
+| `ArticleProps`                | `src/types/common.ts`                  | [ ]    |
+| `AsideProps`                  | `src/types/common.ts`                  | [ ]    |
+| `BreadcrumbItem`              | `src/types/common.ts`                  | [ ]    |
+| `ContentProps`                | `src/types/common.ts`                  | [ ]    |
+| `HandbookProps`               | `src/types/common.ts`                  | [ ]    |
+| `NotFoundProps`               | `src/types/common.ts`                  | [ ]    |
+| `PaginationProps`             | `src/types/common.ts`                  | [ ]    |
+| `NotificationSpec`            | `src/types/k8s-resources.ts`           | [ ]    |
+| `NavFooterDocsSection`        | `src/types/navigation.ts`              | [ ]    |
+| `NavSection`                  | `src/types/navigation.ts`              | [ ]    |
+| `StrapiImageFormat`           | `src/types/strapi.ts`                  | [ ]    |
+| `StrapiSeo`                   | `src/types/strapi.ts`                  | [ ]    |
+| `NormalizedTeamMember`        | `src/utils/authorUtils.ts`             | [ ]    |
+| `MarkdownSource`              | `src/utils/markdownRegistry.ts`        | [ ]    |
+| `ToYouTubeEmbedUrlOptions`    | `src/utils/youtube.ts`                 | [ ]    |
+
+## Root `scripts/` not referenced
+
+_None detected._
+
+## Client scripts (known wiring)
+
+| Script                                 | Expected entry                        | Review |
+| -------------------------------------- | ------------------------------------- | ------ |
+| `src/static/scripts/scroll-effects.js` | Layout / LayoutMinimal / LayoutSimple | [ ]    |
+| `src/static/scripts/module-animate.js` | Layout.astro                          | [ ]    |
+| `src/static/scripts/error-tracker.js`  | 404.astro                             | [ ]    |
+
+## Astro files containing `<script>` (manual review of inline JS)
+
+Not “unused” — inventory of client/inline JS surfaces.
+
+| File                                                   | `<script>` tags | Review |
+| ------------------------------------------------------ | --------------: | ------ |
+| `src/components/about/PeopleStrapi.astro`              |               1 | [ ]    |
+| `src/components/about/ProfileModal.astro`              |               1 | [ ]    |
+| `src/components/content/Tabs.astro`                    |               1 | [ ]    |
+| `src/components/events/CommunityHuddlePastModal.astro` |               1 | [ ]    |
+| `src/components/events/EventCalendarSection.astro`     |               1 | [ ]    |
+| `src/components/Footer.astro`                          |               1 | [ ]    |
+| `src/components/forms/BookDemo.astro`                  |               1 | [ ]    |
+| `src/components/forms/DedicatedCloudForm.astro`        |               1 | [ ]    |
+| `src/components/forms/NewsletterModal.astro`           |               1 | [ ]    |
+| `src/components/handbook/Article.astro`                |               1 | [ ]    |
+| `src/components/hello/HelloHero.astro`                 |               1 | [ ]    |
+| `src/components/hello/HelloModal.astro`                |               1 | [ ]    |
+| `src/components/hello/HelloPeople.astro`               |               2 | [ ]    |
+| `src/components/JsonLd.astro`                          |               1 | [ ]    |
+| `src/components/LayoutEmbedScripts.astro`              |               5 | [ ]    |
+| `src/components/locations/LocationsList.astro`         |               1 | [ ]    |
+| `src/components/LogoDropdown.astro`                    |               1 | [ ]    |
+| `src/components/MarkdownLightbox.astro`                |               1 | [ ]    |
+| `src/components/MediaLightbox.astro`                   |               1 | [ ]    |
+| `src/components/Nav.astro`                             |               2 | [ ]    |
+| `src/components/roadmap/RoadmapViewFilter.astro`       |               1 | [ ]    |
+| `src/components/SecondaryTabNav.astro`                 |               1 | [ ]    |
+| `src/components/TableOfContents.astro`                 |               1 | [ ]    |
+| `src/layouts/Layout.astro`                             |               3 | [ ]    |
+| `src/layouts/LayoutMinimal.astro`                      |               4 | [ ]    |
+| `src/layouts/LayoutSimple.astro`                       |               3 | [ ]    |
+| `src/pages/_features-legacy.astro`                     |               2 | [ ]    |
+| `src/pages/404.astro`                                  |               1 | [ ]    |
+| `src/pages/careers.astro`                              |               3 | [ ]    |
+| `src/pages/download/[slug].astro`                      |               1 | [ ]    |
+| `src/pages/essentials.astro`                           |               1 | [ ]    |
+| `src/pages/locations.astro`                            |               1 | [ ]    |
+| `src/pages/shop/index.astro`                           |               2 | [ ]    |
+
+## Review checklist
+
+- [ ] Confirm no dynamic `import()` / string path
+- [ ] Check `server.mjs` and API routes
+- [ ] For Astro, search MDX content + relative `./X.astro` imports
+- [ ] For types, try removing and run `npm run typecheck`

--- a/scripts/audit/scan-unused.mjs
+++ b/scripts/audit/scan-unused.mjs
@@ -1,0 +1,730 @@
+#!/usr/bin/env node
+/**
+ * Static audit: unused CSS classes + unused JS/TS modules / exports / Astro components.
+ * Heuristic — false positives expected. Output: docs/UNUSED_*.md
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+const SRC = path.join(ROOT, 'src');
+
+const IGNORE_DIRS = new Set([
+  'node_modules', 'dist', '.git', '.astro', '.cache',
+  'playwright-report', 'test-results', '.persistent',
+]);
+
+const TEXT_EXT = new Set([
+  '.astro', '.ts', '.tsx', '.js', '.mjs', '.cjs', '.jsx',
+  '.md', '.mdx', '.html', '.css', '.scss', '.json',
+]);
+
+function walk(dir, filterExt) {
+  const out = [];
+  if (!fs.existsSync(dir)) return out;
+  const stack = [dir];
+  while (stack.length) {
+    const cur = stack.pop();
+    let entries;
+    try { entries = fs.readdirSync(cur, { withFileTypes: true }); } catch { continue; }
+    for (const ent of entries) {
+      if (IGNORE_DIRS.has(ent.name)) continue;
+      const full = path.join(cur, ent.name);
+      if (ent.isDirectory()) stack.push(full);
+      else if (!filterExt || filterExt.has(path.extname(ent.name))) out.push(full);
+    }
+  }
+  return out;
+}
+
+function rel(p) {
+  return path.relative(ROOT, p).split(path.sep).join('/');
+}
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function stripCssComments(css) {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function read(p) {
+  return fs.readFileSync(p, 'utf8');
+}
+
+function loadCorpus() {
+  const corpus = new Map();
+  for (const root of [SRC, path.join(ROOT, 'public'), path.join(ROOT, 'scripts'), path.join(ROOT, 'tests')]) {
+    for (const file of walk(root, TEXT_EXT)) {
+      try { corpus.set(file, read(file)); } catch { /* */ }
+    }
+  }
+  for (const f of ['server.mjs', 'astro.config.mjs', 'playwright.config.ts', 'eslint.config.mjs', 'package.json']) {
+    const full = path.join(ROOT, f);
+    if (fs.existsSync(full)) corpus.set(full, read(full));
+  }
+  return corpus;
+}
+
+/** Extract class names that appear as CSS selectors (not @apply utilities). */
+function extractCssClasses(css) {
+  const cleaned = stripCssComments(css);
+  // Remove @apply contents so utilities aren't treated as definitions
+  const noApply = cleaned.replace(/@apply[\s\S]*?;/g, ';');
+  const map = new Map(); // name -> lines[]
+  const lines = noApply.split('\n');
+  const re = /(^|[{},;\s>+~])\.([a-zA-Z_][a-zA-Z0-9_-]*)/g;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // skip pure property lines roughly
+    if (/^\s*(--|@apply|@import|@layer|@theme|@media|@keyframes|font-|color:|background|margin|padding|width|height|display|content:)/.test(line) && !line.includes('{') && !/^\s*\./.test(line)) {
+      continue;
+    }
+    let m;
+    re.lastIndex = 0;
+    while ((m = re.exec(line)) !== null) {
+      const name = m[2];
+      if (name.length < 2) continue;
+      if (!map.has(name)) map.set(name, []);
+      if (!map.get(name).includes(i + 1)) map.get(name).push(i + 1);
+    }
+  }
+  return map;
+}
+
+const TAILWIND_EXACT = new Set([
+  'container', 'flex', 'grid', 'hidden', 'block', 'inline', 'absolute',
+  'relative', 'fixed', 'sticky', 'static', 'sr-only', 'not-sr-only',
+]);
+
+function looksLikeCustomClass(name) {
+  if (TAILWIND_EXACT.has(name)) return false;
+  if (/^(sm|md|lg|xl|2xl|hover|focus|active|disabled|group|peer):/.test(name)) return false;
+  return true;
+}
+
+/** Find dynamic class construction patterns in non-CSS sources */
+function findDynamicPrefixes(corpus) {
+  const prefixes = new Set();
+  // `foo--${`, 'foo--' + , "foo--" +
+  // Prefer BEM modifier prefixes ending in `--` (avoids greedy `changelog-` matches).
+  const patterns = [
+    /(?:[`'"\s])([a-zA-Z_][a-zA-Z0-9_-]*--)\$\{/g,
+    /(?:[`'"\s])([a-zA-Z_][a-zA-Z0-9_-]*--)['"]\s*\+/g,
+  ];
+  for (const [file, content] of corpus) {
+    if (file.includes(`${path.sep}static${path.sep}styles${path.sep}`)) continue;
+    for (const re of patterns) {
+      re.lastIndex = 0;
+      let m;
+      while ((m = re.exec(content)) !== null) {
+        prefixes.add(m[1]);
+      }
+    }
+  }
+  return prefixes;
+}
+
+function classMatchesDynamic(name, prefixes) {
+  for (const p of prefixes) {
+    if (name.startsWith(p)) return p;
+  }
+  return null;
+}
+
+function countNonCssUsages(corpus, className, defineFile) {
+  const token = new RegExp(`(?:^|[^a-zA-Z0-9_-])${escapeRe(className)}(?:[^a-zA-Z0-9_-]|$)`);
+  const hits = [];
+  for (const [file, content] of corpus) {
+    if (file === defineFile) continue;
+    if (file.includes(`${path.sep}static${path.sep}styles${path.sep}`)) continue;
+    if (token.test(content)) hits.push(rel(file));
+  }
+  return hits;
+}
+
+function analyzeCss(corpus) {
+  const cssFiles = walk(path.join(SRC, 'static', 'styles'), new Set(['.css']));
+  const dynamicPrefixes = findDynamicPrefixes(corpus);
+
+  const unused = [];
+  const dynamicLikely = [];
+  const orphanCssFiles = [];
+  let classCount = 0;
+  let usedCount = 0;
+
+  for (const file of cssFiles) {
+    const base = path.basename(file);
+    const content = read(file);
+    const isEntry = [
+      'global.css', 'base.css', 'theme.css', 'variables.css', 'fonts.css',
+      'utilities.css', 'components.css', 'color-theme.css',
+      'variables-breakpoints.css', 'fonts-dejavu.css',
+    ].includes(base);
+
+    let imported = isEntry;
+    if (!imported) {
+      for (const [, c] of corpus) {
+        if (c.includes(base) || c.includes(`styles/${base}`)) { imported = true; break; }
+      }
+    }
+    if (!imported) {
+      orphanCssFiles.push({ file: rel(file), reason: 'No import/reference found' });
+    }
+
+    const classes = extractCssClasses(content);
+    for (const [name, lines] of classes) {
+      if (!looksLikeCustomClass(name)) continue;
+      classCount++;
+      const dyn = classMatchesDynamic(name, dynamicPrefixes);
+      const hits = countNonCssUsages(corpus, name, file);
+      const entry = {
+        className: name,
+        definedIn: rel(file),
+        lines: lines.slice(0, 8),
+        sampleUsages: hits.slice(0, 5),
+        dynamicPrefix: dyn,
+      };
+      if (hits.length === 0) {
+        if (dyn) dynamicLikely.push(entry);
+        else unused.push(entry);
+      } else {
+        usedCount++;
+      }
+    }
+  }
+
+  const dedupe = (arr) => {
+    const seen = new Set();
+    return arr.filter((x) => {
+      const k = `${x.className}|${x.definedIn}`;
+      if (seen.has(k)) return false;
+      seen.add(k);
+      return true;
+    });
+  };
+
+  return {
+    cssFileCount: cssFiles.length,
+    classCount,
+    usedCount,
+    unusedClasses: dedupe(unused).sort((a, b) => a.definedIn.localeCompare(b.definedIn) || a.className.localeCompare(b.className)),
+    dynamicLikely: dedupe(dynamicLikely).sort((a, b) => a.className.localeCompare(b.className)),
+    orphanCssFiles,
+    dynamicPrefixes: [...dynamicPrefixes].sort(),
+  };
+}
+
+/**
+ * Resolve whether moduleA is imported by looking for import/from path fragments.
+ */
+function modulePathAliases(modulePath) {
+  const r = rel(modulePath);
+  const noExt = r.replace(/\.(ts|js|mjs|astro)$/, '');
+  const base = path.basename(noExt);
+  const aliases = new Set([
+    noExt,
+    `${noExt}.ts`,
+    `${noExt}.js`,
+    `${noExt}.mjs`,
+    `${noExt}.astro`,
+    `@/${noExt}`,
+    `@/src/${noExt.replace(/^src\//, '')}`,
+  ]);
+  // Directory barrels: src/foo/index.ts is imported as src/foo or @components/foo
+  if (/\/index$/.test(noExt)) {
+    const dir = noExt.replace(/\/index$/, '');
+    aliases.add(dir);
+    aliases.add(`@/${dir}`);
+    aliases.add(`@/src/${dir.replace(/^src\//, '')}`);
+  }
+
+  const replacements = [
+    [/^src\/utils\//, '@utils/'],
+    [/^src\/libs\//, '@libs/'],
+    [/^src\/types\//, '@types/'],
+    [/^src\/components\//, '@components/'],
+    [/^src\/layouts\//, '@layouts/'],
+    [/^src\/data\//, '@data/'],
+    [/^src\/actions\//, '@actions/'],
+    [/^src\/v1\//, '@v1/'],
+    [/^src\/content\//, '@content/'],
+    [/^src\/static\//, '@/src/static/'],
+    [/^src\/plugins\//, '../plugins/'],
+  ];
+  for (const [re, prefix] of replacements) {
+    if (re.test(noExt)) {
+      const rest = noExt.replace(re, '');
+      aliases.add(prefix + rest);
+      aliases.add(prefix + rest + '.ts');
+      aliases.add(prefix + rest + '.js');
+      aliases.add(prefix + rest + '.astro');
+      aliases.add(prefix + rest + '.mjs');
+      if (rest.endsWith('/index') || rest === 'index') {
+        const dirRest = rest.replace(/\/?index$/, '');
+        aliases.add(prefix + dirRest);
+      }
+    }
+  }
+
+  // relative basename forms commonly used
+  aliases.add(`./${base}`);
+  aliases.add(`./${base}.ts`);
+  aliases.add(`./${base}.js`);
+  aliases.add(`./${base}.astro`);
+  aliases.add(`../${base}`);
+  aliases.add(`../${base}.astro`);
+  aliases.add(`/${base}.astro`);
+  aliases.add(`${base}.astro`);
+
+  // Nested relative imports: ./drivers/redis from sibling folders
+  const parts = noExt.split('/');
+  for (let i = 1; i < parts.length; i++) {
+    const suffix = parts.slice(i).join('/');
+    aliases.add(suffix);
+    aliases.add(`./${suffix}`);
+    aliases.add(`../${suffix}`);
+  }
+
+  return { aliases: [...aliases], base, noExt, r };
+}
+
+function findImportRefs(modulePath, corpus) {
+  const { aliases } = modulePathAliases(modulePath);
+  const refs = [];
+  for (const [file, content] of corpus) {
+    if (file === modulePath) continue;
+    // Prefer import/from/export-from / dynamic import
+    for (const a of aliases) {
+      if (a.length < 3) continue;
+      if (!content.includes(a)) continue;
+      // Require it appears in an import-like context OR as component tag for .astro
+      const escaped = escapeRe(a);
+      const importCtx = new RegExp(
+        `(?:import|export)\\s+[\\s\\S]{0,120}?from\\s*['"][^'"]*${escaped}['"]|import\\s*\\(\\s*['"][^'"]*${escaped}['"]|import\\s+['"][^'"]*${escaped}['"]`
+      );
+      if (importCtx.test(content)) {
+        refs.push(rel(file));
+        break;
+      }
+      // Astro/MDX component usage by import name (basename)
+      if (modulePath.endsWith('.astro')) {
+        const base = path.basename(modulePath, '.astro');
+        if (
+          new RegExp(`import\\s+\\{?[^;]*\\b${escapeRe(base)}\\b`).test(content) ||
+          new RegExp(`<${escapeRe(base)}[\\s/>]`).test(content)
+        ) {
+          refs.push(rel(file));
+          break;
+        }
+      }
+    }
+  }
+  return [...new Set(refs)];
+}
+
+function analyzeJs(corpus) {
+  const moduleCandidates = walk(SRC, new Set(['.ts', '.js', '.mjs'])).filter((f) => {
+    const r = rel(f);
+    if (r.startsWith('src/pages/')) return false;
+    if (r.endsWith('.d.ts')) return false;
+    if (r === 'src/middleware.ts' || r === 'src/content.config.ts' || r === 'src/entrypoint.ts') return false;
+    return true;
+  });
+  const staticScripts = walk(path.join(SRC, 'static', 'scripts'), new Set(['.js']));
+  const astroComponents = walk(path.join(SRC, 'components'), new Set(['.astro']));
+
+  const FRAMEWORK_ENTRIES = new Set([
+    'src/actions/index.ts', // Astro actions entry (convention)
+  ]);
+  const STUB_NOTES = new Map([
+    ['src/libs/strapi/drivers/redis.ts', 'Likely stub / future Redis driver — confirm before delete'],
+    ['src/libs/strapi/drivers/resilient.ts', 'May be wired only from runtime factory — confirm'],
+  ]);
+
+  const unusedModules = [];
+  for (const mod of [...moduleCandidates, ...staticScripts]) {
+    const r = rel(mod);
+    if (FRAMEWORK_ENTRIES.has(r)) continue;
+    const refs = findImportRefs(mod, corpus);
+    if (refs.length === 0) {
+      unusedModules.push({
+        file: r,
+        referenceCount: 0,
+        sampleRefs: [],
+        note: STUB_NOTES.get(r) || '',
+      });
+    }
+  }
+
+  const unusedAstro = [];
+  const maybeAstro = [];
+  for (const comp of astroComponents) {
+    const refs = findImportRefs(comp, corpus);
+    // Also: barrel re-export in same folder index.ts
+    const dir = path.dirname(comp);
+    const indexFile = ['.ts', '.js'].map((e) => path.join(dir, `index${e}`)).find((p) => fs.existsSync(p));
+    let barrelRefs = [];
+    if (indexFile) {
+      const idx = read(indexFile);
+      const base = path.basename(comp, '.astro');
+      if (idx.includes(`./${base}`) || idx.includes(`'./${base}.astro'`) || idx.includes(`"./${base}.astro"`)) {
+        barrelRefs = findImportRefs(indexFile, corpus);
+      }
+    }
+    if (refs.length === 0 && barrelRefs.length === 0) {
+      unusedAstro.push({ file: rel(comp), referenceCount: 0, sampleRefs: [] });
+    } else if (refs.length === 0 && barrelRefs.length > 0) {
+      maybeAstro.push({
+        file: rel(comp),
+        note: `Only via barrel ${rel(indexFile)}`,
+        sampleRefs: barrelRefs.slice(0, 5),
+      });
+    }
+  }
+
+  // Named exports — split type vs value
+  const unusedValueExports = [];
+  const unusedTypeExports = [];
+  for (const mod of moduleCandidates) {
+    const content = corpus.get(mod) || read(mod);
+    const valueNames = new Set();
+    const typeNames = new Set();
+
+    let m;
+    const valRe = /export\s+(?:async\s+)?function\s+([A-Za-z0-9_]+)|export\s+const\s+([A-Za-z0-9_]+)|export\s+class\s+([A-Za-z0-9_]+)|export\s+enum\s+([A-Za-z0-9_]+)/g;
+    while ((m = valRe.exec(content)) !== null) {
+      valueNames.add(m[1] || m[2] || m[3] || m[4]);
+    }
+    const typeRe = /export\s+type\s+([A-Za-z0-9_]+)|export\s+interface\s+([A-Za-z0-9_]+)/g;
+    while ((m = typeRe.exec(content)) !== null) {
+      typeNames.add(m[1] || m[2]);
+    }
+    // export { X } — treat as value unless type-only export { type X }
+    const braceRe = /export\s+\{([^}]+)\}/g;
+    while ((m = braceRe.exec(content)) !== null) {
+      for (const part of m[1].split(',')) {
+        const trimmed = part.trim();
+        if (!trimmed) continue;
+        const isType = /^type\s+/.test(trimmed);
+        const id = trimmed.replace(/^type\s+/, '').split(/\s+as\s+/).pop()?.trim();
+        if (id && /^[A-Za-z_][A-Za-z0-9_]*$/.test(id)) {
+          (isType ? typeNames : valueNames).add(id);
+        }
+      }
+    }
+
+    for (const name of valueNames) {
+      let found = 0;
+      const sample = [];
+      const re = new RegExp(`\\b${escapeRe(name)}\\b`);
+      for (const [file, c] of corpus) {
+        if (file === mod) continue;
+        if (re.test(c)) {
+          found++;
+          if (sample.length < 4) sample.push(rel(file));
+        }
+      }
+      if (found === 0) {
+        unusedValueExports.push({ name, file: rel(mod), sample });
+      }
+    }
+    for (const name of typeNames) {
+      let found = 0;
+      const sample = [];
+      const re = new RegExp(`\\b${escapeRe(name)}\\b`);
+      for (const [file, c] of corpus) {
+        if (file === mod) continue;
+        if (re.test(c)) {
+          found++;
+          if (sample.length < 4) sample.push(rel(file));
+        }
+      }
+      if (found === 0) {
+        unusedTypeExports.push({ name, file: rel(mod), sample });
+      }
+    }
+  }
+
+  // Root scripts
+  const pkg = read(path.join(ROOT, 'package.json'));
+  const unusedRootScripts = [];
+  for (const s of walk(path.join(ROOT, 'scripts'), new Set(['.ts', '.js', '.mjs']))) {
+    if (rel(s).startsWith('scripts/audit/')) continue;
+    const base = path.basename(s);
+    let mentioned = pkg.includes(base);
+    if (!mentioned) {
+      for (const [, c] of corpus) {
+        if (c.includes(base)) { mentioned = true; break; }
+      }
+    }
+    // docs
+    if (!mentioned) {
+      for (const d of walk(path.join(ROOT, 'docs'), new Set(['.md']))) {
+        if (read(d).includes(base)) { mentioned = true; break; }
+      }
+    }
+    if (!mentioned) unusedRootScripts.push({ file: rel(s), note: 'Not referenced in package.json or codebase' });
+  }
+
+  // Inline <script> blocks in Astro — list files with client JS for manual review
+  const inlineScriptFiles = [];
+  for (const [file, content] of corpus) {
+    if (!file.endsWith('.astro')) continue;
+    if (/<script[\s>]/.test(content)) {
+      const count = (content.match(/<script[\s>]/g) || []).length;
+      inlineScriptFiles.push({ file: rel(file), scriptTags: count });
+    }
+  }
+
+  return {
+    moduleCandidateCount: moduleCandidates.length + staticScripts.length,
+    astroComponentCount: astroComponents.length,
+    unusedModules: unusedModules.sort((a, b) => a.file.localeCompare(b.file)),
+    unusedAstro: unusedAstro.sort((a, b) => a.file.localeCompare(b.file)),
+    barrelOnlyAstro: maybeAstro.sort((a, b) => a.file.localeCompare(b.file)),
+    unusedValueExports: unusedValueExports.sort((a, b) => a.file.localeCompare(b.file) || a.name.localeCompare(b.name)),
+    unusedTypeExports: unusedTypeExports.sort((a, b) => a.file.localeCompare(b.file) || a.name.localeCompare(b.name)),
+    unusedRootScripts,
+    inlineScriptFiles: inlineScriptFiles.sort((a, b) => a.file.localeCompare(b.file)),
+  };
+}
+
+function mdEsc(s) { return String(s).replace(/\|/g, '\\|'); }
+
+function writeCssReport(css) {
+  const out = [];
+  out.push('# Unused CSS Classes Audit');
+  out.push('');
+  out.push(`Generated: ${new Date().toISOString()}`);
+  out.push('');
+  out.push('## How to read this');
+  out.push('');
+  out.push('Static heuristic scan of `src/static/styles/**/*.css`. **Review before deleting.**');
+  out.push('');
+  out.push('- A class is “unused” if its name never appears outside CSS (Astro/TS/JS/MD/MDX/HTML).');
+  out.push('- Dynamically built classes (`compute-meter-fill--${tone}`) are listed separately.');
+  out.push('- Animation-step / CSS-orchestrated modifiers may still be live even if unused in markup.');
+  out.push('- False positives: Alpine `x-bind:class`, server-injected HTML, content not in repo.');
+  out.push('');
+  out.push('## Summary');
+  out.push('');
+  out.push('| Metric | Count |');
+  out.push('| --- | ---: |');
+  out.push(`| CSS files scanned | ${css.cssFileCount} |`);
+  out.push(`| Custom class selectors | ${css.classCount} |`);
+  out.push(`| With non-CSS usage | ${css.usedCount} |`);
+  out.push(`| **Candidate unused** | **${css.unusedClasses.length}** |`);
+  out.push(`| Likely dynamic (keep) | ${css.dynamicLikely.length} |`);
+  out.push(`| Orphan CSS files | ${css.orphanCssFiles.length} |`);
+  out.push('');
+
+  out.push('## Detected dynamic class prefixes');
+  out.push('');
+  out.push('Found template/string patterns like `` `prefix${...}` `` in non-CSS sources:');
+  out.push('');
+  if (!css.dynamicPrefixes.length) out.push('_None._');
+  else for (const p of css.dynamicPrefixes) out.push(`- \`${p}\``);
+  out.push('');
+
+  out.push('## Possibly orphan CSS files');
+  out.push('');
+  if (!css.orphanCssFiles.length) out.push('_None detected._');
+  else {
+    out.push('| File | Reason | Review |');
+    out.push('| --- | --- | --- |');
+    for (const f of css.orphanCssFiles) out.push(`| \`${mdEsc(f.file)}\` | ${mdEsc(f.reason)} | [ ] |`);
+  }
+  out.push('');
+
+  out.push('## Likely dynamic classes (probably keep)');
+  out.push('');
+  out.push('No literal usage, but matches a dynamic prefix — usually still live.');
+  out.push('');
+  out.push('| Class | Defined in | Dynamic prefix | Review |');
+  out.push('| --- | --- | --- | --- |');
+  for (const c of css.dynamicLikely) {
+    out.push(`| \`.${mdEsc(c.className)}\` | \`${mdEsc(c.definedIn)}\` | \`${mdEsc(c.dynamicPrefix)}\` | [ ] |`);
+  }
+  out.push('');
+
+  // Group unused by file for easier review
+  out.push('## Candidate unused classes (by file)');
+  out.push('');
+  let current = '';
+  for (const c of css.unusedClasses) {
+    if (c.definedIn !== current) {
+      current = c.definedIn;
+      out.push(`### \`${current}\``);
+      out.push('');
+      out.push('| Class | Lines | Review | Notes |');
+      out.push('| --- | --- | --- | --- |');
+    }
+    out.push(`| \`.${mdEsc(c.className)}\` | ${c.lines.join(', ')} | [ ] | |`);
+  }
+  out.push('');
+  out.push('## Review checklist');
+  out.push('');
+  out.push('- [ ] `rg` the class name across `src/`');
+  out.push('- [ ] Check Alpine / `class:list` / string concatenation');
+  out.push('- [ ] Confirm parent CSS file is imported on live pages');
+  out.push('- [ ] Remove CSS + dead markup together');
+  out.push('');
+
+  const dest = path.join(ROOT, 'docs', 'UNUSED_CSS_AUDIT.md');
+  fs.writeFileSync(dest, out.join('\n'));
+  return dest;
+}
+
+function writeJsReport(js) {
+  const out = [];
+  out.push('# Unused JavaScript / TypeScript Audit');
+  out.push('');
+  out.push(`Generated: ${new Date().toISOString()}`);
+  out.push('');
+  out.push('## How to read this');
+  out.push('');
+  out.push('Static import/reference scan. **Review before deleting.**');
+  out.push('');
+  out.push('- Modules/components need an `import` / `from` / `import()` path hit (or Astro/MDX tag usage).');
+  out.push('- Pages under `src/pages` are routes and excluded from unused-module checks.');
+  out.push('- Type-only exports often look unused when only inferred — verify with `rg`.');
+  out.push('- Barrel-only Astro components (`@components/content`) are listed separately.');
+  out.push('');
+  out.push('## Summary');
+  out.push('');
+  out.push('| Metric | Count |');
+  out.push('| --- | ---: |');
+  out.push(`| Module candidates | ${js.moduleCandidateCount} |`);
+  out.push(`| Astro components | ${js.astroComponentCount} |`);
+  out.push(`| **Unused modules/scripts** | **${js.unusedModules.length}** |`);
+  out.push(`| **Unused Astro components** | **${js.unusedAstro.length}** |`);
+  out.push(`| Barrel-only Astro | ${js.barrelOnlyAstro.length} |`);
+  out.push(`| Unused value exports | ${js.unusedValueExports.length} |`);
+  out.push(`| Unused type/interface exports | ${js.unusedTypeExports.length} |`);
+  out.push(`| Unreferenced root scripts | ${js.unusedRootScripts.length} |`);
+  out.push(`| Astro files with \`<script>\` | ${js.inlineScriptFiles.length} |`);
+  out.push('');
+
+  out.push('## Candidate unused modules / client scripts');
+  out.push('');
+  if (!js.unusedModules.length) out.push('_None detected._');
+  else {
+    out.push('| File | Review | Notes |');
+    out.push('| --- | --- | --- |');
+    for (const m of js.unusedModules) out.push(`| \`${mdEsc(m.file)}\` | [ ] | ${mdEsc(m.note || '')} |`);
+  }
+  out.push('');
+
+  out.push('## Candidate unused Astro components');
+  out.push('');
+  if (!js.unusedAstro.length) out.push('_None detected._');
+  else {
+    out.push('| File | Review | Notes |');
+    out.push('| --- | --- | --- |');
+    for (const m of js.unusedAstro) out.push(`| \`${mdEsc(m.file)}\` | [ ] | |`);
+  }
+  out.push('');
+
+  out.push('## Barrel-only Astro components');
+  out.push('');
+  out.push('Imported via folder `index` barrel (likely used from MDX). Confirm before removing.');
+  out.push('');
+  if (!js.barrelOnlyAstro.length) out.push('_None._');
+  else {
+    out.push('| File | Via | Sample refs | Review |');
+    out.push('| --- | --- | --- | --- |');
+    for (const m of js.barrelOnlyAstro) {
+      out.push(`| \`${mdEsc(m.file)}\` | ${mdEsc(m.note)} | ${m.sampleRefs.map((x) => `\`${x}\``).join(', ')} | [ ] |`);
+    }
+  }
+  out.push('');
+
+  out.push('## Candidate unused value exports (functions/const/class)');
+  out.push('');
+  out.push('| Export | File | Review |');
+  out.push('| --- | --- | --- |');
+  for (const e of js.unusedValueExports) {
+    out.push(`| \`${mdEsc(e.name)}\` | \`${mdEsc(e.file)}\` | [ ] |`);
+  }
+  out.push('');
+
+  out.push('## Candidate unused type / interface exports');
+  out.push('');
+  out.push('Higher false-positive rate — types may only be used via inference or `import type` in ways the scanner missed.');
+  out.push('');
+  out.push('| Export | File | Review |');
+  out.push('| --- | --- | --- |');
+  for (const e of js.unusedTypeExports) {
+    out.push(`| \`${mdEsc(e.name)}\` | \`${mdEsc(e.file)}\` | [ ] |`);
+  }
+  out.push('');
+
+  out.push('## Root `scripts/` not referenced');
+  out.push('');
+  if (!js.unusedRootScripts.length) out.push('_None detected._');
+  else {
+    out.push('| File | Note | Review |');
+    out.push('| --- | --- | --- |');
+    for (const s of js.unusedRootScripts) out.push(`| \`${mdEsc(s.file)}\` | ${mdEsc(s.note)} | [ ] |`);
+  }
+  out.push('');
+
+  out.push('## Client scripts (known wiring)');
+  out.push('');
+  out.push('| Script | Expected entry | Review |');
+  out.push('| --- | --- | --- |');
+  out.push('| `src/static/scripts/scroll-effects.js` | Layout / LayoutMinimal / LayoutSimple | [ ] |');
+  out.push('| `src/static/scripts/module-animate.js` | Layout.astro | [ ] |');
+  out.push('| `src/static/scripts/error-tracker.js` | 404.astro | [ ] |');
+  out.push('');
+
+  out.push('## Astro files containing `<script>` (manual review of inline JS)');
+  out.push('');
+  out.push('Not “unused” — inventory of client/inline JS surfaces.');
+  out.push('');
+  out.push('| File | `<script>` tags | Review |');
+  out.push('| --- | ---: | --- |');
+  for (const f of js.inlineScriptFiles) {
+    out.push(`| \`${mdEsc(f.file)}\` | ${f.scriptTags} | [ ] |`);
+  }
+  out.push('');
+
+  out.push('## Review checklist');
+  out.push('');
+  out.push('- [ ] Confirm no dynamic `import()` / string path');
+  out.push('- [ ] Check `server.mjs` and API routes');
+  out.push('- [ ] For Astro, search MDX content + relative `./X.astro` imports');
+  out.push('- [ ] For types, try removing and run `npm run typecheck`');
+  out.push('');
+
+  const dest = path.join(ROOT, 'docs', 'UNUSED_JS_AUDIT.md');
+  fs.writeFileSync(dest, out.join('\n'));
+  return dest;
+}
+
+console.log('Loading corpus...');
+const corpus = loadCorpus();
+console.log(`Corpus files: ${corpus.size}`);
+console.log('Analyzing CSS...');
+const css = analyzeCss(corpus);
+console.log('Analyzing JS/TS...');
+const js = analyzeJs(corpus);
+const cssPath = writeCssReport(css);
+const jsPath = writeJsReport(js);
+console.log('Wrote', cssPath);
+console.log('Wrote', jsPath);
+console.log(JSON.stringify({
+  unusedCss: css.unusedClasses.length,
+  dynamicCss: css.dynamicLikely.length,
+  orphanCss: css.orphanCssFiles.length,
+  unusedModules: js.unusedModules.length,
+  unusedAstro: js.unusedAstro.length,
+  barrelAstro: js.barrelOnlyAstro.length,
+  unusedValues: js.unusedValueExports.length,
+  unusedTypes: js.unusedTypeExports.length,
+  inlineScripts: js.inlineScriptFiles.length,
+}, null, 2));

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -35,8 +35,9 @@ import NavMenu from '@components/NavMenu.astro';
         target="_blank"
         data-rybbit-event="Nav: Start for free"
       >
+        {/* Mobile shows "Start"; sr-only keeps full text for SEO/a11y (Lighthouse). */}
+        <span class="inline-flex lg:hidden">Start<span class="sr-only"> for free</span></span>
         <span class="hidden lg:inline-flex">Start for free</span>
-        <span class="inline-flex lg:hidden">Start</span>
         <Icon name="arrow-right" size="md" class="hidden lg:inline-flex" />
       </a>
     </div>

--- a/src/components/compute/Performance.astro
+++ b/src/components/compute/Performance.astro
@@ -21,67 +21,69 @@ const { chart } = performance;
 
     <SectionLine left right top bottom />
 
-    <div class="max-width-nopad grid grid-cols-1 items-start gap-10 lg:grid-cols-2 lg:gap-20">
-      <div class="relative">
-        <SectionLine left top extended />
-        <div class="compute-meter-card">
-          <p class="compute-meter-title">{chart.title}</p>
+    <div class="max-width-nopad spacing-pad">
+      <div class="grid grid-cols-1 items-start gap-10 lg:grid-cols-2 lg:gap-20">
+        <div class="relative">
+          <SectionLine left top extended />
+          <div class="compute-meter-card">
+            <p class="compute-meter-title">{chart.title}</p>
 
-          {
-            /* Observed as one list, not per row, so the staggered reveal starts
-            together instead of drifting with each row's own scroll position. */
-          }
-          <ul class="compute-meter-list" data-meter-reveal>
             {
-              chart.bars.map((bar) => (
-                <li class="compute-meter-item">
-                  <div class="compute-meter-head">
-                    <span class="compute-meter-label">{bar.label}</span>
-                    <span class="compute-meter-value">{bar.value}</span>
-                  </div>
-                  {/* The bar is illustrative — the figure beside the label is
+              /* Observed as one list, not per row, so the staggered reveal starts
+            together instead of drifting with each row's own scroll position. */
+            }
+            <ul class="compute-meter-list" data-meter-reveal>
+              {
+                chart.bars.map((bar) => (
+                  <li class="compute-meter-item">
+                    <div class="compute-meter-head">
+                      <span class="compute-meter-label">{bar.label}</span>
+                      <span class="compute-meter-value">{bar.value}</span>
+                    </div>
+                    {/* The bar is illustrative — the figure beside the label is
                     what carries the meaning — so it stays out of the a11y tree.
                     Only the datum travels inline; the width rule lives in CSS. */}
-                  <div class="compute-meter-track" aria-hidden="true">
-                    <span
-                      class:list={['compute-meter-fill', `compute-meter-fill--${bar.tone}`]}
-                      style={`--compute-meter-fill: ${bar.fill}%; --compute-meter-duration: ${bar.durationMs}ms`}
-                    />
-                  </div>
+                    <div class="compute-meter-track" aria-hidden="true">
+                      <span
+                        class:list={['compute-meter-fill', `compute-meter-fill--${bar.tone}`]}
+                        style={`--compute-meter-fill: ${bar.fill}%; --compute-meter-duration: ${bar.durationMs}ms`}
+                      />
+                    </div>
+                  </li>
+                ))
+              }
+            </ul>
+
+            <p class="compute-meter-caption">{chart.caption}</p>
+          </div>
+        </div>
+
+        <div class="flex flex-col items-start gap-8">
+          <h2 class="datum-text-8xl text-midnight-fjord text-pretty">{performance.title}</h2>
+          <p class="datum-text-xl text-app---dark---utility-2/80 text-pretty">
+            {performance.description}
+          </p>
+
+          <ul class="compute-check-list">
+            {
+              performance.points.map((point) => (
+                <li class="compute-check-item">
+                  <Icon name="check" size="lg" class="compute-check-icon" />
+                  <span class="compute-check-text">{point}</span>
                 </li>
               ))
             }
           </ul>
 
-          <p class="compute-meter-caption">{chart.caption}</p>
+          <Button
+            class="btn btn--midnight-fjord"
+            text={performance.cta.text}
+            href={performance.cta.href}
+            icon={{ name: 'arrow-right', size: 'md' }}
+            target="_blank"
+            data-rybbit-event="Compute: Try Datum Compute (performance)"
+          />
         </div>
-      </div>
-
-      <div class="flex flex-col items-start gap-8">
-        <h2 class="datum-text-8xl text-midnight-fjord text-pretty">{performance.title}</h2>
-        <p class="datum-text-xl text-app---dark---utility-2/80 text-pretty">
-          {performance.description}
-        </p>
-
-        <ul class="compute-check-list">
-          {
-            performance.points.map((point) => (
-              <li class="compute-check-item">
-                <Icon name="check" size="lg" class="compute-check-icon" />
-                <span class="compute-check-text">{point}</span>
-              </li>
-            ))
-          }
-        </ul>
-
-        <Button
-          class="btn btn--midnight-fjord"
-          text={performance.cta.text}
-          href={performance.cta.href}
-          icon={{ name: 'arrow-right', size: 'md' }}
-          target="_blank"
-          data-rybbit-event="Compute: Try Datum Compute (performance)"
-        />
       </div>
     </div>
   </div>


### PR DESCRIPTION
Silence astro-mermaid client logs, tighten compute Performance spacing, and add unused CSS/JS audit docs for manual review.