### PR TITLE
fix(brand): Iconography content update + events background seam fix

### DIFF
--- a/src/components/brand/ColorPalette.astro
+++ b/src/components/brand/ColorPalette.astro
@@ -2,7 +2,8 @@
 // src/components/brand/ColorPalette.astro
 export interface ColorSwatch {
   name: string;
-  shade: string;
+  /** Omitted for swatches outside a numbered tint scale (e.g. White). */
+  shade?: string;
   hex: string;
   pantone?: string;
 }
@@ -86,20 +87,46 @@ const SECONDARY_PALETTE: ColorGroup[] = [
   },
 ];
 
+// Recommended icon colors — Figma Datum Master, node 16514-69470. `shade` is
+// omitted for White since it isn't part of a numbered tint scale.
+const ICON_GUIDANCE_PALETTE: ColorGroup[] = [
+  {
+    name: 'Midnight Fjord',
+    swatches: [
+      { name: 'Midnight Fjord', shade: '900', hex: '#0C1D31', pantone: 'Pantone 533 C' },
+      { name: 'Midnight Fjord', shade: '600', hex: '#67717C' },
+    ],
+  },
+  {
+    name: 'Canyon Clay',
+    swatches: [{ name: 'Canyon Clay', shade: '900', hex: '#9C7979' }],
+  },
+  {
+    name: 'White',
+    swatches: [{ name: 'White', hex: '#FFFFFF' }],
+  },
+];
+
 interface Props {
-  variant?: 'core' | 'secondary';
+  variant?: 'core' | 'secondary' | 'icon-guidance';
   groups?: ColorGroup[];
+  class?: string;
 }
 
