### PR TITLE
fix(events): August huddle recap video + hash deep-links for Past tab

### DIFF
--- a/src/components/events/CommunityHuddlePastModal.astro
+++ b/src/components/events/CommunityHuddlePastModal.astro
@@ -143,6 +143,14 @@ import Icon from '@components/Icon.astro';
         document.body.toggleAttribute('data-event-modal-open', false);
         window.removeEventListener('click', this.onWindowClick);
         this.clearPayload();
+        // Drop the entry-specific anchor on close, but stay on the Past tab.
+        if (/^#past-/.test(window.location.hash)) {
+          history.replaceState(
+            null,
+            '',
+            `${window.location.pathname}${window.location.search}#past`
+          );
+        }
       });
       window.addEventListener('keydown', (e) => {
         if (e.key === 'Escape' && this.dialog.open) {
@@ -229,6 +237,16 @@ import Icon from '@components/Icon.astro';
       document.body.toggleAttribute('data-event-modal-open', true);
       this.dialogOpenedAt = Date.now();
       setTimeout(() => window.addEventListener('click', this.onWindowClick), 100);
+
+      // Make the open entry shareable, e.g. #past-august-2026.
+      const anchorId = btn.closest<HTMLElement>('article[id^="past-"]')?.id;
+      if (anchorId && window.location.hash.slice(1) !== anchorId) {
+        history.replaceState(
+          null,
+          '',
+          `${window.location.pathname}${window.location.search}#${anchorId}`
+        );
+      }
     }
 
     closeModal() {

--- a/src/components/events/EventSeriesCard.astro
+++ b/src/components/events/EventSeriesCard.astro
@@ -74,6 +74,16 @@ const pastDateLine = formatDate(
   { weekday: 'short', day: 'numeric', month: 'short', year: 'numeric' },
   event.timezone
 );
+// Deep-link anchor for past entries, e.g. "past-august-2026" (/events/community-huddles#past-august-2026).
+const pastMonthSlug = formatDate(
+  event.start_at,
+  'en-US',
+  { month: 'long', year: 'numeric' },
+  event.timezone
+)
+  .toLowerCase()
+  .replace(/\s+/g, '-');
+const pastAnchorId = `past-${pastMonthSlug}`;
 const pastModalPayloadJson =
   isPast && pastOpensDetailModal
     ? JSON.stringify({
@@ -114,6 +124,7 @@ const timezoneAbbr = event.timezone
   isPast ? (
     pastOpensDetailModal && pastModalPayloadJson ? (
       <article
+        id={pastAnchorId}
         class:list={[
           'event-calendar-list__item',
           'event-calendar-list__item--past-datum',
@@ -138,6 +149,7 @@ const timezoneAbbr = event.timezone
       </article>
     ) : (
       <article
+        id={pastAnchorId}
         class:list={[
           'event-calendar-list__item',
           'event-calendar-list__item--past-datum',

--- a/src/content/events/08-2026-august-datum-monthly-community-huddle/index.mdx
+++ b/src/content/events/08-2026-august-datum-monthly-community-huddle/index.mdx
@@ -7,6 +7,7 @@ timezone: America/New_York
 url: "https://luma.com/ewyvgsob?tk=UV9hrK"
 eventType: community-huddle
 coverImage: ./cover.png
+youtubeUrl: "https://www.youtube.com/watch?v=9DlnvWh6X7M"
 ---
 
 - 1.6 & 1.7 Release review

--- a/src/pages/events/community-huddles.astro
+++ b/src/pages/events/community-huddles.astro
@@ -59,7 +59,15 @@ const communityHuddlesPast = past.filter(isEventCommunityHuddle);
                   const hash = window.location.hash.slice(1);
                   activeTab = hash.startsWith('past') ? 'past' : 'upcoming';
                   if (hash.startsWith('past-')) {
-                    $nextTick(() => document.getElementById(hash)?.scrollIntoView({ behavior: 'smooth', block: 'center' }));
+                    $nextTick(() => {
+                      const entry = document.getElementById(hash);
+                      const openTrigger = entry?.querySelector('[data-community-huddle-past-open]');
+                      if (openTrigger instanceof HTMLElement) {
+                        openTrigger.click();
+                      } else {
+                        entry?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                      }
+                    });
                   }
                 };
                 applyHash();

--- a/src/pages/events/community-huddles.astro
+++ b/src/pages/events/community-huddles.astro
@@ -52,19 +52,35 @@ const communityHuddlesPast = past.filter(isEventCommunityHuddle);
       <section class="event-series-content section--block section--block--x-pad bg-platinum">
         <div class="max-width-nav relative pb-10 md:pb-16 lg:pb-20 xl:pb-28">
           <div class="mx-auto w-full max-w-5xl">
-            <div x-data="{ activeTab: 'upcoming' }" class="event-series-tabs-container">
+            <div
+              x-data="{ activeTab: 'upcoming' }"
+              x-init="
+                const applyHash = () => {
+                  const hash = window.location.hash.slice(1);
+                  activeTab = hash.startsWith('past') ? 'past' : 'upcoming';
+                  if (hash.startsWith('past-')) {
+                    $nextTick(() => document.getElementById(hash)?.scrollIntoView({ behavior: 'smooth', block: 'center' }));
+                  }
+                };
+                applyHash();
+                window.addEventListener('hashchange', applyHash);
+              "
+              class="event-series-tabs-container"
+            >
               <div class="event-series-tabs">
                 <button
                   type="button"
                   class="event-series-tab"
                   x-bind:class="{ 'event-series-tab--active': activeTab === 'upcoming' }"
-                  x-on:click="activeTab = 'upcoming'">Upcoming</button
+                  x-on:click="activeTab = 'upcoming'; history.replaceState(null, '', window.location.pathname)"
+                  >Upcoming</button
                 >
                 <button
                   type="button"
                   class="event-series-tab"
                   x-bind:class="{ 'event-series-tab--active': activeTab === 'past' }"
-                  x-on:click="activeTab = 'past'">Past</button
+                  x-on:click="activeTab = 'past'; history.replaceState(null, '', window.location.pathname + '#past')"
+                  >Past</button
                 >
               </div>
 

--- a/src/static/styles/page-event-series.css
+++ b/src/static/styles/page-event-series.css
@@ -82,4 +82,9 @@
     @apply focus-visible:ring-midnight-fjord/40 border-app---dark---utility-5 cursor-pointer transition-[box-shadow,transform,border-color] duration-200 ease-out focus-visible:ring-2 focus-visible:outline-none;
     @apply hover:border-app---dark---utility-3;
   }
+
+  /* Highlight a past entry when deep-linked via #past-<month>-<year> */
+  .event-calendar-list__item:target {
+    @apply border-midnight-fjord ring-midnight-fjord/40 ring-2;
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up on [#1651](https://github.com/datum-cloud/datum.net/issues/1651#issuecomment-5359299675):

- Add the August Community Huddle recap video (Kaley shared the edited YouTube link) — swaps out the "coming soon" placeholder.
- Make `/events/community-huddles` deep-linkable to the Past tab and individual month entries:
  - `#past` opens the Past tab on load.
  - `#past-august-2026` opens the Past tab, opens that month's recap modal, and is restored if you close and reopen.
  - Clicking Upcoming/Past, or opening/closing a recap modal, now keeps the URL hash in sync (via `history.replaceState`), so any state on the page is shareable.

## Changes

- `src/content/events/08-2026-august-datum-monthly-community-huddle/index.mdx` — added `youtubeUrl`.
- `src/components/events/EventSeriesCard.astro` — added a stable `id="past-<month>-<year>"` anchor to each past event's `<article>`.
- `src/pages/events/community-huddles.astro` — hash-aware Alpine tab state (`x-init` reads `location.hash` on load and on `hashchange`; tab clicks update the hash).
- `src/components/events/CommunityHuddlePastModal.astro` — opening a recap modal sets the hash to that entry's anchor; closing resets it to `#past`.
- `src/static/styles/page-event-series.css` — `:target` highlight style for a deep-linked past entry.

## Test plan

- [x] `astro check` — 0 errors, 0 warnings (pre-existing unrelated hints only)
- [x] Prettier/ESLint via pre-commit hook — clean
- [x] Verified rendered markup/script on local dev server (`:4321`) matches source for all scenarios above
- [ ] Manual click-through in browser: visit `#past-august-2026` fresh and confirm the modal opens automatically
- [ ] Manual click-through: open a recap modal by clicking, confirm URL bar updates to `#past-<month>-<year>`, close modal, confirm URL resets to `#past`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
