### PR TITLE
fix(styles): add roadmap detail section lines and simplify events

### DIFF
--- a/src/components/about/Companies.astro
+++ b/src/components/about/Companies.astro
@@ -1,51 +1,59 @@
 ---
+// src/components/about/Companies.astro
 import { Image } from 'astro:assets';
 import { type CollectionEntry } from 'astro:content';
 import Illustration from '@content/about/images/illustration-2.png';
+import SectionLine from '@components/SectionLine.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
 
 const { content } = Astro.props as { content: CollectionEntry<'about'> };
 const companies = content.data.companies || [];
 ---
 
-<section class="bg-glacier-mist-800 section--block section--block--pad relative">
-  <Image
-    src={Illustration}
-    alt="Illustration"
-    class="absolute right-0 bottom-0 hidden size-auto w-[194px] md:block"
-  />
-  <div class="max-width">
-    <div class="border-midnight-fjord bg-glacier-mist-800 relative z-10 m-auto border">
-      <div class="relative z-10 flex flex-col">
-        <span class="absolute top-0 left-0 translate-x-8 -translate-y-4">
-          <p
-            class="datum-docs-sidebar-headings bg-glacier-mist-800 inline-flex px-5 py-2 text-balance uppercase md:whitespace-nowrap"
-          >
-            {content.data.title}
-          </p>
-        </span>
+<div class="relative">
+  <section class="section--block section--block--x-pad bg-glacier-mist-800 relative">
+    <Image
+      src={Illustration}
+      alt="Illustration"
+      class="absolute right-0 bottom-0 hidden size-auto w-[194px] md:block"
+    />
+    <div class="max-width-nav relative py-10 md:py-16 lg:py-20 xl:py-28">
+      <SectionLine left top />
+      <div class="max-width-nopad">
+        <div class="border-midnight-fjord bg-glacier-mist-800 relative z-10 m-auto border">
+          <div class="relative z-10 flex flex-col">
+            <span class="absolute top-0 left-0 translate-x-8 -translate-y-4">
+              <p
+                class="datum-docs-sidebar-headings bg-glacier-mist-800 inline-flex px-5 py-2 text-balance uppercase md:whitespace-nowrap"
+              >
+                {content.data.title}
+              </p>
+            </span>
 
-        <!-- Companies Section -->
-        {
-          companies.length > 0 && (
-            <div class="px-6 py-4 md:px-10 md:py-6.25 xl:px-12 xl:py-8.75">
-              <div class="grid grid-cols-3 overflow-x-auto md:grid-cols-7">
-                {companies.map(
-                  (company) =>
-                    company.img && (
-                      <div class="flex aspect-29/21 items-center justify-center">
-                        <Image
-                          src={company.img}
-                          alt={company.alt ?? ''}
-                          class="logo-img logo-img--standard"
-                        />
-                      </div>
-                    )
-                )}
-              </div>
-            </div>
-          )
-        }
+            {
+              companies.length > 0 && (
+                <div class="px-6 py-4 md:px-10 md:py-6.25 xl:px-12 xl:py-8.75">
+                  <div class="grid grid-cols-3 overflow-x-auto md:grid-cols-7">
+                    {companies.map(
+                      (company) =>
+                        company.img && (
+                          <div class="flex aspect-29/21 items-center justify-center">
+                            <Image
+                              src={company.img}
+                              alt={company.alt ?? ''}
+                              class="logo-img logo-img--standard"
+                            />
+                          </div>
+                        )
+                    )}
+                  </div>
+                </div>
+              )
+            }
+          </div>
+        </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
+  <ModuleConnector />
+</div>

--- a/src/components/about/Investors.astro
+++ b/src/components/about/Investors.astro
@@ -1,47 +1,56 @@
 ---
+// src/components/about/Investors.astro
 import { type CollectionEntry } from 'astro:content';
 import { Image } from 'astro:assets';
