### PR TITLE
feat(events): add BalticNOG, Infra/STRUCTURE, and NANOG 98 to event calendar

### DIFF
--- a/src/components/events/EventCalendarSection.astro
+++ b/src/components/events/EventCalendarSection.astro
@@ -54,6 +54,7 @@ const eventsData = allEvents.map((e) => {
     isDatumHosted: isEventDatumHosted(e),
     isRecurringSeries: isEventRecurringSeries(e),
     isAltCloudMeetup: isEventAltCloudMeetup(e),
+    tags: e.tags ?? [],
     guests: guestsData,
   };
 });
@@ -194,7 +195,12 @@ const eventsJson = JSON.stringify(eventsData);
                       Datum Hosted
                     </span>
                   </template>
-                  <template x-if="event.isExternal">
+                  <template x-if="event.isExternal && event.tags.length > 0">
+                    <template x-for="tag in event.tags" :key="tag">
+                      <span class="event-badge event-badge--attending" x-text="tag"></span>
+                    </template>
+                  </template>
+                  <template x-if="event.isExternal && event.tags.length === 0">
                     <span class="event-badge event-badge--attending">We'll be there</span>
                   </template>
                 </div>

--- a/src/content/events/09-2026-balticnog-2026/index.mdx
+++ b/src/content/events/09-2026-balticnog-2026/index.mdx
@@ -1,0 +1,20 @@
+---
+name: BalticNOG 2026
+apiId: evt-balticnog-2026
+startAt: "2026-09-23T06:00:00.000Z"
+endAt: "2026-09-24T15:00:00.000Z"
+timezone: Europe/Riga
+url: "https://balticnog.org/"
+eventType: external
+tags:
+  - "We'll be there!"
+  - "Speaker: Zac Smith"
+geoAddress:
+  address: Radisson Blu Latvija Conference & Spa Hotel
+  city: Riga
+  country: Latvia
+  cityState: Riga, Latvia
+  fullAddress: Radisson Blu Latvija Conference & Spa Hotel, Riga, Latvia
+---
+
+We'll be there! Catch Zac Smith speaking at BalticNOG 2026.

--- a/src/content/events/10-2026-infra-structure-summit-2026/index.mdx
+++ b/src/content/events/10-2026-infra-structure-summit-2026/index.mdx
@@ -1,0 +1,20 @@
+---
+name: Infra/STRUCTURE
+apiId: evt-infra-structure-summit-2026
+startAt: "2026-10-07T16:00:00.000Z"
+endAt: "2026-10-09T01:00:00.000Z"
+timezone: America/Los_Angeles
+url: "https://www.infrastructuresummit.io/"
+eventType: external
+tags:
+  - Come find us and say hi
+geoAddress:
+  address: Wynn Las Vegas
+  city: Las Vegas
+  region: Nevada
+  country: US
+  cityState: Las Vegas, Nevada
+  fullAddress: Wynn Las Vegas, Las Vegas, NV, USA
+---
+
+Come find us and say hi at the infra/STRUCTURE summit.

--- a/src/content/events/10-2026-nanog-98/index.mdx
+++ b/src/content/events/10-2026-nanog-98/index.mdx
@@ -1,0 +1,20 @@
+---
+name: NANOG 98
+apiId: evt-nanog-98
+startAt: "2026-10-19T13:00:00.000Z"
+endAt: "2026-10-21T22:00:00.000Z"
+timezone: America/New_York
+url: "https://nanog.org/events/nanog-98/"
+eventType: external
+tags:
+  - "We'll be there!"
+geoAddress:
+  address: InterContinental Miami, 100 Chopin Plaza
+  city: Miami
+  region: Florida
+  country: US
+  cityState: Miami, Florida
+  fullAddress: InterContinental Miami, 100 Chopin Plaza, Miami, FL, USA
+---
+
+We'll be there! Join us at NANOG 98 in Miami.


### PR DESCRIPTION
## Summary

Closes #1659 — adds three upcoming events to the event calendar:

| Event | Dates | Location | Tags |
|---|---|---|---|
| [BalticNOG 2026](https://balticnog.org/) | Sep 23–24, 2026 | Radisson Blu Latvija, Riga, Latvia | "We'll be there!", "Speaker: Zac Smith" |
| [Infra/STRUCTURE](https://www.infrastructuresummit.io/) | Oct 7–8, 2026 | Wynn Las Vegas, NV | "Come find us and say hi" |
| [NANOG 98](https://nanog.org/events/nanog-98/) | Oct 19–21, 2026 | InterContinental Miami, FL | "We'll be there!" |

Venue/date details were cross-checked against each event's official site (see note below on Infra/STRUCTURE).


## Code change

`eventType: external` events previously all rendered an identical hardcoded "We'll be there" badge (`EventCalendarSection.astro`), with no way to show custom text like "Come find us and say hi" or a second "Speaker: X" tag. The events content schema already had an unused `tags: string[]` field, so I wired it through:

- `EventCalendarSection.astro` now serializes each event's `tags` into the Alpine data and renders one badge per tag.
- Falls back to the original "We'll be there" text for any external event with no `tags` set, so existing behavior is unchanged for events that don't need custom badges.

## Changes

- `src/components/events/EventCalendarSection.astro` — render per-event tags as badges instead of a hardcoded label.
- `src/content/events/09-2026-balticnog-2026/index.mdx` — new event.
- `src/content/events/10-2026-infra-structure-summit-2026/index.mdx` — new event.
- `src/content/events/10-2026-nanog-98/index.mdx` — new event.

## Test plan

- [x] `astro check` — 0 errors, 0 warnings (pre-existing unrelated hints only)
- [x] Prettier/ESLint/markdownlint via pre-commit hook — clean
- [x] Verified on local dev server (`:4321/events`) that all three events appear with correct name, city, date range, and tag badges
- [ ] Visual check: confirm badge styling looks right for the two-tag BalticNOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
