### PR TITLE
fix(events): August huddle recap content + September virtual badge

### DIFF
--- a/src/components/events/CommunityHuddlePastModal.astro
+++ b/src/components/events/CommunityHuddlePastModal.astro
@@ -42,6 +42,13 @@ import Icon from '@components/Icon.astro';
               </span>
               <span class="sr-only">Watch recap on YouTube (opens in new tab)</span>
             </a>
+            <p
+              class="community-huddle-past-modal__recap-placeholder"
+              data-past-modal-recap-placeholder
+              hidden
+            >
+              Coming soon
+            </p>
           </div>
           <div class="community-huddle-past-modal__covered" data-past-modal-covered hidden>
             <h3 class="community-huddle-past-modal__section-title">We covered</h3>
@@ -105,6 +112,7 @@ import Icon from '@components/Icon.astro';
     elTitle: HTMLElement;
     elRecap: HTMLElement;
     elRecapLink: HTMLAnchorElement;
+    elRecapPlaceholder: HTMLElement;
     elCover: HTMLImageElement;
     elCovered: HTMLElement;
     elCoveredBody: HTMLElement;
@@ -120,6 +128,7 @@ import Icon from '@components/Icon.astro';
       this.elTitle = this.querySelector('[data-past-modal-title]')!;
       this.elRecap = this.querySelector('[data-past-modal-recap]')!;
       this.elRecapLink = this.querySelector<HTMLAnchorElement>('[data-past-modal-recap-link]')!;
+      this.elRecapPlaceholder = this.querySelector('[data-past-modal-recap-placeholder]')!;
       this.elCover = this.querySelector<HTMLImageElement>('[data-past-modal-cover]')!;
       this.elCovered = this.querySelector('[data-past-modal-covered]')!;
       this.elCoveredBody = this.querySelector('[data-past-modal-covered-body]')!;
@@ -165,13 +174,18 @@ import Icon from '@components/Icon.astro';
       this.elDate.textContent = p.dateLine;
       this.elTitle.textContent = p.title;
 
+      // Always show the "Watch the recap" section — fall back to a "Coming soon"
+      // placeholder when a recording hasn't been published yet.
+      this.elRecap.hidden = false;
       const video = p.videoUrl?.trim() ?? '';
       if (video && isSafeYoutubeWatchTabUrl(video)) {
-        this.elRecap.hidden = false;
+        this.elRecapLink.hidden = false;
         this.elRecapLink.href = video;
+        this.elRecapPlaceholder.hidden = true;
       } else {
-        this.elRecap.hidden = true;
+        this.elRecapLink.hidden = true;
         this.elRecapLink.href = '#';
+        this.elRecapPlaceholder.hidden = false;
       }
 
       if (p.coverUrl.trim()) {

--- a/src/content/events/08-2026-august-datum-monthly-community-huddle/index.mdx
+++ b/src/content/events/08-2026-august-datum-monthly-community-huddle/index.mdx
@@ -9,7 +9,6 @@ eventType: community-huddle
 coverImage: ./cover.png
 ---
 
-- 1.6 Release "Katherine" & 1.7 "Kwolek" Recap
-- The State of Bare Metal with Gianlucca
-- Community POV with David Flanagan
-- A Look into Datum Compute
+- 1.6 & 1.7 Release review
+- State of Bare Metal automation with Gianluca
+- Datum Compute x Galactic VPC technical walk through

--- a/src/content/events/09-2026-september-datum-monthly-community-huddle/index.mdx
+++ b/src/content/events/09-2026-september-datum-monthly-community-huddle/index.mdx
@@ -7,6 +7,8 @@ timezone: America/New_York
 url: "https://luma.com/l399k6qz?tk=9auxAq"
 eventType: community-huddle
 coverImage: ./cover.png
+meetingUrl: "https://luma.com/l399k6qz?tk=9auxAq"
+zoomMeetingUrl: "https://luma.com/l399k6qz?tk=9auxAq"
 ---
 
 * To be announced

--- a/src/static/styles/components-modal.css
+++ b/src/static/styles/components-modal.css
@@ -162,6 +162,10 @@
     @apply border-aurora-moss bg-aurora-moss text-midnight-fjord absolute top-1/2 left-1/2 flex size-[72px] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-0 shadow-sm;
   }
 
+  .community-huddle-past-modal__recap-placeholder {
+    @apply bg-glacier-mist-700 text-app---dark---utility-4 datum-text-base m-0 flex aspect-16/9 w-full max-w-[311px] items-center justify-center rounded-md;
+  }
+
   .community-huddle-past-modal__covered-body {
     @apply text-midnight-fjord datum-text-base m-0 min-w-0 break-words;
 


### PR DESCRIPTION
## Summary

Follow-up on #1651 (August Community Huddle updates).

- `content(events)`: updated the August huddle's "We covered" list to the topics from the issue, and gave the September huddle a `meetingUrl`/`zoomMeetingUrl` (matching October's pattern) so it picks up a "Virtual" location badge on the `/events` calendar widget instead of showing none.
- `feat(events)`: the community huddle recap modal now always shows the "Watch the recap" section, with a "Coming soon" placeholder when a huddle is past but its recording isn't published yet (currently: August). Previously the whole section was hidden in that case.

August itself needed no code change to move into the "Past" tab — that's date-driven off `startAt` vs. today, and Aug 19 is already before today.

## Test plan

- [ ] Visit `/events/community-huddles`, open the "Past" tab, click into August — confirm the updated "We covered" bullets and a "Coming soon" placeholder under "Watch the recap".
- [ ] Confirm July and earlier past huddles still show their real recording thumbnail/link (unaffected).
- [ ] Visit `/events`, confirm September now shows a "Virtual" badge in the calendar list alongside October.
- `npx astro check --skip-playwright` — 0 errors.

Closes #1651

🤖 Generated with [Claude Code](https://claude.com/claude-code)
