### PR TITLE
fix(styles): align utility page headers and section lines

### DIFF
--- a/src/components/career/Benefits.astro
+++ b/src/components/career/Benefits.astro
@@ -1,6 +1,8 @@
 ---
 // src/components/career/Benefits.astro
 import Icon from '@components/Icon.astro';
+import SectionLine from '@components/SectionLine.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
 
 const benefits = [
   {
@@ -41,26 +43,34 @@ const benefits = [
 ];
 ---
 
-<section id="benefits" class="section--block section--block--pad bg-glacier-mist-700">
-  <div class="max-width">
-    <h2 class="datum-text-8xl mb-10 text-center font-medium">Open by design</h2>
-    <p class="datum-text-lg mb-10 text-center text-pretty md:mb-18">What to expect working here</p>
-    <div class="border-midnight-fjord border bg-white p-7 md:p-16">
-      <div class="flex flex-wrap gap-x-13 gap-y-8">
-        {
-          benefits.map((benefit) => (
-            <div class="flex w-full items-start gap-6 md:w-[calc(33.333%-35px)]">
-              <div class="bg-canyon-clay/20 text-canyon-clay---links flex h-10 w-10 shrink-0 items-center justify-center rounded-[4.7px] p-2">
-                <Icon name={benefit.icon} size="md" />
-              </div>
-              <div class="text-midnight-fjord flex min-w-0 flex-1 flex-col gap-2.5">
-                <h3 class="datum-text-lg font-medium">{benefit.title}</h3>
-                <p class="datum-text-base opacity-80">{benefit.description}</p>
-              </div>
-            </div>
-          ))
-        }
+<div class="relative">
+  <section id="benefits" class="section--block section--block--x-pad bg-glacier-mist-700">
+    <div class="max-width-nav relative py-10 md:py-16 lg:py-20 xl:py-28">
+      <SectionLine left top />
+      <div class="max-width-nopad">
+        <h2 class="datum-text-8xl mb-10 text-center font-medium">Open by design</h2>
+        <p class="datum-text-lg mb-10 text-center text-pretty md:mb-18">
+          What to expect working here
+        </p>
+        <div class="border-midnight-fjord border bg-white p-7 md:p-16">
+          <div class="flex flex-wrap gap-x-13 gap-y-8">
+            {
+              benefits.map((benefit) => (
+                <div class="flex w-full items-start gap-6 md:w-[calc(33.333%-35px)]">
+                  <div class="bg-canyon-clay/20 text-canyon-clay---links flex h-10 w-10 shrink-0 items-center justify-center rounded-[4.7px] p-2">
+                    <Icon name={benefit.icon} size="md" />
+                  </div>
+                  <div class="text-midnight-fjord flex min-w-0 flex-1 flex-col gap-2.5">
+                    <h3 class="datum-text-lg font-medium">{benefit.title}</h3>
+                    <p class="datum-text-base opacity-80">{benefit.description}</p>
+                  </div>
+                </div>
+              ))
+            }
+          </div>
+        </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
+  <ModuleConnector />
+</div>

--- a/src/components/career/Culture.astro
+++ b/src/components/career/Culture.astro
@@ -3,92 +3,101 @@
 import { Image } from 'astro:assets';
 import ImageRight from '@assets/images/good-look-section/left-stone.png';
 import ImageLeft from '@assets/images/good-look-section/right-stone.png';
+import SectionLine from '@components/SectionLine.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
 ---
 
-<section
-  id="culture-shaped"
-  class="career-culture section--block section--block--pad bg-glacier-mist-800 overflow-clip"
->
-  <div class="max-width relative z-20">
-    <div class="text-midnight-fjord grid grid-cols-1 gap-14 md:grid-cols-2 md:gap-20 lg:gap-26">
-      <div class="col-span-1 flex flex-col gap-6">
-        <h2 class="datum-text-8xl mb-6 font-medium">A culture shaped by our mission</h2>
-        <p class="datum-text-lg">
-          People first and purpose driven, we are dedicated to connecting others to their advantage.
-          We strive to balance a sense of humility with a strong conviction for what's next.
-        </p>
-      </div>
+<div class="relative">
+  <section
+    id="culture-shaped"
+    class="career-culture section--block section--block--x-pad bg-glacier-mist-800 overflow-clip"
+  >
+    <div class="max-width-nav relative py-10 md:py-16 lg:py-20 xl:py-28">
+      <SectionLine left top />
+      <div class="max-width-nopad relative z-20">
+        <div class="text-midnight-fjord grid grid-cols-1 gap-14 md:grid-cols-2 md:gap-20 lg:gap-26">
+          <div class="col-span-1 flex flex-col gap-6">
+            <h2 class="datum-text-8xl mb-6 font-medium">A culture shaped by our mission</h2>
+            <p class="datum-text-lg">
+              People first and purpose driven, we are dedicated to connecting others to their
+              advantage. We strive to balance a sense of humility with a strong conviction for
+              what's next.
+            </p>
+          </div>
 
-      <div class="flex grid-cols-1 flex-col gap-7">
-        <div class="flex-1">
-          <h3 class="datum-text-lg mb-4 font-medium">Who we are:</h3>
-          <ul class="datum-text-base space-y-1">
-            <li
-              class="datum-text-base before:bg-blush-quartz relative pl-6 before:absolute before:top-2.5 before:left-0 before:size-1.5 before:rounded-full before:content-['']"
-            >
-              We are connectors — of people, businesses, apps and networks.
-            </li>
-            <li
-              class="datum-text-base before:bg-blush-quartz relative pl-6 before:absolute before:top-2.5 before:left-0 before:size-1.5 before:rounded-full before:content-['']"
-            >
-              We are operators at heart
-            </li>
-            <li
-              class="datum-text-base before:bg-blush-quartz relative pl-6 before:absolute before:top-2.5 before:left-0 before:size-1.5 before:rounded-full before:content-['']"
-            >
-              We are passionate about working in the open
-            </li>
-          </ul>
+          <div class="flex grid-cols-1 flex-col gap-7">
+            <div class="flex-1">
+              <h3 class="datum-text-lg mb-4 font-medium">Who we are:</h3>
+              <ul class="datum-text-base space-y-1">
+                <li
+                  class="datum-text-base before:bg-blush-quartz relative pl-6 before:absolute before:top-2.5 before:left-0 before:size-1.5 before:rounded-full before:content-['']"
+                >
+                  We are connectors — of people, businesses, apps and networks.
+                </li>
+                <li
+                  class="datum-text-base before:bg-blush-quartz relative pl-6 before:absolute before:top-2.5 before:left-0 before:size-1.5 before:rounded-full before:content-['']"
+                >
+                  We are operators at heart
+                </li>
+                <li
+                  class="datum-text-base before:bg-blush-quartz relative pl-6 before:absolute before:top-2.5 before:left-0 before:size-1.5 before:rounded-full before:content-['']"
+                >
+                  We are passionate about working in the open
+                </li>
+              </ul>
+            </div>
+
+            <div class="flex-1">
+              <h3 class="datum-text-lg mb-4 font-medium">How we act:</h3>
+              <ul class="datum-text-base space-y-1">
+                <li
+                  class="datum-text-base before:bg-blush-quartz relative pl-6 before:absolute before:top-2.5 before:left-0 before:size-1.5 before:rounded-full before:content-['']"
+                >
+                  We find creative answers to hard problems
+                </li>
+                <li
+                  class="datum-text-base before:bg-blush-quartz relative pl-6 before:absolute before:top-2.5 before:left-0 before:size-1.5 before:rounded-full before:content-['']"
+                >
+                  We prioritize outcomes for users, customers, and partners
+                </li>
+                <li
+                  class="datum-text-base before:bg-blush-quartz relative pl-6 before:absolute before:top-2.5 before:left-0 before:size-1.5 before:rounded-full before:content-['']"
+                >
+                  We write our own words
+                </li>
+              </ul>
+            </div>
+
+            <p>
+              Read more about
+              <a
+                href="/handbook"
+                class="datum-text-base text-canyon-clay---links hover:text-canyon-clay---links/80 underline transition-opacity hover:opacity-80"
+                >how we work</a
+              >.
+            </p>
+          </div>
         </div>
-
-        <div class="flex-1">
-          <h3 class="datum-text-lg mb-4 font-medium">How we act:</h3>
-          <ul class="datum-text-base space-y-1">
-            <li
-              class="datum-text-base before:bg-blush-quartz relative pl-6 before:absolute before:top-2.5 before:left-0 before:size-1.5 before:rounded-full before:content-['']"
-            >
-              We find creative answers to hard problems
-            </li>
-            <li
-              class="datum-text-base before:bg-blush-quartz relative pl-6 before:absolute before:top-2.5 before:left-0 before:size-1.5 before:rounded-full before:content-['']"
-            >
-              We prioritize outcomes for users, customers, and partners
-            </li>
-            <li
-              class="datum-text-base before:bg-blush-quartz relative pl-6 before:absolute before:top-2.5 before:left-0 before:size-1.5 before:rounded-full before:content-['']"
-            >
-              We write our own words
-            </li>
-          </ul>
-        </div>
-
-        <p>
-          Read more about
-          <a
-            href="/handbook"
-            class="datum-text-base text-canyon-clay---links hover:text-canyon-clay---links/80 underline transition-opacity hover:opacity-80"
-            >how we work</a
-          >.
-        </p>
       </div>
     </div>
-  </div>
 
-  <div class="absolute bottom-0 left-0 z-0 max-w-1/3 md:max-w-64 lg:max-w-84">
-    <Image
-      src={ImageLeft}
-      layout="constrained"
-      alt="Scene left illustration"
-      class="w-half size-auto -scale-x-100 transform"
-    />
-  </div>
+    <div class="absolute bottom-0 left-0 z-0 max-w-1/3 md:max-w-64 lg:max-w-84">
+      <Image
+        src={ImageLeft}
+        layout="constrained"
+        alt="Scene left illustration"
+        class="w-half size-auto -scale-x-100 transform"
+      />
+    </div>
 
-  <div class="absolute right-0 bottom-0 z-0 max-w-1/2 md:max-w-110 lg:max-w-120">
-    <Image
-      src={ImageRight}
-      layout="constrained"
-      alt="Scene right illustration"
-      class="size-auto w-full -scale-x-100 transform"
-    />
-  </div>
-</section>
+    <div class="absolute right-0 bottom-0 z-0 max-w-1/2 md:max-w-110 lg:max-w-120">
+      <Image
+        src={ImageRight}
+        layout="constrained"
+        alt="Scene right illustration"
+        class="size-auto w-full -scale-x-100 transform"
+      />
+    </div>
+  </section>
+  <ModuleConnector />
+</div>

--- a/src/components/career/Mission.astro
+++ b/src/components/career/Mission.astro
@@ -4,38 +4,41 @@ import illustration from '@content/careers/images/careers.png';
 import { Image } from 'astro:assets';
 import { render, type CollectionEntry } from 'astro:content';
 import Button from '@components/Button.astro';
+import SectionLine from '@components/SectionLine.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
 
 const { content } = Astro.props as { content: CollectionEntry<'pages'> };
 const { Content } = await render(content);
 ---
 
-<section
-  id="mission"
-  class="section--block overflow-clip bg-white pt-8 pb-14 md:pt-10 md:pb-16 xl:pt-16 xl:pb-24"
->
-  <div class="max-width">
-    <div
-      class="flex flex-col items-center justify-center gap-8 md:flex-row md:gap-12 lg:gap-16 xl:gap-31"
-    >
-      <div class="grow">
-        <Image
-          src={illustration}
-          alt="About"
-          class="size-auto w-full md:w-auto md:max-w-92 lg:max-w-128.5"
-        />
-      </div>
-      <div class="grow">
-        <h1 class="datum-text-8xl mb-8.75">
-          {content.data.title}
-        </h1>
-        <div class="datum-text-xl">
-          <Content />
+<div class="relative">
+  <section id="mission" class="section--block section--block--x-pad overflow-clip bg-white">
+    <div class="max-width-nav relative pt-8 pb-14 md:pt-10 md:pb-16 xl:pt-16 xl:pb-24">
+      <SectionLine left right top />
+      <div
+        class="max-width-nopad flex flex-col items-center justify-center gap-8 md:flex-row md:gap-12 lg:gap-16 xl:gap-31"
+      >
+        <div class="grow">
+          <Image
+            src={illustration}
+            alt="About"
+            class="size-auto w-full md:w-auto md:max-w-92 lg:max-w-128.5"
+          />
+        </div>
+        <div class="grow">
+          <h1 class="datum-text-8xl mb-8.75">
+            {content.data.title}
+          </h1>
+          <div class="datum-text-xl">
+            <Content />
 
-          <div class="mt-8 flex">
-            <Button href="#roles" class="btn btn--alpha" text="View open roles" />
+            <div class="mt-8 flex">
+              <Button href="#roles" class="btn btn--alpha" text="View open roles" />
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
+  <ModuleConnector />
+</div>

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -6,6 +6,7 @@ import '@styles/page-blog.css';
 import Layout from '@layouts/Layout.astro';
 import Hero from '@components/Hero.astro';
 import Footer from '@components/Footer.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
 import GlobalSection from '@components/GlobalSection.astro';
 import BlogStrapiIndex from '@components/blog/BlogStrapi.astro';
 import defaultOgImage from '@content/images/og/blog.png';
@@ -68,18 +69,23 @@ const jsonLd = {
   jsonLd={jsonLd}
 >
   <section class="datum-container">
-    <Hero
-      class="light"
-      iconName={icon}
-      title={title}
-      subtitle={subtitle}
-      description={description}
-    />
+    <div class="relative">
+      <Hero
+        class="light"
+        iconName={icon}
+        title={title}
+        subtitle={subtitle}
+        description={description}
+        showSectionLines
+        sectionLines={{ left: true, right: true, top: true }}
+      />
 
-    <div class="section--block section--block--pad bg-midnight-fjord dark">
-      <div class="max-width">
-        <BlogStrapiIndex page={1} />
+      <div class="section--block section--block--pad bg-midnight-fjord dark">
+        <div class="max-width">
+          <BlogStrapiIndex page={1} />
+        </div>
       </div>
+      <ModuleConnector />
     </div>
 
     <GlobalSection />

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -7,6 +7,7 @@ import Layout from '@layouts/Layout.astro';
 import Hero from '@components/Hero.astro';
 import Footer from '@components/Footer.astro';
 import ModuleConnector from '@components/home/ModuleConnector.astro';
+import SectionLine from '@components/SectionLine.astro';
 import GlobalSection from '@components/GlobalSection.astro';
 import BlogStrapiIndex from '@components/blog/BlogStrapi.astro';
 import defaultOgImage from '@content/images/og/blog.png';
@@ -79,13 +80,19 @@ const jsonLd = {
         showSectionLines
         sectionLines={{ left: true, right: true, top: true }}
       />
+      <ModuleConnector />
+    </div>
 
-      <div class="section--block section--block--pad bg-midnight-fjord dark">
-        <div class="max-width">
-          <BlogStrapiIndex page={1} />
+    <div class="relative">
+      <div class="section--block section--block--x-pad bg-midnight-fjord dark">
+        <div class="max-width-nav relative py-10 md:py-16 lg:py-20 xl:py-28">
+          <SectionLine left top bottom class="bg-app---dark---utility-2" />
+          <div class="max-width">
+            <BlogStrapiIndex page={1} />
+          </div>
         </div>
       </div>
-      <ModuleConnector />
+      <ModuleConnector barClass="bg-app---dark---utility-2" />
     </div>
 
     <GlobalSection />

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -11,6 +11,8 @@ import Button from '@components/Button.astro';
 import Icon from '@components/Icon.astro';
 import ArticleNavigation from '@components/ArticleNavigation.astro';
 import MediaLightbox from '@components/MediaLightbox.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
+import SectionLine from '@components/SectionLine.astro';
 import { Breadcrumbs } from 'astro-breadcrumbs';
 import {
   getStrapiMediaUrl,
@@ -300,18 +302,29 @@ const processedBlocks: ProcessedBlock[] =
       meta={{ og: { image: defaultOgImage } }}
     >
       <section class="datum-container">
-        <Hero
-          class="light"
-          iconName="book-image"
-          title={blogPage?.data?.title}
-          subtitle={blogPage?.data?.subtitle ?? 'Blog'}
-          description={blogPage?.data?.description ?? ''}
-        />
+        <div class="relative">
+          <Hero
+            class="light"
+            iconName="book-image"
+            title={blogPage?.data?.title}
+            subtitle={blogPage?.data?.subtitle ?? 'Blog'}
+            description={blogPage?.data?.description ?? ''}
+            showSectionLines
+            sectionLines={{ left: true, right: true, top: true }}
+          />
+          <ModuleConnector />
+        </div>
 
-        <div class="section--block section--block--pad bg-midnight-fjord dark">
-          <div class="max-width">
-            <BlogStrapiPage page={parsedPage} />
+        <div class="relative">
+          <div class="section--block section--block--x-pad bg-midnight-fjord dark">
+            <div class="max-width-nav relative py-10 md:py-16 lg:py-20 xl:py-28">
+              <SectionLine left top bottom class="bg-app---dark---utility-2" />
+              <div class="max-width">
+                <BlogStrapiPage page={parsedPage} />
+              </div>
+            </div>
           </div>
+          <ModuleConnector barClass="bg-app---dark---utility-2" />
         </div>
 
         <GlobalSection />
@@ -334,238 +347,248 @@ const processedBlocks: ProcessedBlock[] =
       <section class="datum-container">
         <Hero class="light" hideContent={true} hideHero />
 
-        <section class="bg-glacier-mist-700 section--block pt-6 md:pt-10 xl:pt-16">
-          <div class="max-width blog-detail max-w-256.5 pb-14 md:pb-20 lg:pb-28">
-            <aside class="blog-aside">
-              <div class="blog-aside-content sticky top-0">
-                <Button
-                  class="btn btn--alpha btn--fluid mb-11"
-                  text="Back to Blog"
-                  icon={{ name: 'arrow-left', size: 'md' }}
-                  iconPosition="left"
-                  iconClass="stroke-1.5"
-                  href="/blog"
-                />
+        <div class="relative">
+          <section class="section--block section--block--x-pad bg-glacier-mist-700">
+            <div class="max-width-nav relative pt-6 md:pt-10 xl:pt-16">
+              <SectionLine left top bottom />
+              <div class="max-width blog-detail max-w-256.5 pb-14 md:pb-20 lg:pb-28">
+                <aside class="blog-aside">
+                  <div class="blog-aside-content sticky top-0">
+                    <Button
+                      class="btn btn--alpha btn--fluid mb-11"
+                      text="Back to Blog"
+                      icon={{ name: 'arrow-left', size: 'md' }}
+                      iconPosition="left"
+                      iconClass="stroke-1.5"
+                      href="/blog"
+                    />
 
-                {/* Author Information */}
-                {authorName && (
-                  <div class="blog-article-author">
-                    <div class="blog-article-author-avatar">
-                      {authorAvatar ? (
-                        hasAuthorHref ? (
-                          <a href={authorHref} class="blog-article-author-image">
-                            <Image
-                              src={authorAvatar}
-                              alt={authorName}
-                              width={64}
-                              height={64}
-                              class="h-full w-full object-cover"
+                    {/* Author Information */}
+                    {authorName && (
+                      <div class="blog-article-author">
+                        <div class="blog-article-author-avatar">
+                          {authorAvatar ? (
+                            hasAuthorHref ? (
+                              <a href={authorHref} class="blog-article-author-image">
+                                <Image
+                                  src={authorAvatar}
+                                  alt={authorName}
+                                  width={64}
+                                  height={64}
+                                  class="h-full w-full object-cover"
+                                  style={
+                                    authorBgColor ? `background-color: ${authorBgColor}` : undefined
+                                  }
+                                />
+                              </a>
+                            ) : (
+                              <div class="blog-article-author-image">
+                                <Image
+                                  src={authorAvatar}
+                                  alt={authorName}
+                                  width={64}
+                                  height={64}
+                                  class="h-full w-full object-cover"
+                                  style={
+                                    authorBgColor ? `background-color: ${authorBgColor}` : undefined
+                                  }
+                                />
+                              </div>
+                            )
+                          ) : hasAuthorHref ? (
+                            <a
+                              href={authorHref}
+                              class="blog-article-author-image"
                               style={
                                 authorBgColor ? `background-color: ${authorBgColor}` : undefined
                               }
-                            />
+                            >
+                              <span class="text-lg font-bold text-gray-600">
+                                {authorName.charAt(0)}
+                              </span>
+                            </a>
+                          ) : (
+                            <div
+                              class="blog-article-author-image"
+                              style={
+                                authorBgColor ? `background-color: ${authorBgColor}` : undefined
+                              }
+                            >
+                              <span class="text-lg font-bold text-gray-600">
+                                {authorName.charAt(0)}
+                              </span>
+                            </div>
+                          )}
+                        </div>
+                        {hasAuthorHref ? (
+                          <a href={authorHref} class="blog-article-author-name">
+                            {authorName}
                           </a>
                         ) : (
-                          <div class="blog-article-author-image">
-                            <Image
-                              src={authorAvatar}
-                              alt={authorName}
-                              width={64}
-                              height={64}
-                              class="h-full w-full object-cover"
-                              style={
-                                authorBgColor ? `background-color: ${authorBgColor}` : undefined
-                              }
-                            />
-                          </div>
-                        )
-                      ) : hasAuthorHref ? (
-                        <a
-                          href={authorHref}
-                          class="blog-article-author-image"
-                          style={authorBgColor ? `background-color: ${authorBgColor}` : undefined}
-                        >
-                          <span class="text-lg font-bold text-gray-600">
-                            {authorName.charAt(0)}
-                          </span>
-                        </a>
-                      ) : (
-                        <div
-                          class="blog-article-author-image"
-                          style={authorBgColor ? `background-color: ${authorBgColor}` : undefined}
-                        >
-                          <span class="text-lg font-bold text-gray-600">
-                            {authorName.charAt(0)}
-                          </span>
-                        </div>
-                      )}
-                    </div>
-                    {hasAuthorHref ? (
-                      <a href={authorHref} class="blog-article-author-name">
-                        {authorName}
-                      </a>
-                    ) : (
-                      <span class="blog-article-author-name">{authorName}</span>
+                          <span class="blog-article-author-name">{authorName}</span>
+                        )}
+                      </div>
                     )}
-                  </div>
-                )}
 
-                <span class="icon-label">
-                  <div class="icon-bg">
-                    <Icon name="clock" size="sm" />
-                  </div>
-                  <span class="icon-label-text">{readingTime.text}</span>
-                </span>
+                    <span class="icon-label">
+                      <div class="icon-bg">
+                        <Icon name="clock" size="sm" />
+                      </div>
+                      <span class="icon-label-text">{readingTime.text}</span>
+                    </span>
 
-                <span class="icon-label">
-                  <div class="icon-bg">
-                    <Icon name="calendar" size="sm" />
-                  </div>
-                  <span class="icon-label-text">{formattedDate}</span>
-                </span>
+                    <span class="icon-label">
+                      <div class="icon-bg">
+                        <Icon name="calendar" size="sm" />
+                      </div>
+                      <span class="icon-label-text">{formattedDate}</span>
+                    </span>
 
-                <span class="icon-label">
-                  <div class="icon-bg">
-                    <Icon name="copy" size="sm" />
+                    <span class="icon-label">
+                      <div class="icon-bg">
+                        <Icon name="copy" size="sm" />
+                      </div>
+                      <span class="icon-label-text">
+                        <button
+                          type="button"
+                          class="border-b hover:cursor-pointer"
+                          x-data="{ copied: false }"
+                          @click={`navigator.clipboard.writeText('${pageCanonicalUrl}').then(() => { copied = true; setTimeout(() => { copied = false; }, 2000); })`}
+                          x-text="copied ? 'Copied!' : 'Copy URL'"
+                        />
+                      </span>
+                    </span>
                   </div>
-                  <span class="icon-label-text">
-                    <button
-                      type="button"
-                      class="border-b hover:cursor-pointer"
-                      x-data="{ copied: false }"
-                      @click={`navigator.clipboard.writeText('${pageCanonicalUrl}').then(() => { copied = true; setTimeout(() => { copied = false; }, 2000); })`}
-                      x-text="copied ? 'Copied!' : 'Copy URL'"
-                    />
+                </aside>
+
+                <article class="blog-article">
+                  <span class="hidden" style="display: none;">
+                    {' '}
+                    post{' '}
                   </span>
-                </span>
-              </div>
-            </aside>
+                  <span class="hidden" style="display: none;">
+                    {authorName}
+                  </span>
+                  <span class="hidden" style="display: none;">
+                    {categoryName}
+                  </span>
 
-            <article class="blog-article">
-              <span class="hidden" style="display: none;">
-                {' '}
-                post{' '}
-              </span>
-              <span class="hidden" style="display: none;">
-                {authorName}
-              </span>
-              <span class="hidden" style="display: none;">
-                {categoryName}
-              </span>
+                  {/* Article Header */}
+                  <header class="blog-article-header">
+                    <div class="blog-article-breadcrumbs">
+                      <Breadcrumbs
+                        linkTextFormat="sentence"
+                        mainBemClass="a-breadcrumbs"
+                        crumbs={breadcrumbData.length > 0 ? breadcrumbData : undefined}
+                      >
+                        <svg
+                          slot="index"
+                          aria-label="Home Page"
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="24"
+                          height="24"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        >
+                          <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"> </path>
+                          <polyline points="9 22 9 12 15 12 15 22" />
+                        </svg>
+                      </Breadcrumbs>
+                    </div>
+                    <h1 class="blog-article-title">{fm?.title}</h1>
+                    <div class="datum-text-sm mt-4 flex flex-wrap gap-1 opacity-60 md:hidden">
+                      <a href={authorHref ?? '#'} class="blog-article-author-name">
+                        {authorName},
+                      </a>
+                      <span class="blog-article-meta-date">{readingTime.text}, </span>
+                      <span class="blog-article-meta-date">{formattedDate}, </span>
+                      <button
+                        type="button"
+                        class="blog-article-meta-share"
+                        x-data="{ copied: false }"
+                        @click={`navigator.clipboard.writeText('${pageCanonicalUrl}').then(() => { copied = true; setTimeout(() => { copied = false; }, 2000); })`}
+                        x-text="copied ? 'Copied!' : 'Copy URL'"
+                      />
+                    </div>
+                  </header>
 
-              {/* Article Header */}
-              <header class="blog-article-header">
-                <div class="blog-article-breadcrumbs">
-                  <Breadcrumbs
-                    linkTextFormat="sentence"
-                    mainBemClass="a-breadcrumbs"
-                    crumbs={breadcrumbData.length > 0 ? breadcrumbData : undefined}
-                  >
-                    <svg
-                      slot="index"
-                      aria-label="Home Page"
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="24"
-                      height="24"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    >
-                      <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"> </path>
-                      <polyline points="9 22 9 12 15 12 15 22" />
-                    </svg>
-                  </Breadcrumbs>
-                </div>
-                <h1 class="blog-article-title">{fm?.title}</h1>
-                <div class="datum-text-sm mt-4 flex flex-wrap gap-1 opacity-60 md:hidden">
-                  <a href={authorHref ?? '#'} class="blog-article-author-name">
-                    {authorName},
-                  </a>
-                  <span class="blog-article-meta-date">{readingTime.text}, </span>
-                  <span class="blog-article-meta-date">{formattedDate}, </span>
-                  <button
-                    type="button"
-                    class="blog-article-meta-share"
-                    x-data="{ copied: false }"
-                    @click={`navigator.clipboard.writeText('${pageCanonicalUrl}').then(() => { copied = true; setTimeout(() => { copied = false; }, 2000); })`}
-                    x-text="copied ? 'Copied!' : 'Copy URL'"
-                  />
-                </div>
-              </header>
+                  {/* Featured Image */}
+                  {fm?.featuredImage && (
+                    <div class="blog-article-image">
+                      <Image
+                        src={fm.featuredImage}
+                        alt={article?.cover?.alternativeText || fm?.title}
+                        width={1200}
+                        height={630}
+                        widths={[400, 800, 1200]}
+                        sizes="(max-width: 768px) 400px, (max-width: 1200px) 800px, 1200px"
+                        format="webp"
+                        loading="eager"
+                        fetchpriority="high"
+                      />
+                    </div>
+                  )}
 
-              {/* Featured Image */}
-              {fm?.featuredImage && (
-                <div class="blog-article-image">
-                  <Image
-                    src={fm.featuredImage}
-                    alt={article?.cover?.alternativeText || fm?.title}
-                    width={1200}
-                    height={630}
-                    widths={[400, 800, 1200]}
-                    sizes="(max-width: 768px) 400px, (max-width: 1200px) 800px, 1200px"
-                    format="webp"
-                    loading="eager"
-                    fetchpriority="high"
-                  />
-                </div>
-              )}
-
-              {/* Article Content */}
-              <div class="blog-article-content">
-                {processedBlocks.map((block) => {
-                  if (block.kind === 'quote') {
-                    return (
-                      <blockquote class="blog-article-quote">
-                        <h3>{block.title}</h3>
-                        <p set:html={block.html} />
-                      </blockquote>
-                    );
-                  }
-
-                  if (block.kind === 'rich') {
-                    return <div set:html={block.html} />;
-                  }
-
-                  return null;
-                })}
-              </div>
-
-              {/* Article Navigation */}
-              <ArticleNavigation
-                previousArticle={
-                  previousArticle
-                    ? {
-                        id: previousArticle.slug,
-                        title: previousArticle.title,
-                        url: `/blog/${previousArticle.slug}`,
-                        navLabel: 'Next article',
+                  {/* Article Content */}
+                  <div class="blog-article-content">
+                    {processedBlocks.map((block) => {
+                      if (block.kind === 'quote') {
+                        return (
+                          <blockquote class="blog-article-quote">
+                            <h3>{block.title}</h3>
+                            <p set:html={block.html} />
+                          </blockquote>
+                        );
                       }
-                    : undefined
-                }
-                nextArticle={
-                  nextArticle
-                    ? {
-                        id: nextArticle.slug,
-                        title: nextArticle.title,
-                        url: `/blog/${nextArticle.slug}`,
-                        navLabel: 'Previous article',
+
+                      if (block.kind === 'rich') {
+                        return <div set:html={block.html} />;
                       }
-                    : undefined
-                }
+
+                      return null;
+                    })}
+                  </div>
+
+                  {/* Article Navigation */}
+                  <ArticleNavigation
+                    previousArticle={
+                      previousArticle
+                        ? {
+                            id: previousArticle.slug,
+                            title: previousArticle.title,
+                            url: `/blog/${previousArticle.slug}`,
+                            navLabel: 'Next article',
+                          }
+                        : undefined
+                    }
+                    nextArticle={
+                      nextArticle
+                        ? {
+                            id: nextArticle.slug,
+                            title: nextArticle.title,
+                            url: `/blog/${nextArticle.slug}`,
+                            navLabel: 'Previous article',
+                          }
+                        : undefined
+                    }
+                  />
+                </article>
+              </div>
+
+              <MediaLightbox
+                selector=".blog-article-content img, .blog-article-image img"
+                videoSelector=""
               />
-            </article>
-          </div>
+            </div>
+          </section>
+          <ModuleConnector />
+        </div>
 
-          <MediaLightbox
-            selector=".blog-article-content img, .blog-article-image img"
-            videoSelector=""
-          />
-
-          <Footer />
-        </section>
+        <Footer />
       </section>
     </Layout>
   )

--- a/src/pages/blog/category/[slug].astro
+++ b/src/pages/blog/category/[slug].astro
@@ -7,6 +7,7 @@ import Layout from '@layouts/Layout.astro';
 import Hero from '@components/Hero.astro';
 import Footer from '@components/Footer.astro';
 import ModuleConnector from '@components/home/ModuleConnector.astro';
+import SectionLine from '@components/SectionLine.astro';
 import { fetchStrapiArticlesByCategory } from '@libs/strapi';
 import { normalizeArticle } from '@/src/types/strapi';
 import BlogItemStrapi from '@components/blog/BlogItemStrapi.astro';
@@ -61,32 +62,38 @@ const subtitle = 'Blog';
         showSectionLines
         sectionLines={{ left: true, right: true, top: true }}
       />
+      <ModuleConnector />
+    </div>
 
-      <div class="section--block section--block--pad bg-midnight-fjord dark">
-        <div class="max-width relative">
-          <!-- Hidden meta tag to identify this as a category page -->
-          <span style="display: none;">category</span>
+    <div class="relative">
+      <div class="section--block section--block--x-pad section--block--pad bg-midnight-fjord dark">
+        <div class="max-width-nav relative">
+          <SectionLine left top bottom class="bg-app---dark---utility-2" />
+          <div class="max-width relative">
+            <!-- Hidden meta tag to identify this as a category page -->
+            <span style="display: none;">category</span>
 
-          <!-- Blog List -->
-          <div class="blog-list">
-            {currentPageData.map((post) => <BlogItemStrapi post={post} baseUrl="/blog" />)}
+            <!-- Blog List -->
+            <div class="blog-list">
+              {currentPageData.map((post) => <BlogItemStrapi post={post} baseUrl="/blog" />)}
+            </div>
+
+            <!-- Pagination -->
+            {
+              totalPages > 1 && (
+                <BlogPagination
+                  currentPage={currentPage}
+                  totalPages={totalPages}
+                  baseUrl={baseUrl}
+                  prevUrl={prevUrl}
+                  nextUrl={nextUrl}
+                />
+              )
+            }
           </div>
-
-          <!-- Pagination -->
-          {
-            totalPages > 1 && (
-              <BlogPagination
-                currentPage={currentPage}
-                totalPages={totalPages}
-                baseUrl={baseUrl}
-                prevUrl={prevUrl}
-                nextUrl={nextUrl}
-              />
-            )
-          }
         </div>
       </div>
-      <ModuleConnector />
+      <ModuleConnector barClass="bg-app---dark---utility-2" />
     </div>
 
     <Footer />

--- a/src/pages/blog/category/[slug].astro
+++ b/src/pages/blog/category/[slug].astro
@@ -6,6 +6,7 @@ import '@styles/page-blog.css';
 import Layout from '@layouts/Layout.astro';
 import Hero from '@components/Hero.astro';
 import Footer from '@components/Footer.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
 import { fetchStrapiArticlesByCategory } from '@libs/strapi';
 import { normalizeArticle } from '@/src/types/strapi';
 import BlogItemStrapi from '@components/blog/BlogItemStrapi.astro';
@@ -51,31 +52,41 @@ const subtitle = 'Blog';
   meta={{}}
 >
   <section class="datum-container">
-    <Hero class="light" iconName={icon} title={title} subtitle={subtitle} />
+    <div class="relative">
+      <Hero
+        class="light"
+        iconName={icon}
+        title={title}
+        subtitle={subtitle}
+        showSectionLines
+        sectionLines={{ left: true, right: true, top: true }}
+      />
 
-    <div class="section--block section--block--pad bg-midnight-fjord dark">
-      <div class="max-width relative">
-        <!-- Hidden meta tag to identify this as a category page -->
-        <span style="display: none;">category</span>
+      <div class="section--block section--block--pad bg-midnight-fjord dark">
+        <div class="max-width relative">
+          <!-- Hidden meta tag to identify this as a category page -->
+          <span style="display: none;">category</span>
 
-        <!-- Blog List -->
-        <div class="blog-list">
-          {currentPageData.map((post) => <BlogItemStrapi post={post} baseUrl="/blog" />)}
+          <!-- Blog List -->
+          <div class="blog-list">
+            {currentPageData.map((post) => <BlogItemStrapi post={post} baseUrl="/blog" />)}
+          </div>
+
+          <!-- Pagination -->
+          {
+            totalPages > 1 && (
+              <BlogPagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                baseUrl={baseUrl}
+                prevUrl={prevUrl}
+                nextUrl={nextUrl}
+              />
+            )
+          }
         </div>
-
-        <!-- Pagination -->
-        {
-          totalPages > 1 && (
-            <BlogPagination
-              currentPage={currentPage}
-              totalPages={totalPages}
-              baseUrl={baseUrl}
-              prevUrl={prevUrl}
-              nextUrl={nextUrl}
-            />
-          )
-        }
       </div>
+      <ModuleConnector />
     </div>
 
     <Footer />

--- a/src/pages/blog/category/[slug]/[page].astro
+++ b/src/pages/blog/category/[slug]/[page].astro
@@ -7,6 +7,7 @@ import Layout from '@layouts/Layout.astro';
 import Hero from '@components/Hero.astro';
 import Footer from '@components/Footer.astro';
 import ModuleConnector from '@components/home/ModuleConnector.astro';
+import SectionLine from '@components/SectionLine.astro';
 import { fetchStrapiArticlesByCategory } from '@libs/strapi';
 import { normalizeArticle } from '@/src/types/strapi';
 import BlogItemStrapi from '@components/blog/BlogItemStrapi.astro';
@@ -63,28 +64,34 @@ const subtitle = 'Blog';
         showSectionLines
         sectionLines={{ left: true, right: true, top: true }}
       />
+      <ModuleConnector />
+    </div>
 
-      <div class="section--block section--block--pad bg-midnight-fjord dark">
-        <div class="max-width relative">
-          <!-- Hidden meta tag to identify this as a category page -->
-          <span style="display: none;">category</span>
+    <div class="relative">
+      <div class="section--block section--block--x-pad section--block--pad bg-midnight-fjord dark">
+        <div class="max-width-nav relative">
+          <SectionLine left top bottom class="bg-app---dark---utility-2" />
+          <div class="max-width relative">
+            <!-- Hidden meta tag to identify this as a category page -->
+            <span style="display: none;">category</span>
 
-          <!-- Blog List -->
-          <div class="blog-list">
-            {currentPageData.map((post) => <BlogItemStrapi post={post} baseUrl="/blog" />)}
+            <!-- Blog List -->
+            <div class="blog-list">
+              {currentPageData.map((post) => <BlogItemStrapi post={post} baseUrl="/blog" />)}
+            </div>
+
+            <!-- Pagination -->
+            <BlogPagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              baseUrl={baseUrl}
+              prevUrl={prevUrl}
+              nextUrl={nextUrl}
+            />
           </div>
-
-          <!-- Pagination -->
-          <BlogPagination
-            currentPage={currentPage}
-            totalPages={totalPages}
-            baseUrl={baseUrl}
-            prevUrl={prevUrl}
-            nextUrl={nextUrl}
-          />
         </div>
       </div>
-      <ModuleConnector />
+      <ModuleConnector barClass="bg-app---dark---utility-2" />
     </div>
 
     <Footer />

--- a/src/pages/blog/category/[slug]/[page].astro
+++ b/src/pages/blog/category/[slug]/[page].astro
@@ -6,6 +6,7 @@ import '@styles/page-blog.css';
 import Layout from '@layouts/Layout.astro';
 import Hero from '@components/Hero.astro';
 import Footer from '@components/Footer.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
 import { fetchStrapiArticlesByCategory } from '@libs/strapi';
 import { normalizeArticle } from '@/src/types/strapi';
 import BlogItemStrapi from '@components/blog/BlogItemStrapi.astro';
@@ -53,27 +54,37 @@ const subtitle = 'Blog';
   meta={{}}
 >
   <section class="datum-container">
-    <Hero class="light" iconName={icon} title={title} subtitle={subtitle} />
+    <div class="relative">
+      <Hero
+        class="light"
+        iconName={icon}
+        title={title}
+        subtitle={subtitle}
+        showSectionLines
+        sectionLines={{ left: true, right: true, top: true }}
+      />
 
-    <div class="section--block section--block--pad bg-midnight-fjord dark">
-      <div class="max-width relative">
-        <!-- Hidden meta tag to identify this as a category page -->
-        <span style="display: none;">category</span>
+      <div class="section--block section--block--pad bg-midnight-fjord dark">
+        <div class="max-width relative">
+          <!-- Hidden meta tag to identify this as a category page -->
+          <span style="display: none;">category</span>
 
-        <!-- Blog List -->
-        <div class="blog-list">
-          {currentPageData.map((post) => <BlogItemStrapi post={post} baseUrl="/blog" />)}
+          <!-- Blog List -->
+          <div class="blog-list">
+            {currentPageData.map((post) => <BlogItemStrapi post={post} baseUrl="/blog" />)}
+          </div>
+
+          <!-- Pagination -->
+          <BlogPagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            baseUrl={baseUrl}
+            prevUrl={prevUrl}
+            nextUrl={nextUrl}
+          />
         </div>
-
-        <!-- Pagination -->
-        <BlogPagination
-          currentPage={currentPage}
-          totalPages={totalPages}
-          baseUrl={baseUrl}
-          prevUrl={prevUrl}
-          nextUrl={nextUrl}
-        />
       </div>
+      <ModuleConnector />
     </div>
 
     <Footer />

--- a/src/pages/careers.astro
+++ b/src/pages/careers.astro
@@ -8,6 +8,8 @@ import Mission from '@components/career/Mission.astro';
 import Culture from '@components/career/Culture.astro';
 import Benefits from '@components/career/Benefits.astro';
 import JobList from '@components/career/JobList.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
+import SectionLine from '@components/SectionLine.astro';
 import { getCollectionEntry } from '@utils/collectionUtils';
 
 // Get career landing page from pages/career.mdx
@@ -41,32 +43,38 @@ const description = fm.description || '';
       <Benefits />
     </div>
 
-    <section id="roles" class="section--block section--block--pad bg-white">
-      <div class="max-width">
-        <h2 class="datum-text-8xl mb-12 text-center font-medium">Ready to join the team?</h2>
+    <div class="relative">
+      <section id="roles" class="section--block section--block--x-pad bg-white">
+        <div class="max-width-nav relative py-10 md:py-16 lg:py-20 xl:py-28">
+          <SectionLine left top bottom />
+          <div class="max-width-nopad">
+            <h2 class="datum-text-8xl mb-12 text-center font-medium">Ready to join the team?</h2>
 
-        <!-- Job List (shown when no ashby_jid) -->
-        <div x-show="!hasAshbyJobId" x-cloak>
-          <JobList server:defer>
-            <div slot="fallback" class="mx-auto max-w-4xl py-12 text-center">
-              <div
-                class="border-glacier-mist-800 border-t-canyon-clay mx-auto mb-4 size-8 animate-spin rounded-full border-3"
-              >
-              </div>
-              <p class="text-midnight-fjord/60 text-sm">Loading open positions...</p>
+            <!-- Job List (shown when no ashby_jid) -->
+            <div x-show="!hasAshbyJobId" x-cloak>
+              <JobList server:defer>
+                <div slot="fallback" class="mx-auto max-w-4xl py-12 text-center">
+                  <div
+                    class="border-glacier-mist-800 border-t-canyon-clay mx-auto mb-4 size-8 animate-spin rounded-full border-3"
+                  >
+                  </div>
+                  <p class="text-midnight-fjord/60 text-sm">Loading open positions...</p>
+                </div>
+              </JobList>
             </div>
-          </JobList>
-        </div>
 
-        <!-- Ashby Embed for Job Detail (shown when ashby_jid is present) -->
-        <div x-show="hasAshbyJobId" x-cloak>
-          <div id="ashby_embed"></div>
-          <div id="ashby_embed_fallback" class="py-12 text-center" style="display:none">
-            <p class="text-midnight-fjord/70">Ashby will be right back...</p>
+            <!-- Ashby Embed for Job Detail (shown when ashby_jid is present) -->
+            <div x-show="hasAshbyJobId" x-cloak>
+              <div id="ashby_embed"></div>
+              <div id="ashby_embed_fallback" class="py-12 text-center" style="display:none">
+                <p class="text-midnight-fjord/70">Ashby will be right back...</p>
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+      <ModuleConnector />
+    </div>
 
     <script is:inline>
       window.__Ashby = {

--- a/src/pages/events/alt-cloud-meetups.astro
+++ b/src/pages/events/alt-cloud-meetups.astro
@@ -8,6 +8,8 @@ import Footer from '@components/Footer.astro';
 import SecondaryTabNav from '@components/SecondaryTabNav.astro';
 import EventSeriesCard from '@components/events/EventSeriesCard.astro';
 import MediaLightbox from '@components/MediaLightbox.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
+import SectionLine from '@components/SectionLine.astro';
 import { getCollectionEntry } from '@utils/collectionUtils';
 
 const page = await getCollectionEntry('pages', 'alt-cloud-meetups');
@@ -24,65 +26,80 @@ const altMeetupsPast = past.filter(isEventAltCloudMeetup);
 
 <Layout title={title} description={description} bodyClass="page-event-series" meta={meta}>
   <section class="datum-container">
-    <Hero class="light content-alt pb-0" title={title} description={description}>
-      <SecondaryTabNav
-        slot="before-content"
-        ariaLabel="Event categories"
-        mobileLabel="Event category"
-        items={[
-          { label: 'All events', href: '/events', exact: true },
-          { label: 'Community Huddles', href: '/events/community-huddles' },
-          { label: 'Alt Cloud Meetups', href: '/events/alt-cloud-meetups' },
-        ]}
-      />
-    </Hero>
+    <div class="relative">
+      <Hero
+        class="light content-alt pb-0"
+        title={title}
+        description={description}
+        showSectionLines
+        sectionLines={{ left: true, right: true, top: true }}
+      >
+        <SecondaryTabNav
+          slot="before-content"
+          ariaLabel="Event categories"
+          mobileLabel="Event category"
+          items={[
+            { label: 'All events', href: '/events', exact: true },
+            { label: 'Community Huddles', href: '/events/community-huddles' },
+            { label: 'Alt Cloud Meetups', href: '/events/alt-cloud-meetups' },
+          ]}
+        />
+      </Hero>
+      <ModuleConnector />
+    </div>
 
-    <section class="event-series-content section--block section--block--pad bg-platinum pt-0">
-      <div class="max-width-5xl">
-        <div x-data="{ activeTab: 'upcoming' }" class="event-series-tabs-container">
-          <div class="event-series-tabs">
-            <button
-              type="button"
-              class="event-series-tab"
-              x-bind:class="{ 'event-series-tab--active': activeTab === 'upcoming' }"
-              x-on:click="activeTab = 'upcoming'">Upcoming</button
-            >
-            <button
-              type="button"
-              class="event-series-tab"
-              x-bind:class="{ 'event-series-tab--active': activeTab === 'past' }"
-              x-on:click="activeTab = 'past'">Past</button
-            >
-          </div>
+    <div class="relative">
+      <section class="event-series-content section--block section--block--x-pad bg-platinum">
+        <div class="max-width-nav relative pb-10 md:pb-16 lg:pb-20 xl:pb-28">
+          <SectionLine left top bottom />
+          <div class="mx-auto w-full max-w-5xl">
+            <div x-data="{ activeTab: 'upcoming' }" class="event-series-tabs-container">
+              <div class="event-series-tabs">
+                <button
+                  type="button"
+                  class="event-series-tab"
+                  x-bind:class="{ 'event-series-tab--active': activeTab === 'upcoming' }"
+                  x-on:click="activeTab = 'upcoming'">Upcoming</button
+                >
+                <button
+                  type="button"
+                  class="event-series-tab"
+                  x-bind:class="{ 'event-series-tab--active': activeTab === 'past' }"
+                  x-on:click="activeTab = 'past'">Past</button
+                >
+              </div>
 
-          <div x-show="activeTab === 'upcoming'" class="event-series-list">
-            {
-              altMeetupsUpcoming.length > 0 ? (
-                altMeetupsUpcoming.map((event) => (
-                  <EventSeriesCard event={event} isPast={false} showVideo={false} />
-                ))
-              ) : (
-                <p class="event-series-empty">
-                  No upcoming Alt Cloud Meetups at the moment. Check back soon!
-                </p>
-              )
-            }
-          </div>
+              <div x-show="activeTab === 'upcoming'" class="event-series-list">
+                {
+                  altMeetupsUpcoming.length > 0 ? (
+                    altMeetupsUpcoming.map((event) => (
+                      <EventSeriesCard event={event} isPast={false} showVideo={false} />
+                    ))
+                  ) : (
+                    <p class="event-series-empty">
+                      No upcoming Alt Cloud Meetups at the moment. Check back soon!
+                    </p>
+                  )
+                }
+              </div>
 
-          <div x-show="activeTab === 'past'" class="event-series-list" style="display: none;">
-            {
-              altMeetupsPast.length > 0 ? (
-                altMeetupsPast.map((event) => (
-                  <EventSeriesCard event={event} isPast={true} showVideo={true} />
-                ))
-              ) : (
-                <p class="event-series-empty">No past Alt Cloud Meetups recorded yet.</p>
-              )
-            }
+              <div x-show="activeTab === 'past'" class="event-series-list" style="display: none;">
+                {
+                  altMeetupsPast.length > 0 ? (
+                    altMeetupsPast.map((event) => (
+                      <EventSeriesCard event={event} isPast={true} showVideo={true} />
+                    ))
+                  ) : (
+                    <p class="event-series-empty">No past Alt Cloud Meetups recorded yet.</p>
+                  )
+                }
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+      <ModuleConnector />
+    </div>
 
     <MediaLightbox selector="" />
     <Footer showIllustration={false} showBackground={false} showCTA={false} />

--- a/src/pages/events/community-huddles.astro
+++ b/src/pages/events/community-huddles.astro
@@ -8,6 +8,8 @@ import Footer from '@components/Footer.astro';
 import SecondaryTabNav from '@components/SecondaryTabNav.astro';
 import EventSeriesCard from '@components/events/EventSeriesCard.astro';
 import CommunityHuddlePastModal from '@components/events/CommunityHuddlePastModal.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
+import SectionLine from '@components/SectionLine.astro';
 import { getCollectionEntry } from '@utils/collectionUtils';
 
 const page = await getCollectionEntry('pages', 'community-huddles');
@@ -25,70 +27,85 @@ const communityHuddlesPast = past.filter(isEventCommunityHuddle);
 
 <Layout title={title} description={description} bodyClass="page-event-series" meta={meta}>
   <section class="datum-container">
-    <Hero class="light content-alt pb-0" title={title} description={description}>
-      <SecondaryTabNav
-        slot="before-content"
-        ariaLabel="Event categories"
-        mobileLabel="Event category"
-        items={[
-          { label: 'All events', href: '/events', exact: true },
-          { label: 'Community Huddles', href: '/events/community-huddles' },
-          { label: 'Alt Cloud Meetups', href: '/events/alt-cloud-meetups' },
-        ]}
-      />
-    </Hero>
+    <div class="relative">
+      <Hero
+        class="light content-alt pb-0"
+        title={title}
+        description={description}
+        showSectionLines
+        sectionLines={{ left: true, right: true, top: true }}
+      >
+        <SecondaryTabNav
+          slot="before-content"
+          ariaLabel="Event categories"
+          mobileLabel="Event category"
+          items={[
+            { label: 'All events', href: '/events', exact: true },
+            { label: 'Community Huddles', href: '/events/community-huddles' },
+            { label: 'Alt Cloud Meetups', href: '/events/alt-cloud-meetups' },
+          ]}
+        />
+      </Hero>
+      <ModuleConnector />
+    </div>
 
-    <section class="event-series-content section--block section--block--pad bg-platinum pt-0">
-      <div class="max-width-5xl">
-        <div x-data="{ activeTab: 'upcoming' }" class="event-series-tabs-container">
-          <div class="event-series-tabs">
-            <button
-              type="button"
-              class="event-series-tab"
-              x-bind:class="{ 'event-series-tab--active': activeTab === 'upcoming' }"
-              x-on:click="activeTab = 'upcoming'">Upcoming</button
-            >
-            <button
-              type="button"
-              class="event-series-tab"
-              x-bind:class="{ 'event-series-tab--active': activeTab === 'past' }"
-              x-on:click="activeTab = 'past'">Past</button
-            >
-          </div>
+    <div class="relative">
+      <section class="event-series-content section--block section--block--x-pad bg-platinum">
+        <div class="max-width-nav relative pb-10 md:pb-16 lg:pb-20 xl:pb-28">
+          <SectionLine left top bottom />
+          <div class="mx-auto w-full max-w-5xl">
+            <div x-data="{ activeTab: 'upcoming' }" class="event-series-tabs-container">
+              <div class="event-series-tabs">
+                <button
+                  type="button"
+                  class="event-series-tab"
+                  x-bind:class="{ 'event-series-tab--active': activeTab === 'upcoming' }"
+                  x-on:click="activeTab = 'upcoming'">Upcoming</button
+                >
+                <button
+                  type="button"
+                  class="event-series-tab"
+                  x-bind:class="{ 'event-series-tab--active': activeTab === 'past' }"
+                  x-on:click="activeTab = 'past'">Past</button
+                >
+              </div>
 
-          <div x-show="activeTab === 'upcoming'" class="event-series-list">
-            {
-              communityHuddlesUpcoming.length > 0 ? (
-                communityHuddlesUpcoming.map((event) => (
-                  <EventSeriesCard event={event} isPast={false} showVideo={false} />
-                ))
-              ) : (
-                <p class="event-series-empty">
-                  No Community Huddles scheduled for next month yet. Check back soon!
-                </p>
-              )
-            }
-          </div>
+              <div x-show="activeTab === 'upcoming'" class="event-series-list">
+                {
+                  communityHuddlesUpcoming.length > 0 ? (
+                    communityHuddlesUpcoming.map((event) => (
+                      <EventSeriesCard event={event} isPast={false} showVideo={false} />
+                    ))
+                  ) : (
+                    <p class="event-series-empty">
+                      No Community Huddles scheduled for next month yet. Check back soon!
+                    </p>
+                  )
+                }
+              </div>
 
-          <div x-show="activeTab === 'past'" class="event-series-list" style="display: none;">
-            {
-              communityHuddlesPast.length > 0 ? (
-                communityHuddlesPast.map((event) => (
-                  <EventSeriesCard
-                    event={event}
-                    isPast={true}
-                    showVideo={true}
-                    pastOpensDetailModal={true}
-                  />
-                ))
-              ) : (
-                <p class="event-series-empty">No past Community Huddles recorded yet.</p>
-              )
-            }
+              <div x-show="activeTab === 'past'" class="event-series-list" style="display: none;">
+                {
+                  communityHuddlesPast.length > 0 ? (
+                    communityHuddlesPast.map((event) => (
+                      <EventSeriesCard
+                        event={event}
+                        isPast={true}
+                        showVideo={true}
+                        pastOpensDetailModal={true}
+                      />
+                    ))
+                  ) : (
+                    <p class="event-series-empty">No past Community Huddles recorded yet.</p>
+                  )
+                }
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+      <ModuleConnector />
+    </div>
 
     <CommunityHuddlePastModal />
     <Footer showIllustration={false} showBackground={false} showCTA={false} />

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -10,6 +10,8 @@ import Hero from '@components/Hero.astro';
 import SecondaryTabNav from '@components/SecondaryTabNav.astro';
 import Footer from '@components/Footer.astro';
 import Card from '@components/events/Card.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
+import SectionLine from '@components/SectionLine.astro';
 
 const page = await getCollectionEntry('pages', 'events');
 
@@ -66,23 +68,38 @@ const jsonLd = {
 
 <Layout title={title} description={description} bodyClass="page-events" meta={meta} jsonLd={jsonLd}>
   <section class="datum-container">
-    <Hero class="light content-alt pb-0" title={title} description={description}>
-      <SecondaryTabNav
-        slot="before-content"
-        ariaLabel="Event categories"
-        mobileLabel="Event category"
-        items={[
-          { label: 'All events', href: '/events', exact: true },
-          { label: 'Community Huddles', href: '/events/community-huddles' },
-          { label: 'Alt Cloud Meetups', href: '/events/alt-cloud-meetups' },
-        ]}
-      />
-    </Hero>
+    <div class="relative">
+      <Hero
+        class="light content-alt pb-0"
+        title={title}
+        description={description}
+        showSectionLines
+        sectionLines={{ left: true, right: true, top: true }}
+      >
+        <SecondaryTabNav
+          slot="before-content"
+          ariaLabel="Event categories"
+          mobileLabel="Event category"
+          items={[
+            { label: 'All events', href: '/events', exact: true },
+            { label: 'Community Huddles', href: '/events/community-huddles' },
+            { label: 'Alt Cloud Meetups', href: '/events/alt-cloud-meetups' },
+          ]}
+        />
+      </Hero>
+      <ModuleConnector />
+    </div>
 
-    <div class="section--block section--block--pad bg-platinum pt-0">
-      <div class="max-width">
-        <Card />
+    <div class="relative">
+      <div class="section--block section--block--x-pad bg-platinum">
+        <div class="max-width-nav relative pb-10 md:pb-16 lg:pb-20 xl:pb-28">
+          <SectionLine left top bottom />
+          <div class="max-width-nopad">
+            <Card />
+          </div>
+        </div>
       </div>
+      <ModuleConnector />
     </div>
 
     <Footer showIllustration={false} showBackground={false} showCTA={false} />

--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -9,6 +9,7 @@ import { fetchGitHubRoadmaps, isRoadmapShipped } from '@libs/githubRoadmap';
 import Layout from '@layouts/Layout.astro';
 import Hero from '@components/Hero.astro';
 import Footer from '@components/Footer.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
 import SecondaryTabNav from '@components/SecondaryTabNav.astro';
 import RoadmapGrid from '@components/roadmap/RoadmapGrid.astro';
 import RoadmapViewFilter from '@components/roadmap/RoadmapViewFilter.astro';
@@ -36,20 +37,29 @@ const tabItems = [
 
 <Layout title={heroTitle} description={description} bodyClass="page-roadmap" meta={meta}>
   <section class="datum-container">
-    <Hero class="light content-alt" title={heroTitle} description={description} />
+    <div class="relative">
+      <Hero
+        class="light content-alt"
+        title={heroTitle}
+        description={description}
+        showSectionLines
+        sectionLines={{ left: true, right: true, top: true }}
+      />
 
-    <div class="section--block section--block--pad bg-platinum pt-0">
-      <div class="max-width">
-        <div class="mb-8 md:mb-13 lg:mb-18">
-          <SecondaryTabNav
-            ariaLabel="Roadmap sections"
-            mobileLabel="Roadmap section"
-            items={tabItems}
-          />
+      <div class="section--block section--block--pad bg-platinum pt-0">
+        <div class="max-width">
+          <div class="mb-8 md:mb-13 lg:mb-18">
+            <SecondaryTabNav
+              ariaLabel="Roadmap sections"
+              mobileLabel="Roadmap section"
+              items={tabItems}
+            />
+          </div>
+          <RoadmapGrid roadmaps={roadmaps} />
+          <RoadmapViewFilter />
         </div>
-        <RoadmapGrid roadmaps={roadmaps} />
-        <RoadmapViewFilter />
       </div>
+      <ModuleConnector />
     </div>
 
     <Footer />

--- a/src/pages/roadmap/backlog.astro
+++ b/src/pages/roadmap/backlog.astro
@@ -10,6 +10,7 @@ import { fetchGitHubRoadmaps, isRoadmapShipped } from '@libs/githubRoadmap';
 import Layout from '@layouts/Layout.astro';
 import Hero from '@components/Hero.astro';
 import Footer from '@components/Footer.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
 import SecondaryTabNav from '@components/SecondaryTabNav.astro';
 import RoadmapBacklog from '@components/roadmap/RoadmapBacklog.astro';
 import BacklogLiveUpdate from '@components/roadmap/BacklogLiveUpdate.astro';
@@ -42,21 +43,30 @@ const tabItems = [
 
 <Layout title={layoutTitle} description={layoutDescription} bodyClass="page-backlog" meta={meta}>
   <section class="datum-container">
-    <Hero class="light content-alt" title={heroTitle} description={heroDescription} />
+    <div class="relative">
+      <Hero
+        class="light content-alt"
+        title={heroTitle}
+        description={heroDescription}
+        showSectionLines
+        sectionLines={{ left: true, right: true, top: true }}
+      />
 
-    <div class="section--block section--block--pad bg-platinum pt-0">
-      <div class="max-width">
-        <div class="mb-8 md:mb-13 lg:mb-18">
-          <SecondaryTabNav
-            ariaLabel="Roadmap sections"
-            mobileLabel="Roadmap section"
-            items={tabItems}
-          />
+      <div class="section--block section--block--pad bg-platinum pt-0">
+        <div class="max-width">
+          <div class="mb-8 md:mb-13 lg:mb-18">
+            <SecondaryTabNav
+              ariaLabel="Roadmap sections"
+              mobileLabel="Roadmap section"
+              items={tabItems}
+            />
+          </div>
+          <BacklogLiveUpdate updatedAt={backlogUpdatedAt} isRefreshing={backlogIsRefreshing}>
+            <RoadmapBacklog items={backlogItems} updatedAt={backlogUpdatedAt} />
+          </BacklogLiveUpdate>
         </div>
-        <BacklogLiveUpdate updatedAt={backlogUpdatedAt} isRefreshing={backlogIsRefreshing}>
-          <RoadmapBacklog items={backlogItems} updatedAt={backlogUpdatedAt} />
-        </BacklogLiveUpdate>
       </div>
+      <ModuleConnector />
     </div>
 
     <Footer />


### PR DESCRIPTION
## Summary

Continues the utility-header consolidation from #1655 by applying the `/brand` header pattern from #1650 across remaining resource-style pages: light hero with `{ left, right, top }` section lines, `ModuleConnector` for a continuous nav line, and aligned content wrappers.

Refs #1650

### Blog
- Listing, category, and paginated category pages: split hero/content connectors; dark list section uses `bg-app---dark---utility-2` section lines and matching connector bar
- Article detail (`/blog/[slug]`): section lines + connector on glacier-mist content; paginated numeric routes aligned with listing
- Footer moved outside content section on detail pages

### Roadmap
- `/roadmap` and `/roadmap/backlog`: brand-style hero section lines + `ModuleConnector`; platinum content wrapper

### Careers
- Mission, Culture, Benefits, and Roles sections: per-section `SectionLine` + `ModuleConnector` so the sticky bar stays connected through each block
- Roles section uses `left top bottom` lines

### Events
- `/events`, `/events/community-huddles`, `/events/alt-cloud-meetups`: hero section lines + platinum content section lines with split connectors

## Context

Issue #1650 flags inconsistent hero/header treatments across utility pages. This branch extends the provisional `/brand` default (plain light hero, corner section lines, optional subtitle/eyebrow) to blog, roadmap, careers, and events so new drift stops while the broader design rules are finalized.

Contact, brand, handbook, and legal were handled in #1655 (`fix/nav-consolidation`).

## Test plan

- [x] `/blog` — hero lines render; connector switches to dark utility color over the midnight-fjord list
- [x] `/blog/[slug]` — left line connects from nav through article content without a gap
- [x] `/blog/category/[slug]` and paginated routes — same header/connector behavior as listing
- [x] `/roadmap` and `/roadmap/backlog` — hero lines + connector; tab nav and grid unchanged
- [x] `/careers` — section lines visible on Mission, Culture, Benefits, and Roles; connector continuous on scroll
- [x] `/careers?ashby_jid=…` — roles section still renders for Ashby embed
- [x] `/events`, `/events/community-huddles`, `/events/alt-cloud-meetups` — hero + content section lines; secondary tab nav unchanged
- [x] Scroll up/down on each page — section lines animate in/out; connector bar stays aligned with left grid line