### PR TITLE
fix(handbook): symmetric hero title spacing, restore mobile gaps, fix TOC dot clipping

### DIFF
--- a/src/static/styles/components-handbook.css
+++ b/src/static/styles/components-handbook.css
@@ -15,7 +15,14 @@
        order-2 below — see the comment on .handbook-toc for why. */
     @apply order-3 flex max-w-none grow flex-col md:order-none;
 
-    @apply p-9 pr-0 pl-0 md:p-12 md:pr-10 md:pl-10 lg:p-16;
+    /* pt-9 below md: content is the last of the stacked mobile columns
+       (sidebar → toc → content), so it still needs its own top gap to
+       separate it from .handbook-toc above it. md:pt-0: once columns sit
+       side-by-side, content is directly under the Hero, whose own py-*
+       already reserves matching space — an extra top padding there would
+       double up and make the gap under the title bigger than the gap
+       above it (see #1650). */
+    @apply pt-9 pr-0 pb-9 pl-0 md:pt-0 md:pr-10 md:pb-12 md:pl-10 lg:pr-16 lg:pb-16 lg:pl-16;
   }
 
   .article-header {
@@ -97,7 +104,12 @@
        otherwise land it. md:order-none restores normal left-to-right order
        (sidebar, content, toc) once the columns sit side by side. */
     @apply relative order-2 flex w-full flex-col gap-y-4 md:order-none md:max-w-53.25 md:min-w-53.25;
-    @apply pt-9 md:pt-12 lg:pt-16;
+    /* pt-9 below md: toc is the second of the stacked mobile columns
+       (right after .handbook-sidebar), so it still needs its own top gap.
+       md:pt-0: matches .handbook-content — once columns sit side-by-side,
+       the Hero's own py-* already reserves the gap under the title, see
+       #1650. */
+    @apply pt-9 md:pt-0;
     @apply pr-0 md:pl-4 lg:pl-7;
 
     .article-aside {
@@ -113,12 +125,18 @@
   }
 
   .handbook-toc .toc-container {
-    /* Below lg: static/visible, matching the sidebar's own mobile toggle —
+    /* pl-2 keeps the active-dot indicator (which intentionally bleeds left onto
+       the dashed guide line) inside the padding box, unconditionally — harmless
+       at any breakpoint even though it only matters where overflow-y is set
+       (same fix as .legal-toc's equivalent rule; missing it here is what let
+       the dot get clipped to a half-circle again at lg+, see #1650).
+
+       Below lg: static/visible, matching the sidebar's own mobile toggle —
        it's a collapsed dropdown that scrolls with the page, not a side
        column, so sticking it and clipping its height would be wrong there
        (same reasoning as the legal pages' equivalent rule). At lg+: sticky
        + capped height + scrolls internally. */
-    @apply static! max-h-none! overflow-visible! lg:sticky! lg:top-9! lg:max-h-[calc(100vh-5rem)]! lg:overflow-y-auto!;
+    @apply static! max-h-none! overflow-visible! pl-2 lg:sticky! lg:top-9! lg:max-h-[calc(100vh-5rem)]! lg:overflow-y-auto!;
   }
 
   .handbook-toc-reopen-row {
@@ -127,27 +145,30 @@
     @apply sticky top-9 z-10 hidden lg:block;
   }
 
-  /* left: calc(100% - 7.5625rem) lands the button's left edge exactly where
+  /* left: calc(100% - 7.0625rem) lands the button's left edge exactly where
      the TOC's own toggle sits — confirmed empirically via getBoundingClientRect
      on both states, not derived from the column-width math (same lesson as
      the legal-page equivalent: that math kept missing real padding
-     contributions). 7.5625rem here vs. 7.0625rem for legal's version — the
-     0.5rem difference is .legal-toc .toc-container's extra pl-2 (added there
-     for the active-dot indicator), which .handbook-toc doesn't have.
+     contributions). Same value as legal's version now that .handbook-toc
+     .toc-container also carries the pl-2 active-dot fix above — it used to
+     be 7.5625rem (0.5rem more) back when handbook's toc-container had no
+     pl-2 of its own.
      w-max is required, not cosmetic: shrink-to-fit sizing for an absolutely
      positioned element with only `left` set uses "available space" as its
      width ceiling, not natural content width, which silently wraps the text
      otherwise. */
   .handbook-toc-reopen {
     @apply datum-text-xs text-midnight-fjord/60 hover:text-midnight-fjord absolute w-max font-medium;
-    left: calc(100% - 7.5625rem);
+    left: calc(100% - 7.0625rem);
   }
 
   .handbook-sidebar {
     /* order-1 pairs with .handbook-toc's order-2 and .handbook-content's
        order-3 above — see the comment on .handbook-toc for why. */
     @apply relative order-1 w-full flex-col gap-y-0 md:order-none md:max-w-55 md:min-w-55 md:gap-y-4 lg:max-w-64.75 lg:min-w-64.75;
-    @apply px-7 pt-5 pl-0 md:px-0 md:pt-12 lg:pt-16;
+    /* pt-0: matches .handbook-content — the Hero's own py-* already reserves
+       the gap under the title, see #1650. */
+    @apply px-7 pt-0 pl-0 md:px-0;
     @apply pr-0 md:pr-4 lg:pr-7;
     @apply flex md:flex;
   }


### PR DESCRIPTION
## Summary

Fixes the handbook page spacing feedback from [#1650](https://github.com/datum-cloud/datum.net/issues/1650#issuecomment-5371700176): the gap below the "Handbook" hero title was visibly larger than the gap above it. While fixing it, also caught and fixed a mobile spacing regression it would have introduced, plus a pre-existing TOC bug on the same component.

## Root cause

`Hero`'s own `py-*` is symmetric (top = bottom), but `.handbook-content`, `.handbook-sidebar`, and `.handbook-toc` each added their **own** top padding right after the Hero on desktop, stacking on top of the Hero's bottom padding and roughly doubling the visual gap under the title (e.g. at desktop: 80px above vs. ~144px below).

## Changes

- **Symmetric hero spacing** — zero the redundant top padding on `.handbook-content` / `.handbook-toc` / `.handbook-sidebar` from `md:` up, since the Hero's own padding already reserves that space.
- **Mobile column gaps preserved** — below `md`, those columns stack (sidebar → toc → content) instead of sitting side-by-side, so only the sidebar sits directly under the Hero. Keeping their original mobile-only top padding avoids collapsing the gaps between the stacked mobile sections (a regression my first pass introduced).
- **TOC active-dot clipping fix** — `.handbook-toc .toc-container` sets `lg:overflow-y-auto` for its sticky scroll panel, which per the CSS spec forces `overflow-x` to `auto` too, clipping the active-heading dot that intentionally bleeds left onto the dashed guide line ("half circle cut" instead of a full circle). `.legal-toc`'s equivalent container already carries a `pl-2` fix for exactly this; mirrored it into `.handbook-toc` and recalibrated `.handbook-toc-reopen`'s `left` offset to match (previously tuned assuming no `pl-2`).

## Test plan

- [x] `astro check --skip-playwright` — 0 errors, 0 warnings across 289 files
- [x] `prettier --check` — passes
- [x] Playwright screenshots of `/handbook` (index) and `/handbook/eos/quarterly-conversations` (nested article) at mobile (390px) and desktop (1920px) widths:
  - Gap above/below the hero title reads symmetric at both breakpoints
  - Mobile: gaps between the stacked sidebar dropdown / "On This Page" toggle / article content are intact
  - Desktop: active TOC dot renders as a full circle, not clipped
  - Desktop: "On This Page" reopen button aligns exactly with the toggle's position after collapse (confirmed via `getBoundingClientRect`, x: 1515 = 1515)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
