### PR TITLE
fix(contact): widen panel to match nav/platform gridline alignment

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -34,44 +34,42 @@ const highlightedTitle = fm.title.replace(/\bchat\b/, '<span class="text-aurora-
         <div class="max-width-nav large-pad relative">
           <SectionLine left right top />
 
-          <div class="max-width-nopad">
-            <div class="contact-panel">
-              <SectionLine left top overlap class="bg-midnight-fjord" />
-              <SectionLine right bottom bottomOverlap class="bg-midnight-fjord" />
+          <div class="contact-panel">
+            <SectionLine left top overlap class="bg-midnight-fjord" />
+            <SectionLine right bottom bottomOverlap class="bg-midnight-fjord" />
 
-              <Image
-                src={starfieldImage}
-                alt=""
-                class="pointer-events-none absolute top-1/2 left-1/4 h-auto w-[200%] max-w-none -translate-y-1/2 rotate-16 opacity-60"
-                aria-hidden="true"
-                loading="eager"
-              />
+            <Image
+              src={starfieldImage}
+              alt=""
+              class="pointer-events-none absolute top-1/2 left-1/4 h-auto w-[200%] max-w-none -translate-y-1/2 rotate-16 opacity-60"
+              aria-hidden="true"
+              loading="eager"
+            />
 
-              <div class="contact-panel-inner">
-                <div class="contact-copy">
-                  <SectionEyebrow variant="aurora-moss">Contact</SectionEyebrow>
-                  <h1 class="contact-title" set:html={highlightedTitle} />
-                  <div class="contact-prose">
-                    <Content />
-                  </div>
+            <div class="contact-panel-inner">
+              <div class="contact-copy">
+                <SectionEyebrow variant="aurora-moss">Contact</SectionEyebrow>
+                <h1 class="contact-title" set:html={highlightedTitle} />
+                <div class="contact-prose">
+                  <Content />
                 </div>
+              </div>
 
-                <div class="contact-card">
-                  <div class="contact-card-copy">
-                    <h2 class="contact-card-title">Schedule time with a founder</h2>
-                    <p class="contact-card-description">
-                      Connect with a founder for coffee, questions or idea sharing.
-                    </p>
-                  </div>
-                  <Image src={ImageFounder} alt="Founders" class="contact-card-image" />
-                  <Button
-                    text="Book a time"
-                    class="btn btn--aurora-moss btn--sm"
-                    href="https://link.datum.net/founders"
-                    target="_blank"
-                    data-rybbit-event="Contact: Founder Meeting"
-                  />
+              <div class="contact-card">
+                <div class="contact-card-copy">
+                  <h2 class="contact-card-title">Schedule time with a founder</h2>
+                  <p class="contact-card-description">
+                    Connect with a founder for coffee, questions or idea sharing.
+                  </p>
                 </div>
+                <Image src={ImageFounder} alt="Founders" class="contact-card-image" />
+                <Button
+                  text="Book a time"
+                  class="btn btn--aurora-moss btn--sm"
+                  href="https://link.datum.net/founders"
+                  target="_blank"
+                  data-rybbit-event="Contact: Founder Meeting"
+                />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Fixes the `/contact` page's dark panel gridlines sitting at a narrower x-coordinate than the nav bar and other pages (e.g. `/platform/deliver`).

**Root cause:** `.contact-panel` was nested inside an extra `max-width-nopad` wrapper (1316px), itself inside `max-width-nav` (1520px). Every other page's equivalent content (nav bar, Hero, `/platform/deliver`'s `SectionGroup`) sits directly in the 1520px `max-width-nav` box. The extra wrapper pulled the panel's `SectionLine` gridlines in by 102px per side.

**Fix:** Removed the redundant `max-width-nopad` wrapper so `.contact-panel` sits directly in `max-width-nav`, matching alignment everywhere else.

## Changes

- `src/pages/contact.astro` — dropped the intervening `max-width-nopad` div; pure structural de-indent, no other markup/class changes.

## Test plan

- [x] `astro check` — 0 errors, 0 warnings (pre-existing unrelated hints only)
- [x] Prettier/ESLint via pre-commit hook — clean
- [x] Verified rendered markup on local dev server — `.contact-panel` now a direct child of `max-width-nav large-pad relative`
- [ ] Visual check: confirm `/contact`'s dark panel edges + gridlines now line up with the nav bar and `/platform/deliver`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
