### PR TITLE
feat(agents): implement is-agentic.com readiness fixes (404s, headings, OpenAPI, Vary, llms.txt)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -30,6 +30,38 @@ const WELL_KNOWN_TYPES = {
   '/.well-known/oauth-authorization-server': 'application/json',
 };
 
+// Merge one or more tokens into an existing Vary header value without
+// duplicating anything already present. Kept in sync with the identical
+// helper in server.mjs (that one runs standalone in production with no
+// build step, so it can't import this file).
+function mergeVary(existing, tokens) {
+  const existingValue = Array.isArray(existing) ? existing.join(', ') : existing || '';
+  const set = new Set(
+    existingValue
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean)
+  );
+  for (const token of tokens) set.add(token);
+  return [...set].join(', ');
+}
+
+// Short markdown body for a 404 response — kept in sync with
+// buildAgentNotFoundMarkdown in server.mjs.
+function buildAgentNotFoundMarkdown(pathname) {
+  return `# 404 — Page not found
+
+\`${pathname}\` does not exist on this site.
+
+## Where to look next
+
+- [Sitemap](/sitemap.xml) — every URL on this site
+- [llms.txt](/llms.txt) — curated page index for agents
+- [Docs](/docs) — product documentation
+- [Home](/) — start over from the homepage
+`;
+}
+
 function wellKnownDevPlugin() {
   return {
     name: 'well-known-content-types',
@@ -61,9 +93,48 @@ function wellKnownDevPlugin() {
           if (existsSync(filePath)) {
             res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
             res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate');
+            res.setHeader('Vary', mergeVary(res.getHeader('Vary'), ['Accept']));
             createReadStream(filePath).pipe(res);
             return;
           }
+
+          // No static markdown export for this path here in dev (real content
+          // pages export markdown via their own [...].md.ts route, prerendered
+          // to dist/client/*.md only at build time — server.mjs serves that in
+          // production). If Astro's own downstream routing is about to 404,
+          // substitute a short agent-recoverable markdown body instead of
+          // falling through to the HTML 404 page, mirroring server.mjs's
+          // handleSSR so dev/test behavior matches production for genuinely
+          // unknown paths. See is-agentic's "Agent-friendly 404s" check.
+          const origWriteHead = res.writeHead.bind(res);
+          const origWrite = res.write.bind(res);
+          const origEnd = res.end.bind(res);
+          let substitute404 = false;
+          let body404 = null;
+
+          res.writeHead = (statusCode, headers) => {
+            if (statusCode === 404) {
+              substitute404 = true;
+              body404 = Buffer.from(buildAgentNotFoundMarkdown(url), 'utf-8');
+              return origWriteHead(404, {
+                'Content-Type': 'text/markdown; charset=utf-8',
+                'Content-Length': body404.length,
+                Vary: mergeVary(null, ['Accept']),
+              });
+            }
+            return origWriteHead(statusCode, headers);
+          };
+          res.write = (chunk, enc, cb) => {
+            if (substitute404) {
+              if (cb) cb();
+              return true;
+            }
+            return origWrite(chunk, enc, cb);
+          };
+          res.end = (chunk, enc, cb) => {
+            if (substitute404) return origEnd(body404);
+            return origEnd(chunk, enc, cb);
+          };
         }
 
         next();

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",
-    "test:e2e:report": "playwright show-report"
+    "test:e2e:report": "playwright show-report",
+    "test:server": "node --test tests/server.test.mjs"
   },
   "dependencies": {
     "@alpinejs/collapse": "^3.16.2",

--- a/server.mjs
+++ b/server.mjs
@@ -57,9 +57,42 @@ const COMPRESSIBLE_EXTENSIONS = /\.(html|css|js|mjs|json|xml|svg|txt|map)$/;
 const AGENT_LINK_HEADERS = [
   '</.well-known/api-catalog>; rel="api-catalog"',
   '</docs/>; rel="service-doc"',
+  '</openapi.json>; rel="service-desc"',
   '</.well-known/openid-configuration>; rel="openid-configuration"',
   '</.well-known/mcp/server-card.json>; rel="describedby"',
 ].join(', ');
+
+// Merge one or more tokens into an existing Vary header value without duplicating
+// anything already present (headers passed to writeHead may already carry one).
+function mergeVary(existing, tokens) {
+  const existingValue = Array.isArray(existing) ? existing.join(', ') : existing || '';
+  const set = new Set(
+    existingValue
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean)
+  );
+  for (const token of tokens) set.add(token);
+  return [...set].join(', ');
+}
+
+// Short markdown body for a 404 response, so an agent that asked for
+// `Accept: text/markdown` gets something it can parse to recover (sitemap,
+// llms.txt, docs, home) instead of an HTML error page it can't read without a
+// browser. See is-agentic's "Agent-friendly 404s" check.
+function buildAgentNotFoundMarkdown(pathname) {
+  return `# 404 — Page not found
+
+\`${pathname}\` does not exist on this site.
+
+## Where to look next
+
+- [Sitemap](/sitemap.xml) — every URL on this site
+- [llms.txt](/llms.txt) — curated page index for agents
+- [Docs](/docs) — product documentation
+- [Home](/) — start over from the homepage
+`;
+}
 
 // Content-type overrides for .well-known files that have no file extension
 const WELL_KNOWN_CONTENT_TYPES = {
@@ -303,16 +336,24 @@ function serveCompressed(req, res, next) {
       const etag = generateETag(stat);
       const lastModified = stat.mtime;
 
-      if (handleConditional(req, res, etag, lastModified, cacheControl, 'Accept-Encoding')) return;
-
       const brContentType = getContentType(url);
+      // HTML pages also have a markdown representation reachable via Accept
+      // negotiation (see the markdown branch below) — Vary must include
+      // Accept too, or a CDN can serve the cached HTML variant to an agent
+      // asking for markdown (or vice versa) depending on cache order.
+      const brVary = brContentType.includes('text/html')
+        ? mergeVary(null, ['Accept', 'Accept-Encoding'])
+        : 'Accept-Encoding';
+
+      if (handleConditional(req, res, etag, lastModified, cacheControl, brVary)) return;
+
       res.writeHead(200, {
         'Content-Type': brContentType,
         'Content-Encoding': 'br',
         'Content-Length': statSync(brPath).size,
         ETag: etag,
         'Last-Modified': lastModified.toUTCString(),
-        Vary: 'Accept-Encoding',
+        Vary: brVary,
         'Cache-Control': cacheControl,
         'X-Cache': 'MISS',
         ...(brContentType.includes('text/html') && { Link: AGENT_LINK_HEADERS }),
@@ -334,16 +375,20 @@ function serveCompressed(req, res, next) {
       const etag = generateETag(stat);
       const lastModified = stat.mtime;
 
-      if (handleConditional(req, res, etag, lastModified, cacheControl, 'Accept-Encoding')) return;
-
       const gzContentType = getContentType(url);
+      const gzVary = gzContentType.includes('text/html')
+        ? mergeVary(null, ['Accept', 'Accept-Encoding'])
+        : 'Accept-Encoding';
+
+      if (handleConditional(req, res, etag, lastModified, cacheControl, gzVary)) return;
+
       res.writeHead(200, {
         'Content-Type': gzContentType,
         'Content-Encoding': 'gzip',
         'Content-Length': statSync(gzPath).size,
         ETag: etag,
         'Last-Modified': lastModified.toUTCString(),
-        Vary: 'Accept-Encoding',
+        Vary: gzVary,
         'Cache-Control': cacheControl,
         'X-Cache': 'MISS',
         ...(gzContentType.includes('text/html') && { Link: AGENT_LINK_HEADERS }),
@@ -418,6 +463,9 @@ const SSR_COMPRESSIBLE = /^(text\/|application\/(javascript|json|xml|manifest\+j
 // Wrap the Astro SSR handler with streaming compression and cache headers
 function handleSSR(req, res) {
   const acceptEncoding = req.headers['accept-encoding'] ?? '';
+  const wantsMarkdown =
+    (req.method === 'GET' || req.method === 'HEAD') &&
+    (req.headers['accept'] || '').includes('text/markdown');
 
   let compressor = null;
   let encoding = null;
@@ -439,6 +487,12 @@ function handleSSR(req, res) {
   const origEnd = res.end.bind(res);
 
   let compressionActive = false;
+  // Set when Astro is about to render its (HTML) 404 page but the request
+  // asked for text/markdown — substitutes a short markdown 404 body instead,
+  // so an agent gets something it can parse. See is-agentic's "Agent-friendly
+  // 404s" check and buildAgentNotFoundMarkdown above.
+  let substituteMarkdown404 = false;
+  let markdown404Buffer = null;
 
   res.writeHead = (statusCode, headers) => {
     const h = headers && typeof headers === 'object' ? { ...headers } : {};
@@ -446,13 +500,35 @@ function handleSSR(req, res) {
     const ct = String(
       h['content-type'] ?? h['Content-Type'] ?? res.getHeader('content-type') ?? ''
     );
+
+    if (statusCode === 404 && wantsMarkdown) {
+      substituteMarkdown404 = true;
+      markdown404Buffer = Buffer.from(buildAgentNotFoundMarkdown(req.url.split('?')[0]), 'utf-8');
+      return origWriteHead(404, {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Content-Length': markdown404Buffer.length,
+        'Cache-Control': 'no-cache',
+        Vary: mergeVary(null, ['Accept', 'Accept-Encoding']),
+        Link: AGENT_LINK_HEADERS,
+      });
+    }
+
     compressionActive = !!compressor && SSR_COMPRESSIBLE.test(ct);
 
     if (compressionActive) {
       delete h['content-length'];
       delete h['Content-Length'];
       h['Content-Encoding'] = encoding;
-      h['Vary'] = 'Accept-Encoding';
+    }
+
+    // Any HTML (or markdown) response here also has the other representation
+    // reachable via Accept negotiation — Vary must include Accept, or a CDN
+    // can serve the wrong cached variant depending on which landed in cache
+    // first. Harmless to set on other content types too.
+    if (ct.includes('text/html') || ct.includes('text/markdown')) {
+      h['Vary'] = mergeVary(h['Vary'] ?? h['vary'], ['Accept', 'Accept-Encoding']);
+    } else if (compressionActive) {
+      h['Vary'] = mergeVary(h['Vary'] ?? h['vary'], ['Accept-Encoding']);
     }
 
     if (!h['Cache-Control'] && !h['cache-control']) {
@@ -466,21 +542,29 @@ function handleSSR(req, res) {
     return origWriteHead(statusCode, h);
   };
 
+  res.write = (chunk, enc, cb) => {
+    if (substituteMarkdown404) {
+      if (cb) cb();
+      return true;
+    }
+    if (!compressionActive) return origWrite(chunk, enc, cb);
+    return compressor.write(chunk, enc, cb);
+  };
+
+  res.end = (chunk, enc, cb) => {
+    if (substituteMarkdown404) {
+      if (req.method === 'HEAD') return origEnd();
+      return origEnd(markdown404Buffer);
+    }
+    if (!compressionActive) return origEnd(chunk, enc, cb);
+    if (chunk) compressor.write(chunk);
+    compressor.end();
+  };
+
   if (compressor) {
     compressor.on('data', (chunk) => origWrite(chunk));
     compressor.on('end', () => origEnd());
     compressor.on('error', () => origEnd());
-
-    res.write = (chunk, enc, cb) => {
-      if (!compressionActive) return origWrite(chunk, enc, cb);
-      return compressor.write(chunk, enc, cb);
-    };
-
-    res.end = (chunk, enc, cb) => {
-      if (!compressionActive) return origEnd(chunk, enc, cb);
-      if (chunk) compressor.write(chunk);
-      compressor.end();
-    };
   }
 
   handler(req, res);
@@ -544,6 +628,10 @@ const server = createServer((req, res) => {
         'Content-Type': 'text/markdown; charset=utf-8',
         'Cache-Control': 'public, max-age=0, must-revalidate',
         'Content-Length': stat.size,
+        // This URL also has an HTML representation — Vary: Accept tells any
+        // CDN in front to key its cache on Accept, not just Accept-Encoding,
+        // so it doesn't serve this markdown body to a browser (or vice versa).
+        Vary: mergeVary(null, ['Accept', 'Accept-Encoding']),
         Link: AGENT_LINK_HEADERS,
       });
       if (req.method === 'HEAD') {

--- a/src/components/MobileMenu.astro
+++ b/src/components/MobileMenu.astro
@@ -152,8 +152,11 @@ const mainNav = filterNavMain(navData.main);
                 <div class="mobile-dropdown-content" x-show="open" x-collapse>
                   {item.children.map((section) => (
                     <div class="mobile-dropdown-section">
+                      {/* p, not a heading — decorative mobile-menu column label, ahead of
+                          the page's own h1 in DOM order; see NavMenu.astro's equivalent
+                          rule for why this can't be a heading tag. */}
                       {'title' in section && section.title && (
-                        <h3 class="mobile-dropdown-title">
+                        <p class="mobile-dropdown-title">
                           {section.href ? (
                             <a
                               href={section.href}
@@ -165,7 +168,7 @@ const mainNav = filterNavMain(navData.main);
                           ) : (
                             section.title
                           )}
-                        </h3>
+                        </p>
                       )}
                       <ul class="mobile-dropdown-items">
                         {section.items?.map((subItem) => (

--- a/src/components/NavMenu.astro
+++ b/src/components/NavMenu.astro
@@ -88,8 +88,13 @@ function navDropdownParentClass(text: string): string {
                     <li
                       class={`nav-dropdown-section ${item.children!.length > 1 ? 'nav-dropdown-mega-section' : ''}`}
                     >
+                      {/* p, not a heading — this is a decorative mega-menu column label,
+                          not part of the page's content outline. A real heading here (this
+                          renders on every page, ahead of the page's own h1) breaks the
+                          document's heading hierarchy for a11y tools and content-extraction
+                          crawlers (see is-agentic "Content without JavaScript" check). */}
                       {'title' in section && section.title && (
-                        <h3 class="nav-dropdown-title">
+                        <p class="nav-dropdown-title">
                           {section.href ? (
                             <a
                               href={section.href}
@@ -105,7 +110,7 @@ function navDropdownParentClass(text: string): string {
                           ) : (
                             <span>{section.title}</span>
                           )}
-                        </h3>
+                        </p>
                       )}
                       <ul
                         class={

--- a/src/components/home/WhatIsDatum.astro
+++ b/src/components/home/WhatIsDatum.astro
@@ -25,6 +25,16 @@ const { class: className = '' } = Astro.props;
       >
         <div class="spacing-pad flex flex-col gap-7">
           <SectionEyebrow>What is Datum?</SectionEyebrow>
+          {
+            /* sr-only: visually the eyebrow above already reads as this section's label,
+              but it's a <span> (decorative, animated typeout), not a heading — this section's
+              body copy was otherwise the only real content on the homepage with no heading
+              anchoring it at all, which reads as a broken/flat outline to a11y tools and
+              content-extraction crawlers (see is-agentic "Content without JavaScript" check).
+              A visible duplicate heading would look redundant next to the eyebrow, so this
+              stays sr-only rather than changing the visual design. */
+          }
+          <h2 class="sr-only">What is Datum?</h2>
           <div
             class="datum-text-2xl text-midnight-fjord flex flex-col gap-7 text-pretty [&>p]:opacity-80"
           >

--- a/src/data/openapi.ts
+++ b/src/data/openapi.ts
@@ -1,0 +1,77 @@
+// src/data/openapi.ts
+//
+// OpenAPI 3.1 spec for datum.net's OWN public endpoints — the marketing/docs
+// website, not the Datum Cloud platform API.
+//
+// The platform API (creating/managing Application Load Balancers, Connectors,
+// DNS zones, etc.) is a separate Kubernetes-native aggregated API server at
+// https://api.datum.net. It already exposes standard Kubernetes OpenAPI v2/v3
+// discovery at `/openapi/v2` and `/openapi/v3`, but those require an
+// authenticated bearer token to fetch (kubebuilder/apiserver convention) —
+// there's nothing this site can publish anonymously that would accurately
+// describe it without access to that codebase, so this document explicitly
+// scopes itself to what datum.net itself serves and points agents at the
+// platform docs (and the real discovery endpoint) for the rest. Overclaiming
+// a synthesized platform spec here would be worse than not having one: an
+// agent would call endpoints that don't match its actual schema.
+//
+// Keep this in sync with the routes it documents:
+//   - src/pages/api/roadmap/backlog-meta.ts
+
+const SITE_URL = 'https://www.datum.net';
+
+export const openApiSpec = {
+  openapi: '3.1.0',
+  info: {
+    title: 'Datum Website API',
+    version: '1.0.0',
+    description:
+      'Public endpoints served directly by datum.net (the marketing/docs site). This is intentionally a small surface — the Datum Cloud platform API for creating and managing infrastructure (Application Load Balancers, Connectors, DNS, Domains) is a separate Kubernetes-native aggregated API server documented at ' +
+      `${SITE_URL}/docs and reachable at https://api.datum.net. That API follows standard Kubernetes API conventions (the same request shape as \`kubectl\`) and publishes its own OpenAPI v3 discovery document at \`/openapi/v3\`, which requires an authenticated bearer token to fetch — see ${SITE_URL}/docs for how to authenticate, or the \`datumctl\` CLI / MCP server for a higher-level interface that doesn't require calling the platform API directly.`,
+    contact: {
+      name: 'Datum',
+      url: `${SITE_URL}/contact`,
+    },
+  },
+  servers: [{ url: SITE_URL }],
+  externalDocs: {
+    description: 'Datum Cloud platform documentation (full API reference, guides, MCP server)',
+    url: `${SITE_URL}/docs`,
+  },
+  paths: {
+    '/api/roadmap/backlog-meta': {
+      get: {
+        operationId: 'getRoadmapBacklogMeta',
+        summary: 'Roadmap backlog cache status',
+        description:
+          'Lightweight status for the public roadmap backlog cache (backed by the datum-cloud GitHub Projects board) — used by the roadmap page to poll for live updates without re-fetching the full backlog on every request. Read-only, no authentication required.',
+        tags: ['Roadmap'],
+        responses: {
+          '200': {
+            description: 'Current backlog cache status.',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['updatedAt', 'isRefreshing'],
+                  properties: {
+                    updatedAt: {
+                      type: ['integer', 'null'],
+                      description:
+                        'Unix epoch milliseconds of the last successful backlog refresh, or null if the cache has never been populated.',
+                      example: 1735689600000,
+                    },
+                    isRefreshing: {
+                      type: 'boolean',
+                      description: 'True while a background refresh from GitHub is in flight.',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -26,6 +26,12 @@ const description = 'The page you are looking for does not exist.';
             class="btn btn--alpha mr-0 mb-4 md:mr-1 md:mb-0"
             icon={{ name: 'arrow-right', size: 'md' }}
           />
+          <p class="page-404-recovery-links datum-text-sm text-midnight-fjord/60 mt-8">
+            Or try the <a href="/sitemap.xml" class="hover:text-midnight-fjord underline">sitemap</a
+            >,
+            <a href="/llms.txt" class="hover:text-midnight-fjord underline">llms.txt</a>, or the
+            <a href="/docs" class="hover:text-midnight-fjord underline">docs</a>.
+          </p>
         </article>
       </main>
     </div>

--- a/src/pages/api/openapi.yaml.ts
+++ b/src/pages/api/openapi.yaml.ts
@@ -1,0 +1,16 @@
+// src/pages/api/openapi.yaml.ts
+//
+// YAML mirror of /openapi.json at the other conventional discovery path —
+// see src/data/openapi.ts for the spec content and scope notes.
+import type { APIRoute } from 'astro';
+import { stringify } from 'yaml';
+import { openApiSpec } from '@data/openapi';
+
+export const GET: APIRoute = () => {
+  return new Response(stringify(openApiSpec), {
+    headers: {
+      'Content-Type': 'application/yaml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -38,6 +38,16 @@ export const GET: APIRoute = async () => {
     llmsContent += `## About\n\n`;
     llmsContent += `> Datum is an open source network cloud for AI, founded in 2024 and backed by $13.6M from Amplify Partners, CRV, Encoded Ventures, Cervin Ventures, Ex/Ante, Step Function, and Vine Ventures. Built for AI-native developers and alternative cloud providers, Datum provides an Envoy-based Application Load Balancer across 17+ global regions, QUIC-based secure tunnels (Connectors), authoritative DNS, and programmatic domain management — all with a forever-free Builder tier. Core platform licensed AGPLv3. Founded by Zac Smith (ex-Equinix, Packet) and Jacob Smith.\n\n`;
 
+    llmsContent += `## When to Use Datum\n\n`;
+    llmsContent += `Reach for Datum when you (a human, an agent, or an app you're building on behalf of a user) need to:\n\n`;
+    llmsContent += `- **Expose a workload to the internet** — put an Application Load Balancer (Envoy + Coraza WAF) in front of any backend to get a global HTTPS hostname, custom domains, and edge protection without running your own proxy fleet.\n`;
+    llmsContent += `- **Connect two things privately, without a public IP** — use a Connector (QUIC/Iroh tunnel) to reach \`localhost\` or an internal service from the internet, or to link two private networks, without opening inbound ports.\n`;
+    llmsContent += `- **Host and manage DNS programmatically** — create zones/records or verify domain ownership via API/CLI/MCP instead of clicking through a registrar console.\n`;
+    llmsContent += `- **Give an AI agent its own scoped infrastructure identity** — service accounts, RBAC, and Kubernetes-native resources (everything is a CRD) let an autonomous agent provision and tear down networking primitives idempotently, the same way it would with \`kubectl\`.\n`;
+    llmsContent += `- **Build or operate an "alt cloud"** — if you're a smaller cloud/ISV/SaaS provider that needs telco-grade connectivity primitives (load balancing, tunnels, DNS, and eventually a global backbone) without building a network team, Datum is infrastructure you can build on top of, not just consume.\n\n`;
+    llmsContent += `**How an agent should call Datum:** every resource is a Kubernetes Custom Resource Definition exposed through a standard aggregated API server (\`GET/POST/PATCH/DELETE\` on \`{service}.miloapis.com\` / \`networking.datumapis.com\` resource paths) — the same request shape as \`kubectl\`. Prefer, in order: (1) the \`datumctl\` CLI for one-off or scripted operations, (2) the MCP server for search/read against docs and live \`apis\` discovery, (3) direct REST calls against the aggregated API server for programmatic control loops. Auth is OIDC/PKCE by default; set a service-account bearer token for headless/agent use (see Docs below).\n\n`;
+    llmsContent += `**Not a fit for:** general-purpose compute/hosting (Datum is a network/edge layer, not a VM or container platform — Datum Compute is coming but not yet available), or workloads that need a fully managed multi-region database.\n\n`;
+
     // Get all pages sorted, excluding home/* pages
     const pages = await getCollection('pages');
     const filteredPages = pages.filter((page) => !page.id.startsWith('home/'));
@@ -64,6 +74,9 @@ export const GET: APIRoute = async () => {
 
     llmsContent += `\n## Docs\n\n`;
     llmsContent += `- Full documentation index at ${siteUrl}/docs/llms.txt\n`;
+
+    llmsContent += `\n## API\n\n`;
+    llmsContent += `- [OpenAPI spec](${siteUrl}/openapi.json) - machine-readable description of datum.net's own public endpoints (also at ${siteUrl}/api/openapi.yaml). The Datum Cloud platform API itself is documented at ${siteUrl}/docs.\n`;
 
     llmsContent += `\n## MCP\n\n`;
     llmsContent += `- [Datum Docs MCP](${siteUrl}/docs/mcp) - MCP server for AI agents to search and read Datum documentation (JSON-RPC 2.0 over SSE). Tools: \`search_datum_cloud_docs\`, \`query_docs_filesystem_datum_cloud_docs\`.\n`;

--- a/src/pages/openapi.json.ts
+++ b/src/pages/openapi.json.ts
@@ -1,0 +1,16 @@
+// src/pages/openapi.json.ts
+//
+// OpenAPI spec for agent/tooling discovery — see src/data/openapi.ts for the
+// spec content and scope notes, and src/pages/api/openapi.yaml.ts for the
+// YAML mirror at the other conventional path.
+import type { APIRoute } from 'astro';
+import { openApiSpec } from '@data/openapi';
+
+export const GET: APIRoute = () => {
+  return new Response(JSON.stringify(openApiSpec, null, 2), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};

--- a/tests/e2e/agent-readiness.spec.ts
+++ b/tests/e2e/agent-readiness.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test';
+
+// Coverage for the is-agentic.com readiness fixes. Vary-header and
+// production-only 404 behavior (server.mjs, not exercised by `astro dev`)
+// are covered separately in tests/server.test.mjs against a real build.
+
+test.describe('Heading structure (Content without JavaScript)', () => {
+  test('homepage has exactly one h1, and nothing heading-level appears before it', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    // Excludes the dev-only Astro Dev Toolbar overlay (its own panels use
+    // h1s like "Audit" / "Settings") — not real page content, and absent
+    // from the production build is-agentic actually scans.
+    const headingTags = await page.evaluate(() =>
+      [...document.querySelectorAll('h1, h2, h3, h4, h5, h6')]
+        .filter((el) => !el.closest('astro-dev-toolbar'))
+        .map((el) => el.tagName.toLowerCase())
+    );
+
+    expect(headingTags[0]).toBe('h1');
+    expect(headingTags.filter((tag) => tag === 'h1')).toHaveLength(1);
+  });
+
+  test('nav dropdown column labels are not heading elements', async ({ page }) => {
+    await page.goto('/');
+
+    // These are decorative mega-menu labels, not part of the content
+    // outline — asserting the tag directly (not just visual position)
+    // guards against a future h3 creeping back in.
+    const tagNames = await page
+      .locator('.nav-dropdown-title, .mobile-dropdown-title')
+      .evaluateAll((els) => els.map((el) => el.tagName.toLowerCase()));
+
+    expect(tagNames.length).toBeGreaterThan(0);
+    for (const tag of tagNames) {
+      expect(tag).not.toMatch(/^h[1-6]$/);
+    }
+  });
+
+  test('the "What is Datum?" section has a real (if visually hidden) heading', async ({ page }) => {
+    await page.goto('/');
+
+    const heading = page.locator('#what-is-datum h2');
+    await expect(heading).toHaveCount(1);
+    await expect(heading).toHaveText('What is Datum?');
+  });
+});
+
+test.describe('Agent-friendly 404 (HTML)', () => {
+  test('404 page returns 404 status and links to recovery resources', async ({ page }) => {
+    const response = await page.goto('/this-page-does-not-exist-e2e');
+    expect(response?.status()).toBe(404);
+
+    const recoveryLinks = page.locator('.page-404-recovery-links');
+    await expect(recoveryLinks.locator('a[href="/sitemap.xml"]')).toBeVisible();
+    await expect(recoveryLinks.locator('a[href="/llms.txt"]')).toBeVisible();
+    await expect(recoveryLinks.locator('a[href="/docs"]')).toBeVisible();
+  });
+});
+
+test.describe('OpenAPI spec published', () => {
+  test('/openapi.json is a valid OpenAPI 3.x document with paths', async ({ request }) => {
+    const response = await request.get('/openapi.json');
+    expect(response.ok()).toBeTruthy();
+    expect(response.headers()['content-type']).toContain('application/json');
+
+    const spec = await response.json();
+    expect(spec.openapi).toMatch(/^3\./);
+    expect(Object.keys(spec.paths).length).toBeGreaterThan(0);
+  });
+
+  test('/api/openapi.yaml mirrors the JSON spec', async ({ request }) => {
+    const response = await request.get('/api/openapi.yaml');
+    expect(response.ok()).toBeTruthy();
+    expect(response.headers()['content-type']).toContain('yaml');
+
+    const body = await response.text();
+    expect(body).toContain('openapi: 3.');
+    expect(body).toContain('paths:');
+  });
+});
+
+test.describe('Agent instruction / when-to-use', () => {
+  test('llms.txt has an explicit when-to-use section', async ({ request }) => {
+    const response = await request.get('/llms.txt');
+    expect(response.ok()).toBeTruthy();
+
+    const body = await response.text();
+    expect(body).toContain('## When to Use Datum');
+    expect(body).toContain('How an agent should call Datum');
+  });
+});

--- a/tests/server.test.mjs
+++ b/tests/server.test.mjs
@@ -1,0 +1,118 @@
+// tests/server.test.mjs
+//
+// Integration tests against the actual production server (server.mjs serving
+// a real `dist/` build) — the code path is-agentic.com scans in production.
+// Playwright's e2e suite runs against `astro dev`, which doesn't exercise
+// server.mjs at all, so these behaviors (Vary headers, the agent-friendly
+// markdown 404, agent Link headers) need their own coverage here instead.
+//
+// Requires a prior `npm run build` (not run automatically — this suite is
+// about verifying server.mjs's own logic, not paying for a full site build
+// on every invocation). Run with:
+//   npm run build && npm run test:server
+
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const PORT = process.env.TEST_SERVER_PORT || '4399';
+const BASE_URL = `http://localhost:${PORT}`;
+const DIST_CLIENT = new URL('../dist/client', import.meta.url);
+
+let serverProcess;
+
+before(async () => {
+  if (!existsSync(DIST_CLIENT)) {
+    throw new Error('dist/client not found — run `npm run build` before `npm run test:server`.');
+  }
+
+  serverProcess = spawn(process.execPath, ['./server.mjs'], {
+    cwd: new URL('..', import.meta.url),
+    env: { ...process.env, PORT, NODE_ENV: 'production' },
+    stdio: 'pipe',
+  });
+
+  // Wait for the server to accept connections (healthz is unconditional).
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${BASE_URL}/healthz`);
+      if (res.ok) return;
+    } catch {
+      // not up yet
+    }
+    await sleep(200);
+  }
+  throw new Error('server.mjs did not become ready within 15s');
+});
+
+after(() => {
+  serverProcess?.kill();
+});
+
+test('nonexistent path returns a real 404 (not a 200 app-shell)', async () => {
+  const res = await fetch(`${BASE_URL}/this-path-really-does-not-exist-xyz`);
+  assert.equal(res.status, 404);
+});
+
+test('nonexistent path + Accept: text/markdown returns a markdown 404 body with recovery links', async () => {
+  const res = await fetch(`${BASE_URL}/this-path-really-does-not-exist-xyz`, {
+    headers: { Accept: 'text/markdown' },
+  });
+  assert.equal(res.status, 404);
+  assert.match(res.headers.get('content-type') ?? '', /text\/markdown/);
+  assert.match(res.headers.get('vary') ?? '', /Accept\b/);
+
+  const body = await res.text();
+  assert.match(body, /sitemap\.xml/);
+  assert.match(body, /llms\.txt/);
+  assert.match(body, /\/docs/);
+});
+
+test('HTML page response carries Vary: Accept (so a CDN keys on it, not just Accept-Encoding)', async () => {
+  const res = await fetch(`${BASE_URL}/`);
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('content-type') ?? '', /text\/html/);
+  assert.match(res.headers.get('vary') ?? '', /Accept\b/);
+});
+
+test('markdown-negotiated page response also carries Vary: Accept', async () => {
+  const res = await fetch(`${BASE_URL}/`, { headers: { Accept: 'text/markdown' } });
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('content-type') ?? '', /text\/markdown/);
+  assert.match(res.headers.get('vary') ?? '', /Accept\b/);
+});
+
+test('/openapi.json is valid OpenAPI with at least one documented path', async () => {
+  const res = await fetch(`${BASE_URL}/openapi.json`);
+  assert.equal(res.status, 200);
+  const spec = await res.json();
+  assert.match(spec.openapi, /^3\./);
+  assert.ok(Object.keys(spec.paths).length > 0);
+});
+
+test('/api/openapi.yaml mirrors the same spec as YAML', async () => {
+  const [{ parse }, res] = await Promise.all([
+    import('yaml'),
+    fetch(`${BASE_URL}/api/openapi.yaml`),
+  ]);
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('content-type') ?? '', /yaml/);
+  const spec = parse(await res.text());
+  assert.match(spec.openapi, /^3\./);
+  assert.ok(Object.keys(spec.paths).length > 0);
+});
+
+test('llms.txt has an explicit when-to-use section', async () => {
+  const res = await fetch(`${BASE_URL}/llms.txt`);
+  assert.equal(res.status, 200);
+  const body = await res.text();
+  assert.match(body, /## When to Use Datum/);
+});
+
+test('HTML responses advertise the OpenAPI spec via a service-desc Link header', async () => {
+  const res = await fetch(`${BASE_URL}/`);
+  assert.match(res.headers.get('link') ?? '', /openapi\.json.*rel="service-desc"/);
+});


### PR DESCRIPTION
## Summary

Implements the 5 essential/priority fixes from the [is-agentic.com scan](https://is-agentic.com/scan/datum.net) (score 78/100). Scope was deliberately limited to what this repo (the marketing/docs website) can fix accurately on its own — see "Out of scope" below for the items that describe the separate Datum Cloud platform API.

## Changes

### 1. Agent-friendly 404s (was Partial 50%)
`server.mjs` already returned real HTTP 404s for unknown paths; it just never gave agents anything to recover with. Now:
- A request for a nonexistent path with `Accept: text/markdown` gets a **404 with a short markdown body** (links to sitemap, llms.txt, docs, home) instead of an HTML page it can't parse. Mirrored in `astro.config.mjs`'s dev middleware for dev/test parity.
- The visible HTML 404 page also got the same three recovery links added below the "Return to homepage" button.

### 2. Content without JavaScript (was Partial 67%, "flat heading structure")
Two structural defects in the raw (no-JS) homepage HTML:
- The nav's mega-menu column labels ("Deliver", "Build", "Connect") were `<h3>` — decorative, styling-only, but they render on **every page ahead of that page's own `<h1>`**, breaking the document outline for crawlers/a11y tools. Changed to `<p>` (zero visual change, confirmed via screenshot diff — no CSS is keyed on the element type).
- The homepage's "What is Datum?" section — the bulk of the page's actual text content — had **no heading at all** (the eyebrow above it is a decorative `<span>`, not a heading). Added a real, `sr-only` `<h2>` so the outline is `h1 → h2 → h2 → h3 → h2 → h3 → h2 → h3` instead of `h1 → [orphan text] → h2 → h3 → ...`.

### 3. OpenAPI spec published (was Failed)
Publishes a real, honest OpenAPI 3.1 spec at `/openapi.json` and `/api/openapi.yaml`, documenting datum.net's own public endpoint (`GET /api/roadmap/backlog-meta`). **Deliberately does not** attempt to describe the actual Datum Cloud platform API (aggregated Kubernetes API server) — that lives in a different repo, requires an authenticated request even for its own OpenAPI v3 discovery, and fabricating a spec for it here would be actively worse than not having one (an agent would call endpoints against a schema this repo has no way to keep accurate). The spec's `description`/`externalDocs` point agents at `/docs` and the real platform API instead.

### 4. Markdown content negotiation — Vary header (was Failed)
Added `Accept` to the `Vary` header on every response that participates in markdown content negotiation: HTML pages, their `.md` twins, and the new markdown 404 body (previously only `Accept-Encoding` was varied, so a CDN could serve the wrong cached representation to an agent depending on which one landed in cache first).

### 5. Agent instruction / when-to-use (was Failed)
Added a `## When to Use Datum` section to `llms.txt` naming specific best-fit jobs (expose a workload, private connectivity, programmatic DNS, agent infra identity, alt-cloud building), how an agent should call Datum (CLI → MCP → direct REST, in that preference order), and what Datum is explicitly *not* a fit for. Also links `/openapi.json` under a new `## API` section.

### Bonus
Added a `rel="service-desc"` Link header pointing at `/openapi.json` (RFC 8631), alongside the existing `rel="service-doc"` one.

## Out of scope (from the full 15-item scan, not requested for this PR)

Items 6–10 and the MCP-*tools* half of item 12 (typed error model, API versioning/deprecation, rate-limit headers, schema complexity, function-calling compatibility) all describe the **Datum Cloud platform API**, which is a separate Kubernetes aggregated API server in a different repo, currently auth-walled with no public OpenAPI spec anywhere. This repo can't fix those without fabricating something inaccurate. Flagging for the platform team.

## Test plan

- [x] `npm run typecheck` — 0 errors, 0 warnings (292 files)
- [x] `npm run lint` / `npm run format:check` / `npm run lint:md` — clean
- [x] `npm run build` — succeeds
- [x] New `npm run test:server` (Node's built-in test runner, spawns `server.mjs` against a real build): 8/8 pass — covers the markdown 404 substitution, Vary headers, OpenAPI spec/YAML validity, llms.txt content, and the new Link header, against the actual production code path is-agentic scans (`astro dev` doesn't exercise `server.mjs` at all)
- [x] New `tests/e2e/agent-readiness.spec.ts` (Playwright, against `astro dev`): 7/7 pass — heading structure, visible 404 recovery links, OpenAPI endpoints, llms.txt
- [x] Full existing e2e suite (`npx playwright test`): 19/19 pass, no regressions
- [x] Screenshot diff of the homepage and the nav mega-menu (hover state) — confirms the `<h3>` → `<p>` change and the `sr-only` `<h2>` addition have **zero visual impact**
- [x] Manual `curl` verification of `/openapi.json`, `/api/openapi.yaml`, `/llms.txt`, and the markdown 404 body against both dev and a production build

## Remaining recommendations (need product/credentials, not code)

- The real fix for items 6–10 is publishing an OpenAPI spec for the actual platform API from its own repo — that requires access to that codebase and a decision on how much of it to expose publicly while still in private beta.
- Item 12 (MCP *server*) already has a docs-search MCP server; a fuller MCP exposing the platform's actual CRUD operations as tools is a platform-repo effort, not a website one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
