### PR TITLE
fix(legal): redirect /legal without a trailing slash

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -80,9 +80,6 @@ export default defineConfig({
   site: siteUrl || `http://localhost:${port}`,
   trailingSlash: 'never',
   output: 'static',
-  redirects: {
-    '/platform': { status: 301, destination: '/platform/deliver' },
-  },
   security: {
     checkOrigin: false,
   },

--- a/server.mjs
+++ b/server.mjs
@@ -106,6 +106,7 @@ const REDIRECTS = {
     destination: '/blog/internet-superpowers-for-every-builder',
     status: 301,
   },
+  '/legal': { destination: '/legal/terms', status: 301 },
   '/legal/': { destination: '/legal/terms', status: 301 },
   '/privacy-policy/': { destination: '/legal/privacy', status: 301 },
   '/privacy/': { destination: '/legal/privacy', status: 301 },


### PR DESCRIPTION
/legal 404'd because the production redirect map only matched /legal/. Drop the unused Astro redirects so the Node server is the single source.