### PR TITLE
fix(dedicated-cloud): decouple Operators avatar color from /about's index scheme

### DIFF
--- a/src/components/dedicated-cloud/Operators.astro
+++ b/src/components/dedicated-cloud/Operators.astro
@@ -42,7 +42,11 @@ const people = await Promise.all(
     const author = await fetchStrapiAuthorBySlug(person.slug);
     return {
       ...person,
-      avatarUrl: author?.avatar ? getStrapiMediaUrl(author.avatar.url) : null,
+      avatarUrl: person.avatarOverrideUrl
+        ? getStrapiMediaUrl(person.avatarOverrideUrl)
+        : author?.avatar
+          ? getStrapiMediaUrl(author.avatar.url)
+          : null,
       linkedinUrl: person.linkedin ?? author?.social?.linkedin ?? null,
       bgClass: AVATAR_BG[index % AVATAR_BG.length],
     };

--- a/src/data/dedicatedCloud.ts
+++ b/src/data/dedicatedCloud.ts
@@ -107,6 +107,13 @@ export interface Operator {
   slug: string;
   /** Override when the Strapi author record doesn't have `social.linkedin` set. */
   linkedin?: string;
+  /**
+   * Override when this operator's `/about` avatar color (assigned by array index there)
+   * doesn't match the glacier-mist scheme this section standardized on. Points at the
+   * person's glacier-mist variant directly so the two pages can show different color
+   * variants of the same headshot without fighting over one shared Strapi `avatar` field.
+   */
+  avatarOverrideUrl?: string;
 }
 
 export const operators = {
@@ -117,6 +124,8 @@ export const operators = {
       role: 'Co-Founder, CEO',
       bio: 'Twenty years building bare metal and interconnected infrastructure for demanding customers.',
       slug: 'zachary-smith',
+      avatarOverrideUrl:
+        'https://grateful-excitement-dfe9d47bad.media.strapiapp.com/zachary_smith_glacier_mist_b7a391652b.png',
     },
     {
       name: 'Megan O’Conner',
@@ -138,6 +147,8 @@ export const operators = {
       bio: 'Leads the platform and orchestration layers that provide the reliability and creature comforts of our cloud.',
       slug: 'scot-wells',
       linkedin: 'https://www.linkedin.com/in/scot-wells/',
+      avatarOverrideUrl:
+        'https://grateful-excitement-dfe9d47bad.media.strapiapp.com/scot_wells_glacier_mist_c4f150a7a9.png',
     },
   ] satisfies Operator[],
 };


### PR DESCRIPTION
## Summary

Fixes team headshot / background-color mismatches on `/about`, and resolves the resulting conflict with the `/dedicated-cloud` Operators section.

### Root cause

`/about` assigns each team member's card background color by their **array index** (`pine-forge → canyon-clay → glacier-mist`, repeating) — not a stored field. Adding Megan O'Conner to the roster shifted everyone from Silvia Olivares onward by one position, leaving their already-uploaded avatar files one color out of sync with their new expected color.

### Strapi content fixes (no code involved, applied via `scripts/add-team-avatar.mjs`)

Relinked avatars to the correct color variant for: Costello, Flores, Savanovich, Olivares, Raines, Schuchert-Wells, Manish, Smyser, Sprygada, Szychowski, Vetere, Widjaja, Williams, O'Conner, and Zac Smith. These take effect via Strapi's cache-invalidation webhook.

### Code fix (this PR)

Zac Smith and Scot Schuchert-Wells need **different** color variants on the two pages — pine-forge on `/about` (their index-correct color) vs. glacier-mist on Operators (this section's standardized look) — but both pages previously read from one shared Strapi `avatar` field, so only one page could be correct at a time.

Added `avatarOverrideUrl` to the `Operator` type (`src/data/dedicatedCloud.ts`), pointing Zac and Scot's Operators-section avatar at their glacier-mist file directly. `Operators.astro` now prefers this override before falling back to the shared Strapi avatar, so both pages can be correct simultaneously without fighting over one field.

## Test plan

- [x] `astro check` — 0 errors
- [x] Verified via direct Strapi data query: all 26 team members now show their index-correct color on `/about`
- [x] Verified `/dedicated-cloud` still renders all four operators (Zac, Megan, Shelby, Scot) in glacier-mist
- [ ] Visual smoke-test on preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbXXnh72PBLDTytG92XVTM