+import SectionLine from '@components/SectionLine.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
 
 const { content } = Astro.props as { content: CollectionEntry<'about'> };
 const investors = content.data.investors || [];
 ---
 
-<section id="investors" class="bg-aurora-moss section--block section--block--pad relative">
-  <div class="max-width relative z-10 text-center">
-    <h3
-      class="datum-text-8xl mx-auto mb-8 max-w-sm text-center md:mb-12 md:max-w-xl lg:mb-16 xl:mb-21"
-    >
-      {content.data.title}
-    </h3>
+<div class="relative">
+  <section id="investors" class="section--block section--block--x-pad bg-aurora-moss relative">
+    <div class="max-width-nav relative py-10 md:py-16 lg:py-20 xl:py-28">
+      <SectionLine left top bottom />
+      <div class="max-width-nopad relative z-10 text-center">
+        <h3
+          class="datum-text-8xl mx-auto mb-8 max-w-sm text-center md:mb-12 md:max-w-xl lg:mb-16 xl:mb-21"
+        >
+          {content.data.title}
+        </h3>
 
-    <div
-      class="flex flex-wrap justify-center-safe gap-4 md:gap-6 xl:gap-9 [&>div]:w-full [&>div]:sm:w-[279px]"
-    >
-      {
-        investors.length > 0 &&
-          investors.map(
-            (investor) =>
-              investor.img && (
-                <div class="border-pine-forge bg-aurora-moss flex items-center justify-center border px-8 py-4 md:p-10">
-                  {investor.url ? (
-                    <a href={investor.url} target="_blank" rel="noreferrer" class="block">
-                      <Image
-                        src={investor.img}
-                        alt={investor.alt ?? ''}
-                        class="logo-img logo-img--standard size-auto max-h-19 max-w-38 mix-blend-multiply"
-                      />
-                    </a>
-                  ) : (
-                    <Image
-                      src={investor.img}
-                      alt={investor.alt ?? ''}
-                      class="logo-img logo-img--standard size-auto max-h-19 max-w-38 mix-blend-multiply"
-                    />
-                  )}
-                </div>
+        <div
+          class="flex flex-wrap justify-center-safe gap-4 md:gap-6 xl:gap-9 [&>div]:w-full [&>div]:sm:w-[279px]"
+        >
+          {
+            investors.length > 0 &&
+              investors.map(
+                (investor) =>
+                  investor.img && (
+                    <div class="border-pine-forge bg-aurora-moss flex items-center justify-center border px-8 py-4 md:p-10">
+                      {investor.url ? (
+                        <a href={investor.url} target="_blank" rel="noreferrer" class="block">
+                          <Image
+                            src={investor.img}
+                            alt={investor.alt ?? ''}
+                            class="logo-img logo-img--standard size-auto max-h-19 max-w-38 mix-blend-multiply"
+                          />
+                        </a>
+                      ) : (
+                        <Image
+                          src={investor.img}
+                          alt={investor.alt ?? ''}
+                          class="logo-img logo-img--standard size-auto max-h-19 max-w-38 mix-blend-multiply"
+                        />
+                      )}
+                    </div>
+                  )
               )
-          )
-      }
+          }
+        </div>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
+  <ModuleConnector />
+</div>

--- a/src/components/about/OurMission.astro
+++ b/src/components/about/OurMission.astro
@@ -1,34 +1,39 @@
 ---
+// src/components/about/OurMission.astro
 import illustration from '@content/about/images/about.png';
 import { Image } from 'astro:assets';
 import { render, type CollectionEntry } from 'astro:content';
+import SectionLine from '@components/SectionLine.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
 
 const { content } = Astro.props as { content: CollectionEntry<'about'> };
 const { Content } = await render(content);
 ---
 
-<section
-  class="section--block overflow-clip bg-white pt-8 pb-14 md:pt-10 md:pb-16 xl:pt-16 xl:pb-24"
->
-  <div class="max-width">
-    <div
-      class="flex flex-col items-center justify-center gap-8 md:flex-row md:gap-12 lg:gap-16 xl:gap-31"
-    >
-      <div class="grow">
-        <Image
-          src={illustration}
-          alt="About"
-          class="size-auto w-full md:w-auto md:max-w-92 lg:max-w-128.5"
-        />
-      </div>
-      <div class="grow">
-        <h1 class="datum-text-8xl mb-8.75">
-          {content.data.title}
-        </h1>
-        <div class="datum-text-xl">
-          <Content />
+<div class="relative">
+  <section class="section--block section--block--x-pad overflow-clip bg-white">
+    <div class="max-width-nav relative pt-8 pb-14 md:pt-10 md:pb-16 xl:pt-16 xl:pb-24">
+      <SectionLine left right top />
+      <div
+        class="max-width-nopad flex flex-col items-center justify-center gap-8 md:flex-row md:gap-12 lg:gap-16 xl:gap-31"
+      >
+        <div class="grow">
+          <Image
+            src={illustration}
+            alt="About"
+            class="size-auto w-full md:w-auto md:max-w-92 lg:max-w-128.5"
+          />
+        </div>
+        <div class="grow">
+          <h1 class="datum-text-8xl mb-8.75">
+            {content.data.title}
+          </h1>
+          <div class="datum-text-xl">
+            <Content />
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
+  <ModuleConnector />
+</div>

--- a/src/components/about/PeopleStrapi.astro
+++ b/src/components/about/PeopleStrapi.astro
@@ -4,6 +4,8 @@ import { getStrapiTeamMembers, getTeamBgColor } from '@libs/strapi';
 import { getStrapiMediaUrl } from '@/src/types/strapi';
 import type { StrapiAuthorFull } from '@libs/strapi';
 import ProfileModal from './ProfileModal.astro';
+import SectionLine from '@components/SectionLine.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
 import '@styles/page-about.css';
 
 // Fetch all team members from Strapi (authors where isTeam is true)
@@ -27,64 +29,68 @@ const teamMembersData = teamMembers.map((member, index) => ({
 }));
 ---
 
-<section class="bg-glacier-mist-700 section--block section--block--pad">
-  <div class="max-width">
-    <div class="relative z-10">
-      <h3 class="datum-text-8xl mx-auto mb-8 max-w-sm text-center md:max-w-md lg:mb-10">
-        Meet the people behind Datum
-      </h3>
+<div class="relative">
+  <section class="section--block section--block--x-pad bg-glacier-mist-700">
+    <div class="max-width-nav relative py-10 md:py-16 lg:py-20 xl:py-28">
+      <SectionLine left top />
+      <div class="max-width-nopad relative z-10">
+        <h3 class="datum-text-8xl mx-auto mb-8 max-w-sm text-center md:max-w-md lg:mb-10">
+          Meet the people behind Datum
+        </h3>
 
-      <p
-        class="datum-text-lg mx-auto mb-8 max-w-sm text-center md:mb-12 lg:mb-16 lg:max-w-lg xl:mb-21"
-      >
-        We are infrastructure, open source software, and design nerds who love building for the
-        future.
-      </p>
+        <p
+          class="datum-text-lg mx-auto mb-8 max-w-sm text-center md:mb-12 lg:mb-16 lg:max-w-lg xl:mb-21"
+        >
+          We are infrastructure, open source software, and design nerds who love building for the
+          future.
+        </p>
 
-      {
-        teamMembers.length === 0 ? (
-          <div class="py-12 text-center">
-            <p class="text-gray-500">No team members found.</p>
-          </div>
-        ) : (
-          <div class="grid grid-cols-2 gap-6 md:grid-cols-4 xl:grid-cols-5">
-            {teamMembers.map((member, index) => (
-              <button
-                class="people--card"
-                data-member-trigger
-                data-member-index={index}
-                type="button"
-                tabindex={0}
-                aria-label={`View ${member.name}'s profile`}
-              >
-                {member.avatar && (
-                  <div class="people--card-avatar">
-                    <img
-                      src={getStrapiMediaUrl(member.avatar.url)}
-                      alt={member.name}
-                      class="size-auto w-full bg-cover"
-                      style={`background-color: ${getTeamBgColor(index)}`}
-                    />
-                    {/* Check if member.title contains "Co-Founder" and show Founder label */}
-                    {member.title && member.title.includes('Co-Founder') && (
-                      <span class="people--card-founder-label">Founder</span>
-                    )}
-                  </div>
-                )}
+        {
+          teamMembers.length === 0 ? (
+            <div class="py-12 text-center">
+              <p class="text-gray-500">No team members found.</p>
+            </div>
+          ) : (
+            <div class="grid grid-cols-2 gap-6 md:grid-cols-4 xl:grid-cols-5">
+              {teamMembers.map((member, index) => (
+                <button
+                  class="people--card"
+                  data-member-trigger
+                  data-member-index={index}
+                  type="button"
+                  tabindex={0}
+                  aria-label={`View ${member.name}'s profile`}
+                >
+                  {member.avatar && (
+                    <div class="people--card-avatar">
+                      <img
+                        src={getStrapiMediaUrl(member.avatar.url)}
+                        alt={member.name}
+                        class="size-auto w-full bg-cover"
+                        style={`background-color: ${getTeamBgColor(index)}`}
+                      />
+                      {/* Check if member.title contains "Co-Founder" and show Founder label */}
+                      {member.title && member.title.includes('Co-Founder') && (
+                        <span class="people--card-founder-label">Founder</span>
+                      )}
+                    </div>
+                  )}
 
-                <h4 class="people--card-name">{member.name}</h4>
+                  <h4 class="people--card-name">{member.name}</h4>
 
-                <div class="people--card-title">{member.title && <p>{member.title}</p>}</div>
-              </button>
-            ))}
-          </div>
-        )
-      }
+                  <div class="people--card-title">{member.title && <p>{member.title}</p>}</div>
+                </button>
+              ))}
+            </div>
+          )
+        }
+      </div>
     </div>
-  </div>
 
-  <ProfileModal />
-</section>
+    <ProfileModal />
+  </section>
+  <ModuleConnector />
+</div>
 
 <script is:inline define:vars={{ teamMembersData }}>
   const teamData = teamMembersData;

--- a/src/pages/events/alt-cloud-meetups.astro
+++ b/src/pages/events/alt-cloud-meetups.astro
@@ -9,7 +9,6 @@ import SecondaryTabNav from '@components/SecondaryTabNav.astro';
 import EventSeriesCard from '@components/events/EventSeriesCard.astro';
 import MediaLightbox from '@components/MediaLightbox.astro';
 import ModuleConnector from '@components/home/ModuleConnector.astro';
-import SectionLine from '@components/SectionLine.astro';
 import { getCollectionEntry } from '@utils/collectionUtils';
 
 const page = await getCollectionEntry('pages', 'alt-cloud-meetups');
@@ -51,7 +50,6 @@ const altMeetupsPast = past.filter(isEventAltCloudMeetup);
     <div class="relative">
       <section class="event-series-content section--block section--block--x-pad bg-platinum">
         <div class="max-width-nav relative pb-10 md:pb-16 lg:pb-20 xl:pb-28">
-          <SectionLine left top bottom />
           <div class="mx-auto w-full max-w-5xl">
             <div x-data="{ activeTab: 'upcoming' }" class="event-series-tabs-container">
               <div class="event-series-tabs">
@@ -98,7 +96,6 @@ const altMeetupsPast = past.filter(isEventAltCloudMeetup);
           </div>
         </div>
       </section>
-      <ModuleConnector />
     </div>
 
     <MediaLightbox selector="" />

--- a/src/pages/events/community-huddles.astro
+++ b/src/pages/events/community-huddles.astro
@@ -9,7 +9,6 @@ import SecondaryTabNav from '@components/SecondaryTabNav.astro';
 import EventSeriesCard from '@components/events/EventSeriesCard.astro';
 import CommunityHuddlePastModal from '@components/events/CommunityHuddlePastModal.astro';
 import ModuleConnector from '@components/home/ModuleConnector.astro';
-import SectionLine from '@components/SectionLine.astro';
 import { getCollectionEntry } from '@utils/collectionUtils';
 
 const page = await getCollectionEntry('pages', 'community-huddles');
@@ -52,7 +51,6 @@ const communityHuddlesPast = past.filter(isEventCommunityHuddle);
     <div class="relative">
       <section class="event-series-content section--block section--block--x-pad bg-platinum">
         <div class="max-width-nav relative pb-10 md:pb-16 lg:pb-20 xl:pb-28">
-          <SectionLine left top bottom />
           <div class="mx-auto w-full max-w-5xl">
             <div x-data="{ activeTab: 'upcoming' }" class="event-series-tabs-container">
               <div class="event-series-tabs">
@@ -104,7 +102,6 @@ const communityHuddlesPast = past.filter(isEventCommunityHuddle);
           </div>
         </div>
       </section>
-      <ModuleConnector />
     </div>
 
     <CommunityHuddlePastModal />

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -11,7 +11,6 @@ import SecondaryTabNav from '@components/SecondaryTabNav.astro';
 import Footer from '@components/Footer.astro';
 import Card from '@components/events/Card.astro';
 import ModuleConnector from '@components/home/ModuleConnector.astro';
-import SectionLine from '@components/SectionLine.astro';
 
 const page = await getCollectionEntry('pages', 'events');
 
@@ -93,13 +92,11 @@ const jsonLd = {
     <div class="relative">
       <div class="section--block section--block--x-pad bg-platinum">
         <div class="max-width-nav relative pb-10 md:pb-16 lg:pb-20 xl:pb-28">
-          <SectionLine left top bottom />
           <div class="max-width-nopad">
             <Card />
           </div>
         </div>
       </div>
-      <ModuleConnector />
     </div>
 
     <Footer showIllustration={false} showBackground={false} showCTA={false} />

--- a/src/pages/roadmap/[slug].astro
+++ b/src/pages/roadmap/[slug].astro
@@ -13,6 +13,8 @@ import {
 import Layout from '@layouts/Layout.astro';
 import Hero from '@components/Hero.astro';
 import Footer from '@components/Footer.astro';
+import ModuleConnector from '@components/home/ModuleConnector.astro';
+import SectionLine from '@components/SectionLine.astro';
 import RoadmapDetailContent from '@components/roadmap/RoadmapDetailContent.astro';
 
 const { slug } = Astro.params as { slug: string };
@@ -57,10 +59,16 @@ const pageDescription = roadmap.summary ?? `Datum roadmap for ${formattedDate}.`
   <section class="datum-container">
     <Hero class="light" hideContent={true} hideHero />
 
-    <div class="section--block section--block--pad bg-platinum">
-      <div class="max-width">
-        <RoadmapDetailContent roadmap={roadmap} />
-      </div>
+    <div class="relative">
+      <section class="section--block section--block--x-pad bg-platinum">
+        <div class="max-width-nav relative py-10 md:py-16 lg:py-20 xl:py-28">
+          <SectionLine left top bottom />
+          <div class="max-width-nopad">
+            <RoadmapDetailContent roadmap={roadmap} />
+          </div>
+        </div>
+      </section>
+      <ModuleConnector />
     </div>
 
     <Footer />


### PR DESCRIPTION
Wire section lines and a module connector into roadmap release detail pages. Drop redundant content-section lines and connectors on events pages now that the hero treatment carries the grid line.