### PR TITLE
fix(hello): decouple /hello avatars from the shared /about color rotation

### DIFF
--- a/src/components/hello/HelloPeople.astro
+++ b/src/components/hello/HelloPeople.astro
@@ -1,7 +1,7 @@
 ---
 // src/components/hello/HelloPeople.astro
 import Icon from '@components/Icon.astro';
-import { getStrapiCardMembers, getTeamBgColor } from '@libs/strapi';
+import { getHelloPineForgeAvatarUrl, getStrapiCardMembers, getTeamBgColor } from '@libs/strapi';
 import type { CardCategory, StrapiAuthorFull } from '@libs/strapi';
 import { getStrapiMediaUrl } from '@/src/types/strapi';
 import HelloCard from './HelloCard.astro';
@@ -9,7 +9,19 @@ import HelloModal from './HelloModal.astro';
 import HelloSupportCard from './HelloSupportCard.astro';
 import HelloBehindCard from './HelloBehindCard.astro';
 
-const cardMembers: StrapiAuthorFull[] = await getStrapiCardMembers();
+const strapiCardMembers: StrapiAuthorFull[] = await getStrapiCardMembers();
+
+// /hello always shows the pine-forge avatar variant, resolved independently of
+// the shared `avatar` field the /about team grid depends on — mutating that
+// field to satisfy /hello breaks /about's color-matched cards instead.
+// See helloPineForgeAvatars.ts.
+const cardMembers: StrapiAuthorFull[] = await Promise.all(
+  strapiCardMembers.map(async (member) => {
+    const pineForgeUrl = member.slug ? await getHelloPineForgeAvatarUrl(member.slug) : undefined;
+    if (!pineForgeUrl) return member;
+    return { ...member, avatar: { ...member.avatar, url: pineForgeUrl } };
+  })
+);
 
 const helloMembersData = cardMembers.map((member, index) => ({
   slug: member.slug || member.documentId,

--- a/src/libs/strapi/helloPineForgeAvatars.ts
+++ b/src/libs/strapi/helloPineForgeAvatars.ts
@@ -1,0 +1,66 @@
+// src/libs/strapi/helloPineForgeAvatars.ts
+/**
+ * /hello-only avatar resolution.
+ *
+ * `Author.avatar` is shared with the /about team grid, whose cards rotate
+ * through a fixed background-color sequence (`getTeamBgColor`) — each
+ * person's `avatar` has to stay pinned to whichever media-library variant
+ * (pine-forge / canyon-clay / glacier-mist) has a backdrop matching their
+ * position there. /hello wants every card on the pine-forge variant
+ * regardless of that rotation, so mutating the shared `avatar` field to
+ * satisfy one page breaks the other's color match.
+ *
+ * This resolves each person's pine-forge variant independently, straight
+ * from the media library by slug, so /hello never touches `Author.avatar`.
+ */
+import { cache, config } from './_runtime';
+
+const PINE_FORGE_AVATAR_MAP_CACHE_KEY = 'strapi-hello-pine-forge-avatars';
+const PINE_FORGE_SUFFIX = '-pine-forge';
+
+interface StrapiUploadFileRow {
+  name: string;
+  url: string;
+}
+
+/** `"jacob-smith-pine-forge.png"` → `"jacob-smith"`; `null` if it's not a pine-forge file. */
+function slugFromFileName(fileName: string): string | null {
+  const base = fileName.replace(/\.[^./]+$/, '').toLowerCase();
+  if (!base.endsWith(PINE_FORGE_SUFFIX)) return null;
+  return base.slice(0, -PINE_FORGE_SUFFIX.length);
+}
+
+/** Fetch every "-pine-forge" media file once and index by author slug. */
+async function fetchPineForgeAvatarMap(): Promise<Record<string, string> | null> {
+  if (!config.token) return null;
+
+  try {
+    const response = await fetch(
+      `${config.url}/api/upload/files?filters[name][$containsi]=${PINE_FORGE_SUFFIX}&pagination[pageSize]=200`,
+      { headers: { Authorization: `Bearer ${config.token}` } }
+    );
+    if (!response.ok) return null;
+
+    const files: StrapiUploadFileRow[] = await response.json();
+    const map: Record<string, string> = {};
+    for (const file of files) {
+      const slug = slugFromFileName(file.name);
+      if (slug) map[slug] = file.url;
+    }
+    return map;
+  } catch {
+    return null;
+  }
+}
+
+/** Pine-forge avatar URL for an author slug, or `undefined` if none was uploaded. */
+export async function getHelloPineForgeAvatarUrl(slug: string): Promise<string | undefined> {
+  const map = await cache.getWithFallback(
+    PINE_FORGE_AVATAR_MAP_CACHE_KEY,
+    fetchPineForgeAvatarMap,
+    {
+      tags: ['authors'],
+    }
+  );
+  return map?.[slug.toLowerCase()];
+}

--- a/src/libs/strapi/index.ts
+++ b/src/libs/strapi/index.ts
@@ -93,6 +93,10 @@ export {
   getAuthorBgColorFromStrapi,
 } from './authors';
 
+// /hello-only avatar resolution, decoupled from the shared `avatar` field
+// (see helloPineForgeAvatars.ts for why).
+export { getHelloPineForgeAvatarUrl } from './helloPineForgeAvatars';
+
 // Re-export articles module (queries and cached fetchers)
 export {
   ARTICLES_QUERY,


### PR DESCRIPTION
## Summary

`/hello` and `/about` both render each Author's `avatar` field, but they need different pictures of the same person:

- `/about`'s team grid assigns each card a background color from a fixed rotation (`getTeamBgColor`). Every person's `avatar` has to stay pinned to whichever media-library variant (`pine-forge` / `canyon-clay` / `glacier-mist`) has a backdrop matching their position in that rotation.
- `/hello` wants every card on the `pine-forge` variant, full stop, regardless of what `/about` needs.

Pointing `avatar` at `pine-forge` to fix `/hello` broke the color match on `/about` for the affected authors (Jacob Smith, Kaley Gelineau, Drew Raines, Manish Singh) — their card backgrounds no longer matched their portrait's baked-in backdrop. Reverted `Author.avatar` back to each person's original value in Strapi.

## Fix

Added `getHelloPineForgeAvatarUrl()` (`src/libs/strapi/helloPineForgeAvatars.ts`), which resolves each person's `-pine-forge` file straight from the media library by slug — cached and tagged the same way as the rest of the authors module, so it invalidates alongside everything else.

`HelloPeople.astro` now builds display-only member objects with this pine-forge URL swapped in before rendering `<HelloCard>` / building the modal data. `Author.avatar` itself, `HelloCard.astro`, `HelloModal.astro`, and `/about` are untouched — the two pages can no longer step on each other.

## Also fixed (data, not code)

Megan O'Connor's media-library file labeled `pine-forge` was a byte-for-byte duplicate of her `glacier-mist` file — a pre-existing mislabel in Strapi, unrelated to this change. Re-uploaded the correct artwork so the new lookup resolves to the right image for her too.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Verified on local dev server: `/hello` renders all card members (Scot, Silvia, Zac, Drew, Manish, Jacob, Kaley, Megan) on `pine-forge`
- [x] Verified via Strapi API that `Author.avatar` is back to each person's original value
- [ ] Verify `/about`'s card colors still match once its cache/build picks up the reverted Strapi data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
