### PR TITLE
fix(hello): match avatar background color to the pine-forge image treatment

### DIFF
--- a/src/components/hello/HelloPeople.astro
+++ b/src/components/hello/HelloPeople.astro
@@ -1,7 +1,11 @@
 ---
 // src/components/hello/HelloPeople.astro
 import Icon from '@components/Icon.astro';
-import { getHelloPineForgeAvatarUrl, getStrapiCardMembers, getTeamBgColor } from '@libs/strapi';
+import {
+  getHelloPineForgeAvatarUrl,
+  getStrapiCardMembers,
+  PINE_FORGE_BG_COLOR,
+} from '@libs/strapi';
 import type { CardCategory, StrapiAuthorFull } from '@libs/strapi';
 import { getStrapiMediaUrl } from '@/src/types/strapi';
 import HelloCard from './HelloCard.astro';
@@ -30,7 +34,7 @@ const helloMembersData = cardMembers.map((member, index) => ({
     name: member.name,
     title: member.title,
     helloBio: member.helloBio?.trim() || undefined,
-    avatarBgColor: getTeamBgColor(index),
+    avatarBgColor: PINE_FORGE_BG_COLOR,
     avatar: member.avatar ? { src: getStrapiMediaUrl(member.avatar.url) } : undefined,
     location: member.location,
     timezone: member.timezone,

--- a/src/libs/strapi/authors.ts
+++ b/src/libs/strapi/authors.ts
@@ -82,6 +82,9 @@ function normalizeAuthorFromGraphQL(row: GraphQLAuthorRow): StrapiAuthorFull {
 
 const TEAM_BG_COLORS = ['#5F735E', '#BF9595', '#D1CDC0'] as const;
 
+/** Background color matching the pine-forge avatar variant that /hello always displays. */
+export const PINE_FORGE_BG_COLOR = TEAM_BG_COLORS[0];
+
 export const AUTHORS_QUERY = `
   query GetAuthors($start: Int!, $limit: Int!) {
     authors(pagination: { start: $start, limit: $limit }) {

--- a/src/libs/strapi/index.ts
+++ b/src/libs/strapi/index.ts
@@ -91,6 +91,7 @@ export {
   getStrapiCardMembers,
   getTeamBgColor,
   getAuthorBgColorFromStrapi,
+  PINE_FORGE_BG_COLOR,
 } from './authors';
 
 // /hello-only avatar resolution, decoupled from the shared `avatar` field


### PR DESCRIPTION
## Summary
- `/hello` always renders every team member's pine-forge avatar image (via `helloPineForgeAvatars.ts`), but the modal's background swatch behind each avatar (`avatarBgColor`) was still cycling through the pine-forge/canyon-clay/glacier-mist palette by array index (`getTeamBgColor(index)`), unrelated to which image variant was actually shown.
- The grid cards never revealed this (no background color is applied there), but the detail modal/page did — so anyone not landing on a "pine forge" index showed the pine-forge photo sitting on a mismatched colored background.
- Added `PINE_FORGE_BG_COLOR` and use it for every `/hello` card instead of the index-based color, so the background always matches the pine-forge image.

## Test plan
- [x] Confirmed `/hello` and `/hello/jacob-smith` (and other slugs) now report `avatarBgColor: "#5F735E"` for every card in the rendered payload
- [x] Confirmed the pine-forge image itself is unaffected and still resolves correctly per author

🤖 Generated with [Claude Code](https://claude.com/claude-code)