### PR TITLE
fix: widen page containers and reorganize footer nav

### DIFF
--- a/src/components/Container.astro
+++ b/src/components/Container.astro
@@ -7,7 +7,7 @@ import type { ContainerProps } from '@/src/types/common';
 const { class: className = '', tag = 'div' } = Astro.props as ContainerProps;
 
 // Default container classes
-const defaultClasses = 'm-auto max-w-3xl';
+const defaultClasses = 'm-auto';
 const containerClasses = className ? `${defaultClasses} ${className}` : defaultClasses;
 
 // Determine the HTML tag to use

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -169,35 +169,25 @@ const [platformSection, resourcesSection, companySection] = navData.footer;
 
           {
             resourcesSection && (
-              <div class="footer-nav-section footer-nav-section--stacked">
-                <div class="footer-nav-group">
-                  <p class="footer-nav-header">{resourcesSection.title}</p>
-                  <ul class="footer-nav-list">
-                    {resourcesSection.items.map((item: NavItem) => (
-                      <li>
-                        <a
-                          href={item.href}
-                          class="footer-nav-link"
-                          target={item.isExternal ? '_blank' : undefined}
-                          rel={item.isExternal ? 'noopener noreferrer' : undefined}
-                          data-astro-prefetch="hover"
-                          title={item.text}
-                          tabindex="0"
-                        >
-                          {item.text}
-                        </a>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-
-                <div class="footer-nav-group">
-                  <p class="footer-nav-header">Status</p>
-                  <div
-                    id="hyperping-badge"
-                    class="footer-status-badge datum-docs-sidebar-headings text-glacier-mist-700 [&>div]:bg-logo-object/15 min-w-[140px] normal-case [&>div]:rounded-md [&>div]:px-2 [&>div]:py-1"
-                  />
-                </div>
+              <div class="footer-nav-section">
+                <p class="footer-nav-header">{resourcesSection.title}</p>
+                <ul class="footer-nav-list">
+                  {resourcesSection.items.map((item: NavItem) => (
+                    <li>
+                      <a
+                        href={item.href}
+                        class="footer-nav-link"
+                        target={item.isExternal ? '_blank' : undefined}
+                        rel={item.isExternal ? 'noopener noreferrer' : undefined}
+                        data-astro-prefetch="hover"
+                        title={item.text}
+                        tabindex="0"
+                      >
+                        {item.text}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
               </div>
             )
           }
@@ -227,6 +217,15 @@ const [platformSection, resourcesSection, companySection] = navData.footer;
               </div>
             )
           }
+
+          <div class="footer-nav-section">
+            <p class="footer-nav-header">Status</p>
+            <div
+              id="hyperping-badge"
+              class="footer-status-badge datum-docs-sidebar-headings text-glacier-mist-700 [&>div]:bg-logo-object/15 min-w-[140px] normal-case [&>div]:rounded-md [&>div]:px-2 [&>div]:py-1"
+            >
+            </div>
+          </div>
         </div>
       </div>
 

--- a/src/components/handbook/Article.astro
+++ b/src/components/handbook/Article.astro
@@ -111,12 +111,12 @@ handbooks.forEach((collection) => {
 
 <section
   class:list={[
-    'handbook-article bg-glacier-mist-700 section--block border-glacier-mist-900 overflow-visible border-b',
+    'handbook-article bg-glacier-mist-700 section--block section--block--small-pad border-glacier-mist-900 overflow-visible border-b',
     className,
   ]}
   id="handbook-article-container"
 >
-  <div class="max-width">
+  <div class="max-width-full">
     <div class:list={['handbook-container', !showSidebar && 'handbook-container--no-sidebar']}>
       {showSidebar && <Sidebar selectedId={articleId} items={items} />}
 

--- a/src/pages/legal/[slug].astro
+++ b/src/pages/legal/[slug].astro
@@ -55,7 +55,7 @@ const navItems: LegalNavItem[] = sortedLegal.map((entry) => ({
     />
 
     <div class="section--block section--block--small-pad bg-glacier-mist-700">
-      <div class="max-width">
+      <div class="max-width-full">
         <div class="legal-layout">
           <Sidebar items={navItems} currentId={page.id} />
 

--- a/src/static/styles/components.css
+++ b/src/static/styles/components.css
@@ -289,7 +289,7 @@
   }
 
   .footer-main {
-    @apply max-width bg-midnight-fjord relative z-10 mx-auto flex flex-col gap-10 py-14 lg:py-20;
+    @apply max-width-full bg-midnight-fjord relative z-10 mx-auto flex flex-col gap-10 py-14 lg:py-20;
   }
 
   .footer-grid {
@@ -329,19 +329,11 @@
   }
 
   .footer-nav-container {
-    @apply flex w-full flex-1 flex-col gap-10 sm:flex-row sm:flex-wrap sm:justify-between lg:gap-20;
+    @apply grid w-full flex-1 grid-cols-2 gap-10 sm:flex sm:flex-row sm:flex-wrap sm:justify-between lg:gap-20;
   }
 
   .footer-nav-section {
-    @apply w-full sm:w-auto sm:min-w-36 sm:flex-1;
-  }
-
-  .footer-nav-section--stacked {
-    @apply flex flex-col gap-10;
-  }
-
-  .footer-nav-group {
-    @apply flex flex-col;
+    @apply min-w-0 sm:w-auto sm:min-w-36 sm:flex-1;
   }
 
   .footer-status-badge {

--- a/src/static/styles/utilities.css
+++ b/src/static/styles/utilities.css
@@ -30,6 +30,10 @@
   @apply max-w-8xl mx-auto w-full px-7;
 }
 
+@utility max-width-full {
+  @apply mx-auto w-full max-w-(--datum-max-width-nav) px-7;
+}
+
 @utility max-width-nopad {
   @apply max-w-8xl mx-auto w-full;
 }


### PR DESCRIPTION
Expand handbook, legal, and footer layouts to max-width-full so content aligns with the wider nav container. Remove the default max-w-3xl from Container and add a max-width-full utility.

Reorganize footer navigation with Status as the rightmost column and a two-column grid layout on mobile.