### PR TITLE
fix(pricing): clip hero starfield and style panel corner lines

### DIFF
--- a/src/components/pricing/Hero.astro
+++ b/src/components/pricing/Hero.astro
@@ -34,17 +34,11 @@ import { hero, callout } from '@data/pricing';
       </div>
 
       <div class="pricing-hero-panel">
-        <Image
-          src={starfieldImage}
-          alt=""
-          class="pricing-hero-panel-starfield"
-          aria-hidden="true"
-          loading="eager"
-        />
-        <span class="pricing-hero-panel-tile pricing-hero-panel-tile--top" aria-hidden="true"
-        ></span>
-        <span class="pricing-hero-panel-tile pricing-hero-panel-tile--bottom" aria-hidden="true"
-        ></span>
+        <SectionLine left top overlap class="bg-midnight-fjord" />
+
+        <div class="pricing-hero-panel-starfield-wrap" aria-hidden="true">
+          <Image src={starfieldImage} alt="" class="pricing-hero-panel-starfield" loading="eager" />
+        </div>
 
         <div class="pricing-hero-panel-body">
           <p class="pricing-hero-panel-title">{callout.title}</p>

--- a/src/static/scripts/pricing-rate-card.js
+++ b/src/static/scripts/pricing-rate-card.js
@@ -36,8 +36,13 @@ function initRateCard(card) {
     const padTop = parseFloat(getComputedStyle(cells[0]).paddingTop);
     const boxes = cells.map((cell) => cell.getBoundingClientRect());
 
+    const headStickyTop = parseFloat(getComputedStyle(headBar).top) || 0;
+
     railTrack.style.width = `${inner.offsetWidth}px`;
-    rail.style.setProperty('--pricing-rail-top', `${headBar.offsetHeight + padTop}px`);
+    rail.style.setProperty(
+      '--pricing-rail-top',
+      `${headStickyTop + headBar.offsetHeight + padTop}px`
+    );
 
     boxes.forEach((box, index) => {
       groups[index].style.top = `${box.top - cardTop}px`;

--- a/src/static/styles/components-pricing.css
+++ b/src/static/styles/components-pricing.css
@@ -95,7 +95,7 @@
   /* Pinned column header. Sits outside the scroll container, clipping a track
      that pricing-rate-card.js shifts to match the body's scrollLeft. */
   .pricing-rates-head {
-    @apply bg-platinum border-midnight-fjord sticky top-0 z-30 overflow-hidden border-b;
+    @apply bg-platinum border-midnight-fjord sticky top-3 z-30 overflow-hidden border-b xl:top-4;
   }
 
   /* Below xl the 1092px design width is more scroll than content; a 48rem

--- a/src/static/styles/components-pricing.css
+++ b/src/static/styles/components-pricing.css
@@ -26,12 +26,16 @@
   }
 
   .pricing-hero-panel {
-    @apply bg-midnight-fjord relative flex flex-col justify-center gap-7 overflow-clip p-10;
+    @apply bg-midnight-fjord relative flex flex-col justify-center gap-7 p-10;
     @apply w-full lg:w-105 lg:shrink-0;
   }
 
+  .pricing-hero-panel-starfield-wrap {
+    @apply pointer-events-none absolute inset-0 overflow-clip;
+  }
+
   .pricing-hero-panel-starfield {
-    @apply pointer-events-none absolute top-1/2 left-1/4 h-auto w-[200%] max-w-none;
+    @apply absolute top-1/2 left-1/4 h-auto w-[200%] max-w-none;
     @apply -translate-y-1/2 rotate-16 opacity-60;
   }
 


### PR DESCRIPTION
Wrap the starfield in an overflow-clip container and add midnight fjord SectionLine overlap on the dark callout panel.