### PR TITLE
fix(styles): align section line corners across pages

### DIFF
--- a/src/components/career/Benefits.astro
+++ b/src/components/career/Benefits.astro
@@ -46,7 +46,7 @@ const benefits = [
 <div class="relative">
   <section id="benefits" class="section--block section--block--x-pad bg-glacier-mist-700">
     <div class="max-width-nav relative py-10 md:py-16 lg:py-20 xl:py-28">
-      <SectionLine left top />
+      <SectionLine left right top bottom />
       <div class="max-width-nopad">
         <h2 class="datum-text-8xl mb-10 text-center font-medium">Open by design</h2>
         <p class="datum-text-lg mb-10 text-center text-pretty md:mb-18">

--- a/src/components/career/Culture.astro
+++ b/src/components/career/Culture.astro
@@ -13,7 +13,7 @@ import ModuleConnector from '@components/home/ModuleConnector.astro';
     class="career-culture section--block section--block--x-pad bg-glacier-mist-800 overflow-clip"
   >
     <div class="max-width-nav relative py-10 md:py-16 lg:py-20 xl:py-28">
-      <SectionLine left top />
+      <SectionLine left right top />
       <div class="max-width-nopad relative z-20">
         <div class="text-midnight-fjord grid grid-cols-1 gap-14 md:grid-cols-2 md:gap-20 lg:gap-26">
           <div class="col-span-1 flex flex-col gap-6">

--- a/src/components/career/Mission.astro
+++ b/src/components/career/Mission.astro
@@ -14,7 +14,7 @@ const { Content } = await render(content);
 <div class="relative">
   <section id="mission" class="section--block section--block--x-pad overflow-clip bg-white">
     <div class="max-width-nav relative pt-8 pb-14 md:pt-10 md:pb-16 xl:pt-16 xl:pb-24">
-      <SectionLine left right top />
+      <SectionLine left right top bottom />
       <div
         class="max-width-nopad flex flex-col items-center justify-center gap-8 md:flex-row md:gap-12 lg:gap-16 xl:gap-31"
       >

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -350,7 +350,7 @@ const processedBlocks: ProcessedBlock[] =
         <div class="relative">
           <section class="section--block section--block--x-pad bg-glacier-mist-700">
             <div class="max-width-nav relative pt-6 md:pt-10 xl:pt-16">
-              <SectionLine left top bottom />
+              <SectionLine left right top />
               <div class="max-width blog-detail max-w-256.5 pb-14 md:pb-20 lg:pb-28">
                 <aside class="blog-aside">
                   <div class="blog-aside-content sticky top-0">

--- a/src/pages/blog/category/[slug].astro
+++ b/src/pages/blog/category/[slug].astro
@@ -68,7 +68,7 @@ const subtitle = 'Blog';
     <div class="relative">
       <div class="section--block section--block--x-pad section--block--pad bg-midnight-fjord dark">
         <div class="max-width-nav relative">
-          <SectionLine left top bottom class="bg-app---dark---utility-2" />
+          <SectionLine left top class="bg-app---dark---utility-2" />
           <div class="max-width relative">
             <!-- Hidden meta tag to identify this as a category page -->
             <span style="display: none;">category</span>

--- a/src/pages/blog/category/[slug]/[page].astro
+++ b/src/pages/blog/category/[slug]/[page].astro
@@ -70,7 +70,7 @@ const subtitle = 'Blog';
     <div class="relative">
       <div class="section--block section--block--x-pad section--block--pad bg-midnight-fjord dark">
         <div class="max-width-nav relative">
-          <SectionLine left top bottom class="bg-app---dark---utility-2" />
+          <SectionLine left top class="bg-app---dark---utility-2" />
           <div class="max-width relative">
             <!-- Hidden meta tag to identify this as a category page -->
             <span style="display: none;">category</span>

--- a/src/pages/careers.astro
+++ b/src/pages/careers.astro
@@ -46,7 +46,7 @@ const description = fm.description || '';
     <div class="relative">
       <section id="roles" class="section--block section--block--x-pad bg-white">
         <div class="max-width-nav relative py-10 md:py-16 lg:py-20 xl:py-28">
-          <SectionLine left top bottom />
+          <SectionLine left right top bottom />
           <div class="max-width-nopad">
             <h2 class="datum-text-8xl mb-12 text-center font-medium">Ready to join the team?</h2>
 

--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -13,6 +13,7 @@ import ModuleConnector from '@components/home/ModuleConnector.astro';
 import SecondaryTabNav from '@components/SecondaryTabNav.astro';
 import RoadmapGrid from '@components/roadmap/RoadmapGrid.astro';
 import RoadmapViewFilter from '@components/roadmap/RoadmapViewFilter.astro';
+import SectionLine from '@components/SectionLine.astro';
 
 if (Astro.url.searchParams.get('tab') === 'backlog') {
   return Astro.redirect('/roadmap/backlog', 301);
@@ -46,17 +47,20 @@ const tabItems = [
         sectionLines={{ left: true, right: true, top: true }}
       />
 
-      <div class="section--block section--block--pad bg-platinum pt-0">
-        <div class="max-width">
-          <div class="mb-8 md:mb-13 lg:mb-18">
-            <SecondaryTabNav
-              ariaLabel="Roadmap sections"
-              mobileLabel="Roadmap section"
-              items={tabItems}
-            />
+      <div class="section--block bg-platinum pt-0">
+        <div class="max-width-nav bottom-pad relative">
+          <SectionLine left right bottom />
+          <div class="max-width">
+            <div class="mb-8 md:mb-13 lg:mb-18">
+              <SecondaryTabNav
+                ariaLabel="Roadmap sections"
+                mobileLabel="Roadmap section"
+                items={tabItems}
+              />
+            </div>
+            <RoadmapGrid roadmaps={roadmaps} />
+            <RoadmapViewFilter />
           </div>
-          <RoadmapGrid roadmaps={roadmaps} />
-          <RoadmapViewFilter />
         </div>
       </div>
       <ModuleConnector />

--- a/src/pages/roadmap/[slug].astro
+++ b/src/pages/roadmap/[slug].astro
@@ -62,7 +62,7 @@ const pageDescription = roadmap.summary ?? `Datum roadmap for ${formattedDate}.`
     <div class="relative">
       <section class="section--block section--block--x-pad bg-platinum">
         <div class="max-width-nav relative py-10 md:py-16 lg:py-20 xl:py-28">
-          <SectionLine left top bottom />
+          <SectionLine left right top bottom />
           <div class="max-width-nopad">
             <RoadmapDetailContent roadmap={roadmap} />
           </div>

--- a/src/pages/roadmap/backlog.astro
+++ b/src/pages/roadmap/backlog.astro
@@ -14,6 +14,7 @@ import ModuleConnector from '@components/home/ModuleConnector.astro';
 import SecondaryTabNav from '@components/SecondaryTabNav.astro';
 import RoadmapBacklog from '@components/roadmap/RoadmapBacklog.astro';
 import BacklogLiveUpdate from '@components/roadmap/BacklogLiveUpdate.astro';
+import SectionLine from '@components/SectionLine.astro';
 
 const roadmapPage = await getCollectionEntry('pages', 'roadmap');
 const backlogPage = await getCollectionEntry('pages', 'backlog');
@@ -52,18 +53,21 @@ const tabItems = [
         sectionLines={{ left: true, right: true, top: true }}
       />
 
-      <div class="section--block section--block--pad bg-platinum pt-0">
-        <div class="max-width">
-          <div class="mb-8 md:mb-13 lg:mb-18">
-            <SecondaryTabNav
-              ariaLabel="Roadmap sections"
-              mobileLabel="Roadmap section"
-              items={tabItems}
-            />
+      <div class="section--block bg-platinum relative pt-0">
+        <div class="max-width-nav bottom-pad relative">
+          <SectionLine left right bottom />
+          <div class="max-width">
+            <div class="mb-8 md:mb-13 lg:mb-18">
+              <SecondaryTabNav
+                ariaLabel="Roadmap sections"
+                mobileLabel="Roadmap section"
+                items={tabItems}
+              />
+            </div>
+            <BacklogLiveUpdate updatedAt={backlogUpdatedAt} isRefreshing={backlogIsRefreshing}>
+              <RoadmapBacklog items={backlogItems} updatedAt={backlogUpdatedAt} />
+            </BacklogLiveUpdate>
           </div>
-          <BacklogLiveUpdate updatedAt={backlogUpdatedAt} isRefreshing={backlogIsRefreshing}>
-            <RoadmapBacklog items={backlogItems} updatedAt={backlogUpdatedAt} />
-          </BacklogLiveUpdate>
         </div>
       </div>
       <ModuleConnector />

--- a/src/static/styles/utilities.css
+++ b/src/static/styles/utilities.css
@@ -1,3 +1,7 @@
+@utility bottom-pad {
+  @apply pb-10 md:pb-16 lg:pb-20 xl:pb-28;
+}
+
 @utility large-pad {
   @apply py-16 md:py-20 lg:py-30 xl:py-35 2xl:py-40;
 }


### PR DESCRIPTION
Add bottom-pad utility, wrap roadmap content in max-width-nav with bottom SectionLine corners, and correct SectionLine props on blog and career sections.