-const VARIANTS: Record<'core' | 'secondary', ColorGroup[]> = {
+const VARIANTS: Record<'core' | 'secondary' | 'icon-guidance', ColorGroup[]> = {
   core: CORE_PALETTE,
   secondary: SECONDARY_PALETTE,
+  'icon-guidance': ICON_GUIDANCE_PALETTE,
 };
 
-const { variant = 'core', groups = VARIANTS[variant] } = Astro.props as Props;
+const {
+  variant = 'core',
+  groups = VARIANTS[variant],
+  class: className = '',
+} = Astro.props as Props;
 ---
 
-<div class="color-palette">
+<div class:list={['color-palette', className]}>
   {
     groups
       .filter((group) => group.swatches)
@@ -108,7 +135,7 @@ const { variant = 'core', groups = VARIANTS[variant] } = Astro.props as Props;
           {group.name && <h3 class="color-group--name">{group.name}</h3>}
           <div class="color-group--swatches">
             {group.swatches
-              .filter((swatch) => swatch.hex && swatch.shade)
+              .filter((swatch) => swatch.hex)
               .map((swatch) => (
                 <div class="color-swatch">
                   <div class="color-swatch--preview" style={`background-color: ${swatch.hex}`} />

--- a/src/content/pages/brand/iconography.mdx
+++ b/src/content/pages/brand/iconography.mdx
@@ -1,7 +1,5 @@
 ---
-title: "Iconography"
-subtitle: "Iconography"
-iconName: "layout-grid"
+title: "Our icon library"
 meta:
   title: "Datum Iconography: Official Icon Set & Usage Guidelines"
   description: "Datum uses the open-source Lucide icon library: lightweight, scalable vector symbols with a friendly yet precise tone across all digital experiences."
@@ -13,12 +11,13 @@ meta:
 import Container from '@components/Container.astro';
 import BrandCardImage from '@components/brand/BrandCardImage.astro';
 import Button from '@components/Button.astro';
+import ColorPalette from '@components/brand/ColorPalette.astro';
 
-## Library
+## Icon Library
 
-We use the Lucide icon library in our digital experiences, an Open Source collection of lightweight, highly optimized, scalable vector symbols with package support, that have an appropriately friendly yet precise tone.
+We use Lucide icons across our digital experiences. Its lightweight, open-source symbols combine a friendly, approachable character with the clarity and precision expected of a technical product. A shared library also helps us communicate actions and ideas consistently across the Datum website and product.
 
-<Container tag="section" class="space-y-12 max-w-none brand-card-pad">
+<Container tag="section" class="space-y-12 max-w-none brand-card-pad mb-8 md:mb-12">
 <BrandCardImage>
   ![Lucide icons.](./assets/lucide-icons.png)
 </BrandCardImage>
@@ -29,4 +28,27 @@ text="Access the library"
 target="_blank"
 href="https://lucide.dev/"
 />
+</Container>
+
+## Color Guidance
+
+Icons should use Midnight Fjord, Canyon Clay, or White in most situations, selecting the option that provides the clearest contrast against the background. Within a featured product category—Deliver, Build, or Connect—icons can use the corresponding tonal color to connect them with the surrounding content.
+
+<Container class="max-w-none brand-card-pad mb-8 md:mb-12">
+  <ColorPalette variant="icon-guidance" class="compact" />
+</Container>
+
+## Size and Stroke Width Guidance
+
+Consistent sizing and stroke widths help icons remain clear and balanced alongside text and interface elements. On the website, icons are typically displayed at 20px with a 1.75px stroke. Within the product, use 16px icons with a 1px stroke.
+
+<Container class="max-w-none brand-card-pad">
+  <div class="icon-spec-table not-prose">
+
+| Digital Experience | Size | Stroke Width |
+| ------------------- | ---- | ------------ |
+| Website | 20px | 1.75px |
+| Product | 16px | 1px |
+
+  </div>
 </Container>

--- a/src/pages/events/alt-cloud-meetups.astro
+++ b/src/pages/events/alt-cloud-meetups.astro
@@ -37,9 +37,7 @@ const altMeetupsPast = past.filter(isEventAltCloudMeetup);
       />
     </Hero>
 
-    <section
-      class="event-series-content section--block section--block--pad bg-glacier-mist-700 pt-0"
-    >
+    <section class="event-series-content section--block section--block--pad bg-platinum pt-0">
       <div class="max-width-5xl">
         <div x-data="{ activeTab: 'upcoming' }" class="event-series-tabs-container">
           <div class="event-series-tabs">

--- a/src/pages/events/community-huddles.astro
+++ b/src/pages/events/community-huddles.astro
@@ -38,9 +38,7 @@ const communityHuddlesPast = past.filter(isEventCommunityHuddle);
       />
     </Hero>
 
-    <section
-      class="event-series-content section--block section--block--pad bg-glacier-mist-700 pt-0"
-    >
+    <section class="event-series-content section--block section--block--pad bg-platinum pt-0">
       <div class="max-width-5xl">
         <div x-data="{ activeTab: 'upcoming' }" class="event-series-tabs-container">
           <div class="event-series-tabs">

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -79,7 +79,7 @@ const jsonLd = {
       />
     </Hero>
 
-    <div class="section--block section--block--pad bg-glacier-mist-700 pt-0">
+    <div class="section--block section--block--pad bg-platinum pt-0">
       <div class="max-width">
         <Card />
       </div>

--- a/src/static/styles/page-brand.css
+++ b/src/static/styles/page-brand.css
@@ -137,6 +137,12 @@
   .color-palette {
     @apply bg-white p-6.5 md:p-10 lg:p-14.75 xl:p-18.5;
     @apply grid grid-cols-1 items-start justify-between gap-8 sm:grid-cols-2 md:gap-12 lg:grid-cols-3;
+
+    /* Shorter card for single-row usage (e.g. Iconography > Color Guidance) —
+       the default padding scale is sized for the full multi-row Color page grid. */
+    &.compact {
+      @apply p-8 lg:p-10.75;
+    }
   }
 
   /* Shared by ColorPalette and UtilityPalette */
@@ -156,7 +162,7 @@
     @apply flex items-center gap-4;
 
     .color-swatch--preview {
-      @apply h-10 w-10 shrink-0 rounded-sm;
+      @apply h-10 w-10 shrink-0 rounded-sm border border-gray-200;
     }
 
     .color-swatch--info {
@@ -173,6 +179,23 @@
       .color-swatch--pantone {
         @apply text-sm text-gray-600;
       }
+    }
+  }
+
+  /* Icon spec table (e.g. Iconography > Size and Stroke Width Guidance) */
+  .icon-spec-table {
+    @apply overflow-hidden rounded-md border border-gray-200 bg-white;
+
+    table {
+      @apply w-full border-collapse text-left;
+    }
+
+    th {
+      @apply bg-gray-50 px-6 py-3 text-sm font-semibold text-gray-900;
+    }
+
+    td {
+      @apply border-t border-gray-200 px-6 py-3 text-sm text-gray-600;
     }
   }
 


### PR DESCRIPTION
## Summary

Follow-up on #1512 (Ollie's [Iconography content/edits](https://github.com/datum-cloud/datum.net/issues/1512#issuecomment-5346920302), Figma node `16514-69470`), plus a small unrelated background-seam fix picked up along the way on the events pages.

**Iconography page (`/brand/iconography`)**
- Header now falls back to the shared "Design Assets" eyebrow/icon instead of a page-specific override, and the title reads "Our icon library" — matching the Figma reference and the rest of the brand section.
- Updated the Icon Library intro copy.
- Added a **Color Guidance** section (Midnight Fjord / Canyon Clay / White swatches).
- Added a **Size and Stroke Width Guidance** section (website vs. product spec table).
- `ColorPalette` gained an `icon-guidance` variant, a shade-less swatch (for White), and a `compact` padding modifier for single-row cards. Added `.icon-spec-table` for small bordered spec tables (scoped with `not-prose` so it doesn't inherit Tailwind Typography's default table margins).

**Events pages (`/events`, `/events/community-huddles`, `/events/alt-cloud-meetups`)**
- The Hero sat on `bg-platinum` (`#F9F9F8`) directly above a content section on `bg-glacier-mist-700` (`#F6F6F5`) — two near-identical off-whites that produced a faint but visible seam. Switched the content section to `bg-platinum` on all three pages so it's seamless.

## Test plan

- [ ] Visit `/brand/iconography` — confirm header, copy, Color Guidance, and Size/Stroke Width sections match the Figma reference, with even spacing between sections.
- [ ] Visit `/events/community-huddles`, `/events/alt-cloud-meetups`, `/events` — confirm no visible seam between the hero and the content section below it.
- `npx astro check --skip-playwright` — 0 errors.
- `npx prettier --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
