### PR TITLE
fix(toc): widen content when hidden + dedicated-cloud Operators update

### DIFF
--- a/src/components/handbook/Article.astro
+++ b/src/components/handbook/Article.astro
@@ -122,6 +122,32 @@ handbooks.forEach((collection) => {
 
       {/* Main Content Area */}
       <article class="handbook-content">
+        <div class="handbook-toc-reopen-row">
+          <button
+            type="button"
+            class="handbook-toc-reopen toc-pill-toggle"
+            hidden
+            aria-label="Show On This Page"
+          >
+            On This Page
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="toc-panel-chevron"
+              aria-hidden="true"
+            >
+              <path d="m9 18 6-6-6-6"></path>
+            </svg>
+          </button>
+        </div>
+
         {
           showTitle && (
             <header class="article-header">
@@ -167,7 +193,14 @@ handbooks.forEach((collection) => {
       </article>
 
       <aside class="handbook-toc">
-        <TableOfContents headings={headings} title="On This Page" showTitle={true} sticky={true} />
+        <TableOfContents
+          headings={headings}
+          title="On This Page"
+          showTitle={true}
+          sticky={true}
+          collapsible={true}
+          panelCollapsible={true}
+        />
       </aside>
     </div>
   </div>
@@ -200,6 +233,26 @@ handbooks.forEach((collection) => {
         `;
 
         heading.appendChild(anchorLink);
+      });
+    }
+
+    // Wire the reopen button to the TOC panel's own toggle events — same
+    // contract as the legal pages' equivalent in [slug].astro. Hiding the
+    // whole column (not just the nav inside it) lets .handbook-content's
+    // own flex-grow reclaim that width.
+    const wrapper = document.querySelector<HTMLElement>('.handbook-toc');
+    const reopenButton = document.querySelector<HTMLButtonElement>('.handbook-toc-reopen');
+    if (wrapper && reopenButton) {
+      window.addEventListener('datum:toc-panel-toggle', (event) => {
+        const collapsed = (event as CustomEvent<{ collapsed: boolean }>).detail?.collapsed ?? false;
+        wrapper.classList.toggle('is-hidden', collapsed);
+        reopenButton.hidden = !collapsed;
+      });
+
+      reopenButton.addEventListener('click', () => {
+        wrapper.classList.remove('is-hidden');
+        reopenButton.hidden = true;
+        window.dispatchEvent(new CustomEvent('datum:toc-panel-show'));
       });
     }
   });

--- a/src/data/dedicatedCloud.ts
+++ b/src/data/dedicatedCloud.ts
@@ -119,6 +119,13 @@ export const operators = {
       slug: 'zachary-smith',
     },
     {
+      name: 'Megan O’Conner',
+      role: 'Chief of Staff & Strategic Accounts',
+      bio: 'Turns complex infrastructure into clear, human-led paths to what’s next for our biggest accounts.',
+      slug: 'megan-oconner',
+      linkedin: 'https://www.linkedin.com/in/meganoconnorco/',
+    },
+    {
       name: 'Shelby Lindsey',
       role: 'Lead Network Engineer',
       bio: 'A physical networking guru who oversees our backbone, peering, and edge fabrics.',

--- a/src/static/styles/components-handbook.css
+++ b/src/static/styles/components-handbook.css
@@ -11,7 +11,9 @@
   /* Main Content */
 
   .handbook-content {
-    @apply flex max-w-none grow flex-col;
+    /* order-3 pairs with .handbook-sidebar's order-1 and .handbook-toc's
+       order-2 below — see the comment on .handbook-toc for why. */
+    @apply order-3 flex max-w-none grow flex-col md:order-none;
 
     @apply p-9 pr-0 pl-0 md:p-12 md:pr-10 md:pl-10 lg:p-16;
   }
@@ -86,7 +88,15 @@
   }
 
   .handbook-toc {
-    @apply relative hidden w-full flex-col gap-y-4 md:max-w-53.25 md:min-w-53.25 lg:flex;
+    /* Visible at every breakpoint (not just lg+) — below lg it renders as
+       the same collapsed-by-default dropdown pattern the legal pages'
+       equivalent uses, via TableOfContents.astro's own matchMedia check,
+       rather than disappearing entirely on mobile/tablet. order-2 puts it
+       right after the sidebar when .handbook-container is stacked (below
+       md) instead of after all the article content where DOM order would
+       otherwise land it. md:order-none restores normal left-to-right order
+       (sidebar, content, toc) once the columns sit side by side. */
+    @apply relative order-2 flex w-full flex-col gap-y-4 md:order-none md:max-w-53.25 md:min-w-53.25;
     @apply pt-9 md:pt-12 lg:pt-16;
     @apply pr-0 md:pl-4 lg:pl-7;
 
@@ -103,7 +113,12 @@
   }
 
   .handbook-toc .toc-container {
-    @apply top-9!;
+    /* Below lg: static/visible, matching the sidebar's own mobile toggle —
+       it's a collapsed dropdown that scrolls with the page, not a side
+       column, so sticking it and clipping its height would be wrong there
+       (same reasoning as the legal pages' equivalent rule). At lg+: sticky
+       + capped height + scrolls internally. */
+    @apply static! max-h-none! overflow-visible! lg:sticky! lg:top-9! lg:max-h-[calc(100vh-5rem)]! lg:overflow-y-auto!;
   }
 
   .handbook-toc-reopen-row {
@@ -129,7 +144,9 @@
   }
 
   .handbook-sidebar {
-    @apply relative w-full flex-col gap-y-0 md:max-w-55 md:min-w-55 md:gap-y-4 lg:max-w-64.75 lg:min-w-64.75;
+    /* order-1 pairs with .handbook-toc's order-2 and .handbook-content's
+       order-3 above — see the comment on .handbook-toc for why. */
+    @apply relative order-1 w-full flex-col gap-y-0 md:order-none md:max-w-55 md:min-w-55 md:gap-y-4 lg:max-w-64.75 lg:min-w-64.75;
     @apply px-7 pt-5 pl-0 md:px-0 md:pt-12 lg:pt-16;
     @apply pr-0 md:pr-4 lg:pr-7;
     @apply flex md:flex;

--- a/src/static/styles/components-handbook.css
+++ b/src/static/styles/components-handbook.css
@@ -93,10 +93,39 @@
     .article-aside {
       @apply mb-6;
     }
+
+    /* Hiding the whole column (not just its nav) lets .handbook-content's
+       flex-grow reclaim the width. Toggled from the script at the bottom of
+       Article.astro in response to the TOC's own panel-toggle button. */
+    &.is-hidden {
+      @apply lg:hidden!;
+    }
   }
 
   .handbook-toc .toc-container {
     @apply top-9!;
+  }
+
+  .handbook-toc-reopen-row {
+    /* top-9 matches the TOC's own sticky offset, so the reopen affordance
+       stays reachable at the same scroll position the panel would occupy. */
+    @apply sticky top-9 z-10 hidden lg:block;
+  }
+
+  /* left: calc(100% - 7.5625rem) lands the button's left edge exactly where
+     the TOC's own toggle sits — confirmed empirically via getBoundingClientRect
+     on both states, not derived from the column-width math (same lesson as
+     the legal-page equivalent: that math kept missing real padding
+     contributions). 7.5625rem here vs. 7.0625rem for legal's version — the
+     0.5rem difference is .legal-toc .toc-container's extra pl-2 (added there
+     for the active-dot indicator), which .handbook-toc doesn't have.
+     w-max is required, not cosmetic: shrink-to-fit sizing for an absolutely
+     positioned element with only `left` set uses "available space" as its
+     width ceiling, not natural content width, which silently wraps the text
+     otherwise. */
+  .handbook-toc-reopen {
+    @apply datum-text-xs text-midnight-fjord/60 hover:text-midnight-fjord absolute w-max font-medium;
+    left: calc(100% - 7.5625rem);
   }
 
   .handbook-sidebar {

--- a/src/static/styles/page-legal.css
+++ b/src/static/styles/page-legal.css
@@ -150,6 +150,20 @@
   .legal-content {
     @apply order-3 flex-1 px-0 pt-9 pb-0 md:order-none md:px-10 md:pt-12 lg:px-16 lg:pt-16;
 
+    /* Widen the article's own reading measure when the TOC column is
+       hidden — otherwise hiding it only grows .legal-content's outer box
+       (flex-1 reclaiming the freed width), while the <article> inside
+       stays capped at its own max-w-4xl (set per-page via the Container
+       component in each .mdx file) and never visibly uses the extra
+       space. :has() reaches "backward" to .legal-toc — a later sibling in
+       the DOM — since a forward-only combinator (~) can't select .legal-content
+       from something that comes after it. Specificity here (two classes +
+       :has() + an element type) intentionally beats the single-class
+       max-w-4xl utility set inline per-page. */
+    &:has(~ .legal-toc.is-hidden) article {
+      @apply max-w-6xl!;
+    }
+
     table {
       @apply my-6 w-full border-separate;
       @apply bg-glacier-mist-900;


### PR DESCRIPTION
## Summary

Three separate fixes/features bundled on one branch:

1. **Legal pages: content didn't widen when TOC hidden** — `.legal-content`'s outer box correctly grew via `flex-1` when the "On This Page" panel was collapsed, but the `<article>` inside stayed capped at `max-w-4xl` (set per-page via `Container`), so the reclaimed width went unused. Added `.legal-content:has(~ .legal-toc.is-hidden) article { max-w-6xl }` to widen the article once the TOC is hidden.
2. **Handbook pages: same TOC collapse/reopen behavior as legal** — ported the panel-toggle, reopen-pill, and width-reclaim pattern from legal pages to `Article.astro` / `components-handbook.css` for parity (e.g. `/handbook/product`).
3. **Dedicated Cloud: Operators section update** — added Megan O'Conner (Chief of Staff & Strategic Accounts) between Zac and Shelby, and switched Zac Smith's avatar to the `glacier-mist` color variant (Shelby and Scot were already on it). Megan's Strapi avatar is still `pine-forge` — no `glacier-mist` variant exists for her yet, so her photo isn't fully consistent with the other three until one is generated and uploaded.

## Test plan

- [x] `npx astro check` — 0 errors
- [x] Verified article width expands (784px→997px) when TOC hidden on `/legal/terms`, confirmed via Playwright bounding-box measurement
- [x] Verified same width-reclaim behavior on `/handbook/product`
- [x] Confirmed Zac's avatar now serves the `glacier-mist` file (`zachary_smith_glacier_mist_*.png`) via curl against the live dev server
- [x] Confirmed Megan renders on `/dedicated-cloud` in the Zac → Megan → Shelby → Scot order
- [ ] Generate/upload a `glacier-mist` avatar variant for Megan O'Conner (follow-up, not blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
