### PR TITLE
fix(agent-readiness): typed errors, versioning, rate limits, and heading/discoverability fixes

### DIFF
--- a/public/.well-known/agent-skills/datum-docs/SKILL.md
+++ b/public/.well-known/agent-skills/datum-docs/SKILL.md
@@ -14,10 +14,11 @@ Navigate to `https://www.datum.net/docs/` to browse documentation, or append `?q
 
 ## Key Resources
 
-- **Overview:** https://www.datum.net/docs/overview/
-- **Quickstart:** https://www.datum.net/docs/quickstart/
-- **API Reference:** https://www.datum.net/docs/api/reference/
-- **datumctl CLI:** https://www.datum.net/docs/datumctl/
+- **Overview:** https://www.datum.net/docs/overview
+- **Quickstart:** https://www.datum.net/docs/datumctl/quickstart
+- **API Reference (this site's own endpoints):** https://www.datum.net/openapi.json (also https://www.datum.net/api/openapi.yaml)
+- **Platform API discovery:** https://api.datum.net/openapi/v3 (Kubernetes-native OpenAPI v3; requires an authenticated bearer token) — for a human-readable path into the same resource types, see https://www.datum.net/docs/datumctl/discovering-resources
+- **datumctl CLI:** https://www.datum.net/docs/datumctl/overview
 - **Application Load Balancer:** https://www.datum.net/docs/alb/overview
 
 ## Authentication

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "type": "skill-md",
       "description": "Search and retrieve Datum network cloud documentation, API references, and developer guides",
       "url": "https://www.datum.net/.well-known/agent-skills/datum-docs/SKILL.md",
-      "digest": "sha256:58ae49b044760e924bc64b385f4e97e2ffb51fdcb8a444abfb255ada0cf4805f"
+      "digest": "sha256:b9dd72b02d59b2981c614ec519d43361e4823ce28618ccc6e1a227a9f5ca8665"
     }
   ]
 }

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -2,6 +2,12 @@
   "linkset": [
     {
       "anchor": "https://www.datum.net",
+      "service-desc": [
+        {
+          "href": "https://www.datum.net/openapi.json",
+          "type": "application/json"
+        }
+      ],
       "service-doc": [
         {
           "href": "https://www.datum.net/docs/",
@@ -19,8 +25,8 @@
       "anchor": "https://api.datum.net",
       "service-desc": [
         {
-          "href": "https://www.datum.net/docs/api/reference/",
-          "type": "text/html"
+          "href": "https://api.datum.net/openapi/v3",
+          "type": "application/json"
         }
       ],
       "service-doc": [

--- a/server.mjs
+++ b/server.mjs
@@ -129,8 +129,13 @@ const REDIRECTS = {
   },
   '/handbook/go-to-market/approach-gtm/': { destination: '/handbook/about/model', status: 301 },
   '/netzero/overview/overview': { destination: '/', status: 301 },
+  // The generated API reference this used to point at was retired (see the
+  // "Currently disabled" note in README.md's API Documentation section) —
+  // '/docs/api/reference' itself now just redirects to the generic docs
+  // home, so send legacy crawls straight there instead of through that
+  // extra hop.
   '/api-reference/invite/deletes-a-invite-by-id': {
-    destination: '/docs/api/reference',
+    destination: '/docs',
     status: 301,
   },
   '/blog/internet-superpowers-for-every-builder/)_/': {

--- a/src/components/home/DatumPlatform.astro
+++ b/src/components/home/DatumPlatform.astro
@@ -130,7 +130,14 @@ const pillars: { icon: string; title: string; description: string }[] = [
                       class="text-pine-forge---links stroke-1.75"
                     />
                   </div>
-                  <p class="datum-text-xl text-midnight-fjord font-semibold">{pillar.title}</p>
+                  {/* Real heading, not a styled <p>: each pillar is a distinct
+                      named topic (title + description) — the only content on
+                      this section that had no heading anchoring it, which read
+                      as flat to a11y tools and content-extraction crawlers (see
+                      is-agentic "Content without JavaScript" check). Sibling to
+                      the "Private, protected, performant." <h3> above under the
+                      same <h2> section, so h3 (not h4) avoids a level skip. */}
+                  <h3 class="datum-text-xl text-midnight-fjord font-semibold">{pillar.title}</h3>
                 </div>
                 <p class="datum-text-base text-app---dark---utility-2 opacity-80">
                   {pillar.description}

--- a/src/data/openapi.ts
+++ b/src/data/openapi.ts
@@ -20,6 +20,97 @@
 
 const SITE_URL = 'https://www.datum.net';
 
+// Versioning & deprecation policy note, included in `info.description` below.
+// This surface is versioned via a response header (`API-Version`) rather than
+// a URL prefix — the small handful of routes documented here don't warrant
+// the churn (and breakage risk for existing callers) of a `/v1/` path rename.
+// A breaking change bumps `API-Version`; a version being retired is signaled
+// via the standard `Deprecation` and `Sunset` response headers with at least
+// 90 days' notice before removal.
+const VERSIONING_POLICY =
+  'This API is versioned via the `API-Version` response header (currently `1`), not a URL prefix — the surface is small enough that a path rename would add churn without adding safety. A breaking change increments the version; a version being retired is announced via the `Deprecation` and `Sunset` response headers (RFC 8594) with at least 90 days’ notice before removal.';
+
+// RFC 9457 (Problem Details for HTTP APIs) error schema, shared by every
+// error response below — see src/libs/httpProblem.ts for the response
+// builder that actually produces this shape at runtime.
+const problemSchema = {
+  type: 'object',
+  description:
+    'RFC 9457 Problem Details for HTTP APIs (https://www.rfc-editor.org/rfc/rfc9457). `status` is the machine-readable signal to branch on; `title`/`detail` are for humans.',
+  required: ['type', 'title', 'status'],
+  properties: {
+    type: {
+      type: 'string',
+      format: 'uri-reference',
+      description:
+        'A URI identifying the problem type. `about:blank` (the default) means the problem has no semantics beyond the HTTP status code.',
+      example: 'about:blank',
+    },
+    title: {
+      type: 'string',
+      description: 'Short, human-readable summary of the problem type.',
+      example: 'Too Many Requests',
+    },
+    status: {
+      type: 'integer',
+      description: 'The HTTP status code for this occurrence of the problem.',
+      example: 429,
+    },
+    detail: {
+      type: 'string',
+      description: 'Human-readable explanation specific to this occurrence of the problem.',
+    },
+    instance: {
+      type: 'string',
+      format: 'uri-reference',
+      description: 'A URI identifying this specific occurrence of the problem.',
+    },
+  },
+} as const;
+
+// Response headers shared by every response on the rate-limited endpoint(s)
+// below — see src/libs/rateLimit.ts for the enforcement.
+const rateLimitHeaders = {
+  'RateLimit-Limit': {
+    description: 'Requests allowed per window.',
+    schema: { type: 'integer' },
+  },
+  'RateLimit-Remaining': {
+    description: 'Requests remaining in the current window.',
+    schema: { type: 'integer' },
+  },
+  'RateLimit-Reset': {
+    description: 'Seconds until the current window resets.',
+    schema: { type: 'integer' },
+  },
+  'API-Version': {
+    description: 'The API version that served this response — see the versioning policy above.',
+    schema: { type: 'string' },
+  },
+} as const;
+
+const tooManyRequestsResponse = {
+  description: 'Rate limit exceeded — retry after `Retry-After` seconds.',
+  headers: {
+    ...rateLimitHeaders,
+    'Retry-After': {
+      description: 'Seconds until the rate limit window resets.',
+      schema: { type: 'integer' },
+    },
+  },
+  content: {
+    'application/problem+json': { schema: { $ref: '#/components/schemas/Problem' } },
+  },
+} as const;
+
+const internalErrorResponse = {
+  description: 'Unexpected server-side failure.',
+  headers: rateLimitHeaders,
+  content: {
+    'application/problem+json': { schema: { $ref: '#/components/schemas/Problem' } },
+  },
+} as const;
+
 export const openApiSpec = {
   openapi: '3.1.0',
   info: {
@@ -27,7 +118,9 @@ export const openApiSpec = {
     version: '1.0.0',
     description:
       'Public endpoints served directly by datum.net (the marketing/docs site). This is intentionally a small surface — the Datum Cloud platform API for creating and managing infrastructure (Application Load Balancers, Connectors, DNS, Domains) is a separate Kubernetes-native aggregated API server documented at ' +
-      `${SITE_URL}/docs and reachable at https://api.datum.net. That API follows standard Kubernetes API conventions (the same request shape as \`kubectl\`) and publishes its own OpenAPI v3 discovery document at \`/openapi/v3\`, which requires an authenticated bearer token to fetch — see ${SITE_URL}/docs for how to authenticate, or the \`datumctl\` CLI / MCP server for a higher-level interface that doesn't require calling the platform API directly.`,
+      `${SITE_URL}/docs and reachable at https://api.datum.net. That API follows standard Kubernetes API conventions (the same request shape as \`kubectl\`) and publishes its own OpenAPI v3 discovery document at \`/openapi/v3\`, which requires an authenticated bearer token to fetch — see ${SITE_URL}/docs for how to authenticate, or the \`datumctl\` CLI / MCP server for a higher-level interface that doesn't require calling the platform API directly.\n\n` +
+      `**Versioning & deprecation:** ${VERSIONING_POLICY}\n\n` +
+      '**Errors:** every non-2xx response returns `application/problem+json` (RFC 9457) — see the `Problem` schema.',
     contact: {
       name: 'Datum',
       url: `${SITE_URL}/contact`,
@@ -38,17 +131,23 @@ export const openApiSpec = {
     description: 'Datum Cloud platform documentation (full API reference, guides, MCP server)',
     url: `${SITE_URL}/docs`,
   },
+  components: {
+    schemas: {
+      Problem: problemSchema,
+    },
+  },
   paths: {
     '/api/roadmap/backlog-meta': {
       get: {
         operationId: 'getRoadmapBacklogMeta',
         summary: 'Roadmap backlog cache status',
         description:
-          'Lightweight status for the public roadmap backlog cache (backed by the datum-cloud GitHub Projects board) — used by the roadmap page to poll for live updates without re-fetching the full backlog on every request. Read-only, no authentication required.',
+          'Lightweight status for the public roadmap backlog cache (backed by the datum-cloud GitHub Projects board) — used by the roadmap page to poll for live updates without re-fetching the full backlog on every request. Read-only, no authentication required. Rate-limited; see the `RateLimit-*` response headers.',
         tags: ['Roadmap'],
         responses: {
           '200': {
             description: 'Current backlog cache status.',
+            headers: rateLimitHeaders,
             content: {
               'application/json': {
                 schema: {
@@ -70,6 +169,8 @@ export const openApiSpec = {
               },
             },
           },
+          '429': tooManyRequestsResponse,
+          '500': internalErrorResponse,
         },
       },
     },

--- a/src/libs/httpProblem.ts
+++ b/src/libs/httpProblem.ts
@@ -1,0 +1,36 @@
+// src/libs/httpProblem.ts
+//
+// RFC 9457 (Problem Details for HTTP APIs) error responses for this site's
+// own public API surface — see src/data/openapi.ts for the documented
+// schema. A stable, machine-readable `status` (and `type`) lets an agent
+// branch on failures instead of parsing prose; `title`/`detail` are for
+// humans reading logs or a debugger.
+//
+// `type` intentionally defaults to `about:blank`: RFC 9457 §4.2.1 says that
+// value means "the problem has no additional semantics beyond that of the
+// HTTP status code," which is accurate here — this site doesn't (yet)
+// publish per-error-code documentation pages, and pointing `type` at a page
+// that doesn't exist would be worse than the default (see the "no
+// overclaiming" note in src/data/openapi.ts).
+
+export interface ProblemDetails {
+  type: string;
+  title: string;
+  status: number;
+  detail?: string;
+  instance?: string;
+}
+
+export type ProblemInput = Omit<ProblemDetails, 'type'> & { type?: string };
+
+export function problemResponse(problem: ProblemInput, init?: { headers?: HeadersInit }): Response {
+  const body: ProblemDetails = { type: 'about:blank', ...problem };
+
+  return new Response(JSON.stringify(body), {
+    status: problem.status,
+    headers: {
+      'Content-Type': 'application/problem+json',
+      ...init?.headers,
+    },
+  });
+}

--- a/src/libs/rateLimit.ts
+++ b/src/libs/rateLimit.ts
@@ -1,0 +1,77 @@
+// src/libs/rateLimit.ts
+//
+// Minimal in-memory fixed-window rate limiter for this site's own public API
+// routes (see src/data/openapi.ts) — surfaces the standard RateLimit-* response
+// headers (draft-ietf-httpapi-ratelimit-headers) so agents can self-throttle
+// instead of guessing. This is a lightweight polling-endpoint signal, not a
+// security boundary: counters are per-process, so the effective ceiling scales
+// with server replica count. That's an acceptable tradeoff for what this
+// guards today; a shared store (e.g. Redis, already used elsewhere in this
+// codebase for caching) would be needed before relying on it for anything
+// stricter.
+
+export interface RateLimitConfig {
+  /** Max requests allowed per window. */
+  limit: number;
+  windowMs: number;
+}
+
+export interface RateLimitResult {
+  limited: boolean;
+  limit: number;
+  remaining: number;
+  /** Seconds until the current window resets. */
+  resetSeconds: number;
+}
+
+interface WindowState {
+  count: number;
+  windowStart: number;
+}
+
+const buckets = new Map<string, WindowState>();
+
+// Opportunistic cleanup so a long-lived process doesn't accumulate an
+// unbounded number of stale per-key entries (e.g. many distinct client IPs
+// over a long uptime) — sweeps expired windows once the map grows past this
+// size, rather than running a timer no one asked for.
+const MAX_TRACKED_KEYS = 10_000;
+
+function sweepExpired(now: number, windowMs: number): void {
+  for (const [key, state] of buckets) {
+    if (now - state.windowStart >= windowMs) {
+      buckets.delete(key);
+    }
+  }
+}
+
+export function checkRateLimit(
+  key: string,
+  { limit, windowMs }: RateLimitConfig,
+  now: number = Date.now()
+): RateLimitResult {
+  if (buckets.size > MAX_TRACKED_KEYS) {
+    sweepExpired(now, windowMs);
+  }
+
+  const existing = buckets.get(key);
+  const windowIsCurrent = existing !== undefined && now - existing.windowStart < windowMs;
+  const windowStart = windowIsCurrent ? existing.windowStart : now;
+  const count = windowIsCurrent ? existing.count + 1 : 1;
+
+  buckets.set(key, { count, windowStart });
+
+  const resetSeconds = Math.max(0, Math.ceil((windowStart + windowMs - now) / 1000));
+
+  return {
+    limited: count > limit,
+    limit,
+    remaining: Math.max(0, limit - count),
+    resetSeconds,
+  };
+}
+
+/** Test-only: clear all tracked windows between test cases. */
+export function _resetRateLimitState(): void {
+  buckets.clear();
+}

--- a/src/pages/api/roadmap/backlog-meta.ts
+++ b/src/pages/api/roadmap/backlog-meta.ts
@@ -4,15 +4,63 @@ export const prerender = false;
 
 import type { APIRoute } from 'astro';
 import { getGitHubBacklogMeta } from '@libs/githubBacklog';
+import { checkRateLimit } from '@libs/rateLimit';
+import { problemResponse } from '@libs/httpProblem';
 
-export const GET: APIRoute = async () => {
-  const meta = await getGitHubBacklogMeta();
+// This endpoint is versioned via a response header rather than a URL prefix
+// (see the versioning policy note in src/data/openapi.ts) — bump this when a
+// breaking change ships, and pair the outgoing old version with `Deprecation`
+// / `Sunset` response headers per that same policy.
+const API_VERSION = '1';
 
-  return new Response(JSON.stringify(meta), {
-    status: 200,
-    headers: {
-      'Content-Type': 'application/json',
-      'Cache-Control': 'no-store',
-    },
-  });
+// Headroom well above real usage: BacklogLiveUpdate.astro polls at most every
+// 2s while a refresh is in flight (~30 req/min for one open tab). This exists
+// so agents get real, enforced values to self-throttle against — not to
+// constrain normal traffic. See src/libs/rateLimit.ts for the per-process
+// caveat.
+const RATE_LIMIT = { limit: 20, windowMs: 10_000 };
+
+export const GET: APIRoute = async ({ clientAddress }) => {
+  const rate = checkRateLimit(`backlog-meta:${clientAddress ?? 'unknown'}`, RATE_LIMIT);
+
+  const commonHeaders = {
+    'API-Version': API_VERSION,
+    'RateLimit-Limit': String(rate.limit),
+    'RateLimit-Remaining': String(rate.remaining),
+    'RateLimit-Reset': String(rate.resetSeconds),
+  };
+
+  if (rate.limited) {
+    return problemResponse(
+      {
+        status: 429,
+        title: 'Too Many Requests',
+        detail: 'Rate limit exceeded for this endpoint — retry after the window resets.',
+      },
+      { headers: { ...commonHeaders, 'Retry-After': String(rate.resetSeconds) } }
+    );
+  }
+
+  try {
+    const meta = await getGitHubBacklogMeta();
+
+    return new Response(JSON.stringify(meta), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store',
+        ...commonHeaders,
+      },
+    });
+  } catch (error) {
+    console.error('Failed to load roadmap backlog meta:', error);
+    return problemResponse(
+      {
+        status: 500,
+        title: 'Internal Server Error',
+        detail: 'Failed to load the roadmap backlog cache status.',
+      },
+      { headers: commonHeaders }
+    );
+  }
 };

--- a/tests/e2e/agent-readiness.spec.ts
+++ b/tests/e2e/agent-readiness.spec.ts
@@ -46,6 +46,22 @@ test.describe('Heading structure (Content without JavaScript)', () => {
     await expect(heading).toHaveCount(1);
     await expect(heading).toHaveText('What is Datum?');
   });
+
+  test('the Datum Platform pillars are real headings, not styled paragraphs', async ({ page }) => {
+    await page.goto('/');
+
+    // These were <p class="font-semibold"> — visually a heading, semantically
+    // flat. Asserting the tag (not just visible text) guards against that
+    // regressing back to a paragraph.
+    const headings = page.locator('#datum-platform h3');
+    await expect(headings).toHaveText([
+      'Private, protected, performant.',
+      'Deliver',
+      'Build',
+      'Connect',
+      'Essentials',
+    ]);
+  });
 });
 
 test.describe('Agent-friendly 404 (HTML)', () => {
@@ -90,5 +106,116 @@ test.describe('Agent instruction / when-to-use', () => {
     const body = await response.text();
     expect(body).toContain('## When to Use Datum');
     expect(body).toContain('How an agent should call Datum');
+  });
+});
+
+test.describe('REST typed error model', () => {
+  test('OpenAPI spec documents a typed RFC 9457 Problem schema on 4xx/5xx responses', async ({
+    request,
+  }) => {
+    const response = await request.get('/openapi.json');
+    const spec = await response.json();
+
+    const problemSchema = spec.components?.schemas?.Problem;
+    expect(problemSchema).toBeTruthy();
+    expect(problemSchema.required).toEqual(expect.arrayContaining(['type', 'title', 'status']));
+
+    const backlogResponses = spec.paths['/api/roadmap/backlog-meta'].get.responses;
+    expect(backlogResponses['429']).toBeTruthy();
+    expect(backlogResponses['500']).toBeTruthy();
+    for (const status of ['429', '500']) {
+      const content = backlogResponses[status].content['application/problem+json'];
+      expect(content.schema.$ref).toBe('#/components/schemas/Problem');
+    }
+  });
+
+  test('a rate-limited response body is a well-formed RFC 9457 problem object', async ({
+    request,
+  }) => {
+    // Exhaust the endpoint's window (limit 20 / 10s — see src/libs/rateLimit.ts)
+    // with margin for a stray request from another test sharing the dev server.
+    let last;
+    for (let i = 0; i < 25; i++) {
+      last = await request.get('/api/roadmap/backlog-meta');
+      if (last.status() === 429) break;
+    }
+
+    expect(last?.status()).toBe(429);
+    expect(last?.headers()['content-type']).toContain('application/problem+json');
+    expect(last?.headers()['retry-after']).toMatch(/^\d+$/);
+
+    const body = await last?.json();
+    expect(body.status).toBe(429);
+    expect(typeof body.title).toBe('string');
+  });
+});
+
+test.describe('REST versioning / deprecation policy', () => {
+  test('OpenAPI info documents the versioning policy', async ({ request }) => {
+    const response = await request.get('/openapi.json');
+    const spec = await response.json();
+
+    expect(spec.info.description).toContain('API-Version');
+    expect(spec.info.description).toContain('Deprecation');
+    expect(spec.info.description).toContain('Sunset');
+  });
+
+  test('responses carry an API-Version header', async ({ request }) => {
+    const response = await request.get('/api/roadmap/backlog-meta');
+    expect(response.headers()['api-version']).toBe('1');
+  });
+});
+
+test.describe('Rate limit response headers', () => {
+  test('/api/roadmap/backlog-meta returns standard RateLimit-* headers', async ({ request }) => {
+    const response = await request.get('/api/roadmap/backlog-meta');
+    const headers = response.headers();
+
+    expect(headers['ratelimit-limit']).toMatch(/^\d+$/);
+    expect(headers['ratelimit-remaining']).toMatch(/^\d+$/);
+    expect(headers['ratelimit-reset']).toMatch(/^\d+$/);
+  });
+});
+
+test.describe('Developer resource discoverability', () => {
+  test('.well-known/api-catalog points at real, resolving service-desc URLs', async ({
+    request,
+  }) => {
+    const response = await request.get('/.well-known/api-catalog');
+    const catalog = await response.json();
+
+    const hrefs = catalog.linkset.flatMap((entry: Record<string, { href: string }[]>) =>
+      Object.values(entry)
+        .flat()
+        .map((link) => (typeof link === 'string' ? link : link.href))
+        .filter(Boolean)
+    );
+
+    // The old service-desc for api.datum.net pointed at a retired page that
+    // silently redirects to the generic docs home — assert it's gone.
+    expect(hrefs).not.toContain('https://www.datum.net/docs/api/reference/');
+
+    const siteEntry = catalog.linkset.find(
+      (e: { anchor: string }) => e.anchor === 'https://www.datum.net'
+    );
+    expect(siteEntry['service-desc'][0].href).toBe('https://www.datum.net/openapi.json');
+  });
+
+  test('the datum-docs agent skill has no known-dead links and a matching digest', async ({
+    request,
+  }) => {
+    const skillResponse = await request.get('/.well-known/agent-skills/datum-docs/SKILL.md');
+    const body = await skillResponse.text();
+
+    expect(body).not.toContain('/docs/api/reference');
+    expect(body).not.toContain('/docs/quickstart/');
+
+    const indexResponse = await request.get('/.well-known/agent-skills/index.json');
+    const index = await indexResponse.json();
+    const entry = index.skills.find((s: { name: string }) => s.name === 'datum-docs-search');
+
+    const crypto = await import('node:crypto');
+    const actualDigest = `sha256:${crypto.createHash('sha256').update(body).digest('hex')}`;
+    expect(entry.digest).toBe(actualDigest);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #1669 — addresses the remaining 5 findings from the [is-agentic.com](https://is-agentic.com/scan/datum.net) readiness scan (score 97/100), failures first:

1. **Content without JavaScript** (Essential, Partial 67%) — the homepage's platform pillars (Deliver/Build/Connect/Essentials) were `<p class="font-semibold">`, not headings — the only real content on that section with nothing anchoring it in the outline.
2. **REST typed error model** (Recommended, Failed) — no typed error schema in the OpenAPI spec.
3. **REST versioning / deprecation policy** (Recommended, Failed) — no versioning strategy.
4. **Rate limit response headers** (Recommended, Failed) — no `RateLimit-*` headers on probed endpoints.
5. **Developer resource discoverability** (Recommended, Partial 33%) — API docs not searchable/typed.

## Changes

- **`fix(seo)`** — promoted the platform pillar titles to `<h3>` (same classes, no visual change — verified no global heading CSS applies outside `.prose`).
- **`feat(api)`** — `/api/roadmap/backlog-meta` now returns RFC 9457 `application/problem+json` on errors (`src/libs/httpProblem.ts`), an `API-Version` header plus a documented versioning/deprecation policy, and `RateLimit-Limit`/`Remaining`/`Reset` headers backed by a real per-process limiter (`src/libs/rateLimit.ts`, 20 req/10s — well above the live roadmap poller's ~30 req/min worst case). All documented in `src/data/openapi.ts` (new `Problem` schema, 429/500 responses).
- **`fix(discovery)`** — `/docs/api/reference` turned out to be a dead link (308 → `/docs`) left over from a retired doc-generation pipeline (see README's own "Currently disabled" note). Fixed the three places still pointing at it: `.well-known/api-catalog`'s `service-desc`, the `datum-docs` agent skill, and a legacy `server.mjs` redirect — plus recomputed the skill file's now-stale content digest.
- **`test(e2e)`** — coverage for all of the above in `tests/e2e/agent-readiness.spec.ts`, including actually tripping the 429.

## Verification

- `astro check` — 0 errors
- `eslint` — clean
- `npm run build` — succeeds
- `npm run test:server` — 8/8 pass
- Manual curl against a built server: rate limit trips at request 21 with correct `problem+json` body and headers; `api-catalog` links resolve; SKILL.md digest matches
- New Playwright suite (`tests/e2e/agent-readiness.spec.ts`) — not run against a live dev server in this session (see note below); please run `npm run dev` + `npx playwright test tests/e2e/agent-readiness.spec.ts` before merge to confirm.

## Remaining recommendation (needs a product decision)

The root cause of #5 is that `npm run generate:api-docs` (the CRD → OpenAPI reference generator) was removed and never restored — there's no real local "API Reference" page, only broken links to one that used to exist. `templates/api-docs/` is still around but `.api-docs-config.yaml`/`.crd-ref-docs.yaml` are gone. Someone needs to decide whether to revive it (needs Go tooling, access to the operator repos, Renovate wiring) or formally retire the README section describing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
