### PR TITLE
fix(legal): make On This Page toggle visibly clickable

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,6 +1,5 @@
 ---
 import type { MarkdownHeading } from 'astro';
-import { PanelRightClose } from '@lucide/astro';
 
 const {
   headings = [] as MarkdownHeading[],
@@ -40,8 +39,22 @@ if (collapsible) {
       {showTitle &&
         (panelCollapsible ? (
           <button type="button" class="toc-panel-toggle toc-pill-toggle" aria-expanded="true">
-            <PanelRightClose class="toc-panel-icon" width={14} height={14} aria-hidden="true" />
             <h3 class="toc-title">{title}</h3>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="toc-panel-chevron"
+              aria-hidden="true"
+            >
+              <path d="m9 18 6-6-6-6" />
+            </svg>
           </button>
         ) : (
           <h3 class="toc-title">{title}</h3>

--- a/src/pages/legal/[slug].astro
+++ b/src/pages/legal/[slug].astro
@@ -5,7 +5,6 @@ import Hero from '@components/Hero.astro';
 import Footer from '@components/Footer.astro';
 import Sidebar from '@components/legal/Sidebar.astro';
 import TableOfContents from '@components/TableOfContents.astro';
-import { PanelRightOpen } from '@lucide/astro';
 import { getCollection, render } from 'astro:content';
 import type { LegalNavItem } from '@/src/types/common';
 
@@ -68,8 +67,22 @@ const navItems: LegalNavItem[] = sortedLegal.map((entry) => ({
                 hidden
                 aria-label="Show On This Page"
               >
-                <PanelRightOpen class="toc-panel-icon" width={14} height={14} aria-hidden="true" />
                 On This Page
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="toc-panel-chevron"
+                  aria-hidden="true"
+                >
+                  <path d="m9 18 6-6-6-6"></path>
+                </svg>
               </button>
             </div>
 

--- a/src/static/styles/components.css
+++ b/src/static/styles/components.css
@@ -667,18 +667,40 @@
   /* Shared pill-toggle look — reused by both the TOC's own panel-toggle
      button below and the page-level reopen button that replaces it when
      collapsed (.legal-toc-reopen in page-legal.css carries this class too),
-     so the two states can't visually drift apart from each other again. */
+     so the two states can't visually drift apart from each other again.
+     shadow-sm + a visible hover background were added after user testing
+     showed people didn't realize this pill was clickable at all — a flat
+     bg-white pill with a thin border reads as a label, not a button. */
   .toc-pill-toggle {
-    @apply border-glacier-mist-900 mb-6 inline-flex cursor-pointer items-center gap-1.5 rounded-full border bg-white px-3 py-1.5 transition-colors duration-150;
+    @apply border-glacier-mist-900 hover:bg-glacier-mist-800 mb-6 inline-flex cursor-pointer items-center gap-1.5 rounded-full border bg-white px-3 py-1.5 shadow-sm transition-colors duration-150;
   }
 
-  /* Sizes the icon in EITHER pill-toggle button — .toc-panel-icon on its own,
-     not scoped to .toc-panel-toggle specifically, since .legal-toc-reopen
-     (page-legal.css) carries the same icon class but not that parent class.
-     Without this unscoped rule, that icon fell back to Lucide's 24x24
-     default and overflowed the pill's padding. */
-  .toc-panel-icon {
-    @apply h-3.5 w-3.5 shrink-0;
+  /* Sizes the chevron in EITHER pill-toggle button — .toc-panel-chevron on
+     its own, not scoped to .toc-panel-toggle specifically, since
+     .legal-toc-reopen (page-legal.css) carries the same chevron class but
+     not that parent class. Without this unscoped rule, an icon here fell
+     back to a much larger default size and overflowed the pill's padding.
+
+     This is the exact same chevron markup/rotation convention as
+     .toc-group-chevron below — deliberately, not coincidentally: the panel
+     toggle used to have its own distinct "panel" icon, and testers didn't
+     recognize it as clickable because it didn't look like the (already
+     understood) per-section chevrons. Reusing the identical glyph and
+     rotation direction makes both controls read as "the same kind of
+     thing" at a glance. */
+  .toc-panel-chevron {
+    @apply h-3.5 w-3.5 shrink-0 transition-transform duration-200 ease-out;
+  }
+
+  /* Base above defaults to un-rotated (pointing right, "closed") — matching
+     a freshly-collapsed .toc-group's chevron, and correct as-is for
+     .legal-toc-reopen (page-legal.css), which is only ever shown while
+     collapsed. .toc-panel-toggle (shown state) starts aria-expanded="true"
+     and needs the opposite default, so it gets its own rotated override
+     instead of relying on an un-rotate override that would never match a
+     chevron outside .toc-panel-toggle entirely. */
+  .toc-panel-toggle[aria-expanded='true'] .toc-panel-chevron {
+    @apply rotate-90;
   }
 
   /* Whole-panel collapse (opt-in via the `panelCollapsible` prop) — hides the


### PR DESCRIPTION
## Summary

User testing (a dozen testers) found nobody noticed the "On This Page" pill on `/legal/*` pages was a toggle button at all — it used a distinct "panel" icon that didn't visually match the per-section chevrons already on the page, so it read as a static label rather than an interactive control.

## Changes

- Replaced the panel icon with the exact same chevron glyph and rotation convention `.toc-group-chevron` already uses for per-section toggles: pointing down = expanded/click-to-collapse, pointing right = collapsed/click-to-expand. Same interaction language the user has already learned from the list below, now applied consistently to the panel-level control too.
- Added `shadow-sm` and a visible hover background to the pill so it reads as a raised button, not a flat text badge.

## Test plan

- [x] `npx astro check` — 0 errors
- [x] Verified both toggle states' actual computed `rotate` CSS property via a fresh Playwright session (not just visual inspection) — shown state: `90deg`, hidden/reopen state: `none` (0deg) — confirmed a real bug (rotation defaults were backwards) before it shipped
- [x] Confirmed hover background and shadow render correctly in both states
- [ ] Confirm with the original dozen testers (or a fresh round) that the toggle is now noticeably clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
